### PR TITLE
Remove a special case for MoneyByteParam

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -498,8 +498,6 @@ def macro_translator(macro, token, line):
             elif param_klass.byte_type == "dw":
                 if param_klass.size == 2:
                     allowed_length += 1 # just label
-                elif param_klass == MoneyByteParam:
-                    allowed_length += 1
                 elif param_klass.size == 3:
                     allowed_length += 2 # bank and label
                 else:


### PR DESCRIPTION
The preprocessor should ideally have no special cases for macros at all
in the first place. But it does. This one doesn't seem to be necessary.
