### PR TITLE
minor, comment change

### DIFF
--- a/data/egg_moves.asm
+++ b/data/egg_moves.asm
@@ -4,7 +4,7 @@ INCLUDE "includes.asm"
 SECTION "Egg Moves", ROMX, BANK[EGG_MOVES]
 
 ; All instances of Charm, Steel Wing, Sweet Scent, and Lovely Kiss were
-; removed from egg move lists in Crystal, because they are also TMs.
+; removed from egg move lists in Crystal, because they were unobtainable.
 
 ; Staryu's egg moves were removed in Crystal, because Staryu is genderless
 ; and can only breed with Ditto.


### PR DESCRIPTION
The reason stated for egg moves removal in Crystal was wrong.
