### PR TITLE
Fail fast when the baserom.gbc file doesn't exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ pokecrystal.o: $(TEXTFILES:.asm=.tx) wram.asm constants.asm $(shell find constan
 .asm.tx:
 	$(eval TEXTQUEUE := $(TEXTQUEUE) $<)
 	@rm -f $@
+baserom:
+	python -c "import os; assert 'baserom.gbc' in os.listdir('.'), 'Wait! Need baserom.gbc first. Check README and INSTALL for details.';"
 
-pokecrystal.gbc: pokecrystal.o
+pokecrystal.gbc: baserom pokecrystal.o
 	rgblink -n pokecrystal.sym -m pokecrystal.map -o $@ $<
 	rgbfix -Cjv -i BYTE -k 01 -l 0x33 -m 0x10 -p 0 -r 3 -t PM_CRYSTAL $@
 


### PR DESCRIPTION
One day this will not be required. But until then, waiting one or more
seconds for the build to fail just to learn that you forgot baserom.gbc
is really silly.

This makes failure almost instantaneous compared to before, which would
take between one and ten seconds depending on system performance.

fixes #167
