### PR TITLE
Changes in sound macros and commentating them

### DIFF
--- a/audio/music/titlescreen.asm
+++ b/audio/music/titlescreen.asm
@@ -7,16 +7,18 @@ Music_TitleScreen: ; eb808
 
 Music_TitleScreen_Ch1: ; eb814
 	tempo 134
-	volume $77
+	volume_red 7, 7
 	dutycycle $3
 	tone $0002
-	vibrato $10, $12
+	vibrato_red $10, 1, 2
 	stereopanning $f0
 	notetype $c, $a7
-	intensity $a0
+
+	intensity_own $a, 0
 	octave 3
 	note __, 4
-	intensity $a7
+
+	intensity_own $a, 7
 	octave 2
 	note G_, 1
 	note __, 2
@@ -903,231 +905,231 @@ Music_TitleScreen_Ch4: ; ebc5c
 	stereopanning $f0
 	notetype $c
 	note __, 4
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 6
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 3
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 4
-	note D#, 2
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 1
-	note C_, 2
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 6
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 3
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 4
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
 	notetype $6
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	note C#, 1
-	note C#, 1
-	note C#, 1
-	note C_, 1
-	note C_, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
 	notetype $c
 	callchannel Music_TitleScreen_branch_ebd77
 	callchannel Music_TitleScreen_branch_ebd81
 	callchannel Music_TitleScreen_branch_ebd81
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note D#, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
 	notetype $6
-	note C#, 1
-	note C#, 1
-	note C_, 1
-	note C_, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
 	notetype $c
 	callchannel Music_TitleScreen_branch_ebd77
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note F_, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum29, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 2
 	callchannel Music_TitleScreen_branch_ebd81
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note D#, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
 	callchannel Music_TitleScreen_branch_ebd77
 	callchannel Music_TitleScreen_branch_ebd81
 	callchannel Music_TitleScreen_branch_ebd81
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note D#, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
 	notetype $6
-	note C#, 1
-	note D_, 1
-	note D_, 1
-	note C#, 1
+	note D5Snare10, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
 	notetype $c
 	callchannel Music_TitleScreen_branch_ebd77
 	callchannel Music_TitleScreen_branch_ebd81
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note F_, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
-	note D#, 2
-	note C_, 2
-	note D#, 2
-	note D#, 2
-	note C_, 1
-	note C_, 1
-	note C_, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum29, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Snare9, 2
+	note D5Drum27, 2
+	note D5Drum27, 2
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 2
 	notetype $6
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	note C#, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
 	notetype $c
-	note A_, 2
-	note D#, 4
-	note A_, 4
-	note D#, 2
-	note A_, 4
-	note A_, 2
-	note D#, 4
-	note A_, 4
-	note D#, 2
-	note A_, 2
-	note A_, 2
-	note A_, 2
-	note D#, 4
-	note A_, 4
-	note D#, 2
-	note A_, 4
-	note A_, 4
-	note A_, 4
-	note A_, 2
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	note C#, 1
-	note C_, 1
-	note C_, 1
+	note D5Snare14, 2
+	note D5Drum27, 4
+	note D5Snare14, 4
+	note D5Drum27, 2
+	note D5Snare14, 4
+	note D5Snare14, 2
+	note D5Drum27, 4
+	note D5Snare14, 4
+	note D5Drum27, 2
+	note D5Snare14, 2
+	note D5Snare14, 2
+	note D5Snare14, 2
+	note D5Drum27, 4
+	note D5Snare14, 4
+	note D5Drum27, 2
+	note D5Snare14, 4
+	note D5Snare14, 4
+	note D5Snare14, 4
+	note D5Snare14, 2
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
 	callchannel Music_TitleScreen_branch_ebd8b
 	callchannel Music_TitleScreen_branch_ebd93
-	note C#, 1
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	notetype $c
-	callchannel Music_TitleScreen_branch_ebd8b
-	callchannel Music_TitleScreen_branch_ebd93
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	note C#, 1
+	note D5Snare10, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
 	notetype $c
 	callchannel Music_TitleScreen_branch_ebd8b
 	callchannel Music_TitleScreen_branch_ebd93
-	note C#, 1
-	note C#, 1
-	note C#, 1
-	note C#, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
 	notetype $c
-	note G#, 16
+	callchannel Music_TitleScreen_branch_ebd8b
+	callchannel Music_TitleScreen_branch_ebd93
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	notetype $c
+	note D5Crash1, 16
 Music_TitleScreen_branch_ebd40: ; ebd40
 	note __, 16
 	loopchannel 6, Music_TitleScreen_branch_ebd40
 	note __, 12
 	notetype $6
-	note D_, 1
-	note C#, 1
-	note D_, 1
-	note C#, 1
-	note D_, 1
-	note C#, 1
-	note C_, 1
-	note C_, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
 	notetype $c
-	note C_, 4
-	note C_, 6
-	note C_, 1
-	note C_, 1
-	note C_, 4
-	note C_, 4
-	note C_, 6
-	note C_, 1
-	note C_, 1
-	note C_, 4
-	note C_, 4
-	note C_, 6
-	note C_, 1
-	note C_, 1
-	note C_, 4
-	note C_, 4
-	note C_, 4
+	note D5Snare9, 4
+	note D5Snare9, 6
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 4
+	note D5Snare9, 4
+	note D5Snare9, 6
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 4
+	note D5Snare9, 4
+	note D5Snare9, 6
+	note D5Snare9, 1
+	note D5Snare9, 1
+	note D5Snare9, 4
+	note D5Snare9, 4
+	note D5Snare9, 4
 	notetype $8
-	note C_, 2
-	note C_, 2
-	note C_, 2
+	note D5Snare9, 2
+	note D5Snare9, 2
+	note D5Snare9, 2
 	notetype $6
-	note C#, 1
-	note C#, 1
-	note D_, 1
-	note D_, 1
-	note C#, 1
-	note C#, 1
-	note C_, 1
-	note C_, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare11, 1
+	note D5Snare11, 1
+	note D5Snare10, 1
+	note D5Snare10, 1
+	note D5Snare9, 1
+	note D5Snare9, 1
 	notetype $c
-	note C_, 4
-	note B_, 4
+	note D5Snare9, 4
+	note D5Kick2, 4
 	endchannel
 ; ebd77
 

--- a/macros/sound.asm
+++ b/macros/sound.asm
@@ -29,6 +29,21 @@ A_ EQU 10
 A# EQU 11
 B_ EQU 12
 
+; Drumkit5
+;__ EQU 0
+D5Snare9 EQU 1 ; c
+D5Snare10 EQU 2 ; c#
+D5Snare11 EQU 3 ; d
+D5Drum27 EQU 4 ; d#
+D5Drum28 EQU 5 ; e
+D5Drum29 EQU 6 ; f
+D5Drum05 EQU 7 ; f#
+D5Triangle1 EQU 8 ; g
+D5Crash1 EQU 9 ; g#
+D5Snare14 EQU 10 ; a
+D5Snare13 EQU 11 ; a#
+D5Kick2 EQU 12 ; b
+
 
 octave: macro
 	db $d8 - (\1)
@@ -57,10 +72,23 @@ dutycycle: macro
 	db \1 ; duty_cycle
 	endm
 
+; parameter is directly written
+; in hardware register NRX2
+; FF12 - NR12 - Channel 1 Volume Envelope (R/W)
+; Bit 7-4 - Initial Volume of envelope (0-0Fh) (0=No Sound)
+; Bit 3   - Envelope Direction (0=Decrease, 1=Increase)
+; Bit 2-0 - Number of envelope sweep (n: 0-7)
+;           (If zero, stop envelope operation.)
 intensity: macro
 	db $dc
 	db \1 ; intensity
 	endm
+
+intensity_own: MACRO
+	db $dc
+	db (\1 << 4) | \2
+ENDM
+
 
 soundinput: macro
 	db $dd
@@ -76,17 +104,33 @@ togglesfx: macro
 	db $df
 	endm
 
+
 unknownmusic0xe0: macro
 	db $e0
 	db \1 ; unknown
 	db \2 ; unknown
 	endm
 
+unknownmusic0xe0_own: macro ; maybe pitchbend???
+	db $e0
+	db \1 ; unknown
+	db (\2 << 4) | \3 ; unknown
+	endm
+
+
 vibrato: macro
 	db $e1
 	db \1 ; delay
 	db \2 ; extent
 	endm
+
+; format: vibrato delay (in frames), extent, rate (# frames per cycle)
+vibrato_red: MACRO
+	db $e1
+	db \1
+	db (\2 << 4) | \3
+ENDM
+
 
 unknownmusic0xe2: macro
 	db $e2
@@ -103,10 +147,27 @@ panning: macro
 	db \1 ; tracks
 	endm
 
+
+; parameter is directly written
+; in hardware register NR50
+; FF24 - NR50 - Channel control / ON-OFF / Volume (R/W)
+; The volume bits specify the "Master Volume" for Left/Right sound output.
+; Bit 7   - Output Vin to SO2 terminal (1=Enable)
+; Bit 6-4 - SO2 output level (volume)  (0-7)
+; Bit 3   - Output Vin to SO1 terminal (1=Enable)
+; Bit 2-0 - SO1 output level (volume)  (0-7)
 volume: macro
 	db $e5
 	db \1 ; volume
 	endm
+
+volume_red: MACRO
+; \1: SO2 output level (volume)  (0-7)
+; \2: SO1 output level (volume)  (0-7)
+	db $e5
+	db (\1 << 4) | \2
+ENDM
+
 
 tone: macro
 	db $e6


### PR DESCRIPTION
Some of the parameters for the sound macros can be split in smaller parts than byte-size. Pokered has some of this changes already implemented and I wanted to put it now into Pokecrystal.
This pull request is just a demonstration at the moment of the changes that I want to implement.

And while I'm playing with this code I try to write better comments for the different macros, so someone interested in using them doesn't have to look into the code of the audio engine (where most of the explanation is at the moment for the commands). 