### PR TITLE
Downloadable virtual machine image (Vagrantfile and box)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,35 @@
+# Vagrant
+
+The simplest way to get pokecrystal to compile is to use Vagrant and
+VirtualBox. Follow these steps:
+
+* [Download and install Vagrant](http://www.vagrantup.com/downloads.html)
+* Follow the instructions to [download and install VirtualBox](http://docs-v1.vagrantup.com/v1/docs/getting-started/)
+* Run these commands:
+
+	vagrant box add pokecrystal http://diyhpl.us/~bryan/irc/pokecrystal/pokecrystal.box
+	mkdir vagrantbox
+	cd vagrantbox
+	vagrant init pokecrystal
+	vagrant up
+	vagrant ssh -c "cd /vagrant && git clone git://github.com/kanzure/pokecrystal.git"
+	vagrant ssh -c "cd /vagrant/pokecrystal && git submodule init && git submodule update"
+	vagrant ssh
+
+Running "vagrant ssh" will give you a shell to type commands into for compiling
+the source code. The the "virtualbox" directory on the host appears as a shared
+folder inside of the guest virtual machine at "/vagrant".
+
+To build the project, run these commands in the guest (that is, inside "vagrant
+ssh"):
+
+	cd /vagrant/pokecrystal
+	make
+
+To make the build work you will need to copy baserom.gbc into the "pokecrystal"
+directory inside the "virtualbox" directory on the host machine. Eventually
+this will not be required.
+
 # Linux
 
 Dependencies:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# TODO: insert scripts to build the box instead of trusting the uploaded
+# version. The default should be to build the box when running "vagrant up",
+# rather than just downloading a pre-existing box.
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "pokecrystal"
+  config.vm.box_url = "http://diyhpl.us/~bryan/irc/pokecrystal/pokecrystal.box"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 8650
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "./", "/vagrant"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  config.vm.provider "virtualbox" do |vb|
+    # Don't boot with headless mode
+    vb.gui = false
+
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+end


### PR DESCRIPTION
Normally, a Vagrantfile specifies the steps to provision the box through scripting. That should definitely be done here. For now it's just a Vagrantfile with a link to a pre-baked box. Users that aren't interested in setting up their own development environment can now download only two dependencies, vagrant and virtualbox.
