### PR TITLE
Fix PlaySFX priority comment

### DIFF
--- a/home/audio.asm
+++ b/home/audio.asm
@@ -196,7 +196,7 @@ endr
 
 PlaySFX:: ; 3c23
 ; Play sound effect de.
-; Sound effects are ordered by priority (lowest to highest)
+; Sound effects are ordered by priority (highest to lowest)
 
 	push hl
 	push de


### PR DESCRIPTION
Sound effect constants are stored in order of decreasing priority, not increasing. See lines 211-213: the routine jumps to `.done` if the new sound effect is greater than the current sound effect.