### PR TITLE
dont use constants in wram.asm

### DIFF
--- a/wram.asm
+++ b/wram.asm
@@ -1676,7 +1676,7 @@ PlayerSpriteY: ; d4ee
 
 SECTION "Objects",WRAMX[$d71e],BANK[1]
 MapObjects: ; d71e
-	ds $10 ; OBJECT_LENGTH * NUM_OBJECTS
+	ds $10 * $10 ; OBJECT_LENGTH * NUM_OBJECTS
 
 
 SECTION "VariableSprites",WRAMX[$d82e],BANK[1]


### PR DESCRIPTION
wram.asm gets read in a preprocessor edge case, which cant handle constants that arent defined inline yet
