### PR TITLE
Fix a reversed label mistake and reference a major bug

### DIFF
--- a/battle/ai/items.asm
+++ b/battle/ai/items.asm
@@ -238,7 +238,7 @@ AI_TryItem: ; 38105
 	res SUBSTATUS_RAGE, [hl]
 
 	xor a
-	ld [LastPlayerCounterMove], a
+	ld [LastEnemyCounterMove], a
 
 	scf
 	ret

--- a/battle/ai/scoring.asm
+++ b/battle/ai/scoring.asm
@@ -756,7 +756,7 @@ AI_Smart_AlwaysHit: ; 38947
 AI_Smart_MirrorMove: ; 3895b
 
 ; If the player did not use any move last turn...
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr nz, .asm_38968
 
@@ -1353,7 +1353,7 @@ AI_Smart_Rage: ; 38b7f
 
 
 AI_Smart_Mimic: ; 38ba8
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr z, .asm_38be9
 
@@ -1361,7 +1361,7 @@ AI_Smart_Mimic: ; 38ba8
 	jr nc, .asm_38bef
 
 	push hl
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	call AIGetEnemyMove
 
 	ld a, $1
@@ -1380,7 +1380,7 @@ AI_Smart_Mimic: ; 38ba8
 	dec [hl]
 
 .asm_38bd4
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	push hl
 	ld hl, UsefulMoves
 	ld de, 1
@@ -1438,7 +1438,7 @@ AI_Smart_Counter: ; 38bf1
 	cp $3
 	jr nc, .asm_38c30
 
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr z, .asm_38c38
 
@@ -1499,7 +1499,7 @@ AI_Smart_Encore: ; 38c3b
 
 .asm_38c68
 	push hl
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	ld hl, .EncoreMoves
 	ld de, 1
 	call IsInArray
@@ -1615,7 +1615,7 @@ AI_Smart_DefrostOpponent: ; 38ccb
 
 
 AI_Smart_Spite: ; 38cd5
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr nz, .asm_38ce7
 
@@ -1837,7 +1837,7 @@ AI_Smart_Disable: ; 38dd1
 	jr nc, .asm_38df3
 
 	push hl
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	ld hl, UsefulMoves
 	ld de, 1
 	call IsInArray
@@ -2367,7 +2367,7 @@ AI_Smart_Magnitude:
 AI_Smart_Earthquake: ; 39044
 
 ; Greatly encourage this move if the player is underground and the enemy is faster.
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	cp DIG
 	ret nz
 
@@ -2741,7 +2741,7 @@ AI_Smart_MirrorCoat: ; 3918b
 	cp $3
 	jr nc, .asm_391ca
 
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr z, .asm_391d2
 
@@ -2775,7 +2775,7 @@ AI_Smart_Twister:
 AI_Smart_Gust: ; 391d5
 
 ; Greatly encourage this move if the player is flying and the enemy is faster.
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	cp FLY
 	ret nz
 

--- a/battle/ai/switch.asm
+++ b/battle/ai/switch.asm
@@ -229,7 +229,7 @@ CheckAbleToSwitch: ; 34941
 	cp 11
 	ret nc
 
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr z, .no_last_counter_move
 
@@ -378,8 +378,8 @@ FindEnemyMonsImmuneToLastCounterMove: ; 34a2a
 	ld [CurSpecies], a
 	call GetBaseData
 
-	; the enemy's last move is damaging...
-	ld a, [LastEnemyCounterMove]
+	; the player's last move is damaging...
+	ld a, [LastPlayerCounterMove]
 	dec a
 	ld hl, Moves + MOVE_POWER
 	call GetMoveAttr
@@ -568,7 +568,7 @@ FindEnemyMonsThatResistPlayer: ; 34b20
 	push hl
 	ld [CurSpecies], a
 	call GetBaseData
-	ld a, [LastEnemyCounterMove]
+	ld a, [LastPlayerCounterMove]
 	and a
 	jr z, .skip_move
 

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -3366,8 +3366,8 @@ CheckWhetherSwitchmonIsPredetermined: ; 3d533
 ResetEnemyBattleVars: ; 3d557
 ; and draw empty TextBox
 	xor a
-	ld [LastEnemyCounterMove], a
 	ld [LastPlayerCounterMove], a
+	ld [LastEnemyCounterMove], a
 	ld [LastEnemyMove], a
 	ld [CurEnemyMove], a
 	dec a
@@ -3766,8 +3766,8 @@ Function_SetEnemyPkmnAndSendOutAnimation: ; 3d7c7
 
 NewEnemyMonStatus: ; 3d834
 	xor a
-	ld [LastEnemyCounterMove], a
 	ld [LastPlayerCounterMove], a
+	ld [LastEnemyCounterMove], a
 	ld [LastEnemyMove], a
 	ld hl, EnemySubStatus1
 rept 4
@@ -4217,8 +4217,8 @@ SendOutPlayerMon: ; 3db5f
 	ld [CurMoveNum], a
 	ld [TypeModifier], a
 	ld [wPlayerMoveStruct + MOVE_ANIM], a
-	ld [LastEnemyCounterMove], a
 	ld [LastPlayerCounterMove], a
+	ld [LastEnemyCounterMove], a
 	ld [LastPlayerMove], a
 	call CheckAmuletCoin
 	call FinishBattleAnim
@@ -4258,8 +4258,8 @@ SendOutPlayerMon: ; 3db5f
 
 NewBattleMonStatus: ; 3dbde
 	xor a
-	ld [LastEnemyCounterMove], a
 	ld [LastPlayerCounterMove], a
+	ld [LastEnemyCounterMove], a
 	ld [LastPlayerMove], a
 	ld hl, PlayerSubStatus1
 rept 4

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -1542,6 +1542,12 @@ BattleCheckTypeMatchup: ; 347c8
 	jr z, CheckTypeMatchup
 	ld hl, BattleMonType1
 CheckTypeMatchup: ; 347d3
+; There is an incorrect assumption about this function made in the AI related code: when
+; the AI calls CheckTypeMatchup (not BattleCheckTypeMatchup), it assumes that placing the
+; offensive type in a will make this function do the right thing. Since a is overwritten,
+; this assumption is incorrect. A simple fix would be to load the move type for the
+; current move into a in BattleCheckTypeMatchup, before falling through, which is
+; consistent with how the rest of the code assumes this code works like.
 	push hl
 	push de
 	push bc

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -971,7 +971,7 @@ BattleCommand_CheckObedience: ; 343db
 .EndDisobedience:
 	xor a
 	ld [LastPlayerMove], a
-	ld [LastEnemyCounterMove], a
+	ld [LastPlayerCounterMove], a
 
 	; Break Encore too.
 	ld hl, PlayerSubStatus5

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -227,7 +227,7 @@ GetBattleVarAddr:: ; 39e7
 	dw wPlayerMoveStructPower,       wEnemyMoveStructPower
 	dw wPlayerMoveStructType,        wEnemyMoveStructType
 	dw CurPlayerMove,                CurEnemyMove
-	dw LastEnemyCounterMove,         LastPlayerCounterMove
+	dw LastPlayerCounterMove,        LastEnemyCounterMove
 	dw LastPlayerMove,               LastEnemyMove
 ; 3a90
 

--- a/misc/mobile_5c.asm
+++ b/misc/mobile_5c.asm
@@ -206,7 +206,7 @@ Function170c06: ; 170c06
 ; 170c8b
 
 Function170c8b: ; 170c8b
-	ld hl, LastPlayerCounterMove
+	ld hl, LastEnemyCounterMove
 	ld b, $5
 .asm_170c90
 	ld a, [hl]

--- a/wram.asm
+++ b/wram.asm
@@ -635,9 +635,9 @@ EnemyDisabledMove:: ; c6f6
 wWhichMonFaintedFirst:: ds 1
 
 ; exists so you can't counter on switch
-LastEnemyCounterMove:: ; c6f8
+LastPlayerCounterMove:: ; c6f8
 	ds 1
-LastPlayerCounterMove:: ; c6f9
+LastEnemyCounterMove:: ; c6f9
 	ds 1
 
 wEnemyMinimized:: ds 1 ; c6fa


### PR DESCRIPTION
I reversed LastEnemyCounterMove and LastPlayerCounterMove (they were in the wrong order).

I also added a comment to CheckTypeMatchup explaining how the rest of the code assumes the function works (the assumption is incorrect).