### PR TITLE
generate a mapfile and symfile on compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ pokecrystal.o: $(TEXTFILES:.asm=.tx) wram.asm constants.asm $(shell find constan
 	@rm -f $@
 
 pokecrystal.gbc: pokecrystal.o
-	rgblink -o $@ $<
+	rgblink -n pokecrystal.sym -m pokecrystal.map -o $@ $<
 	rgbfix -Cjv -i BYTE -k 01 -l 0x33 -m 0x10 -p 0 -r 3 -t PM_CRYSTAL $@
 
 pngs:


### PR DESCRIPTION
a mapfile is a better solution for finding labels than scan_for_predefined_labels in extras/crystal.py.

besides being extremely convenient a symfile actually has to be made by rgbds when generating a mapfile
