### PR TITLE
Remove globals from preprocessor

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -31,9 +31,6 @@ macros += movement_command_classes
 macros += music_classes
 macros += effect_classes
 
-# helpful for debugging macros
-do_macro_sanity_check = False
-
 chars = {
 "ガ": 0x05,
 "ギ": 0x06,
@@ -431,11 +428,12 @@ def is_based_on(something, base):
     options += [something.__name__]
     return (base in options)
 
-def macro_translator(macro, token, line, show_original_lines=False):
+def macro_translator(macro, token, line, show_original_lines=False, do_macro_sanity_check=False):
     """
     Converts a line with a macro into a rgbasm-compatible line.
 
     @param show_original_lines: show lines before preprocessing in stdout
+    @param do_macro_sanity_check: helpful for debugging macros
     """
     assert macro.macro_name == token, "macro/token mismatch"
 


### PR DESCRIPTION
Hah, why are there globals here?
