### PR TITLE
Fix every section to their desired position

### DIFF
--- a/audio.asm
+++ b/audio.asm
@@ -1,7 +1,7 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Audio", ROMX, BANK[AUDIO]
+SECTION "Audio", ROMX[$4000], BANK[AUDIO]
 
 INCLUDE "audio/engine.asm"
 
@@ -21,7 +21,7 @@ INCLUDE "audio/sfx_pointers.asm"
 
 
 
-SECTION "Songs 1", ROMX, BANK[SONGS_1]
+SECTION "Songs 1", ROMX[$54E9], BANK[SONGS_1]
 
 INCLUDE "audio/music/route36.asm"
 INCLUDE "audio/music/rivalbattle.asm"
@@ -40,7 +40,7 @@ INCLUDE "audio/music/lookpokemaniac.asm"
 INCLUDE "audio/music/trainervictory.asm"
 
 
-SECTION "Songs 2", ROMX, BANK[SONGS_2]
+SECTION "Songs 2", ROMX[$4000], BANK[SONGS_2]
 
 INCLUDE "audio/music/route1.asm"
 INCLUDE "audio/music/route3.asm"
@@ -76,7 +76,7 @@ INCLUDE "audio/music/contestresults.asm"
 INCLUDE "audio/music/route30.asm"
 
 
-SECTION "Songs 3", ROMX, BANK[SONGS_3]
+SECTION "Songs 3", ROMX[$4000], BANK[SONGS_3]
 
 INCLUDE "audio/music/violetcity.asm"
 INCLUDE "audio/music/route29.asm"
@@ -86,7 +86,7 @@ INCLUDE "audio/music/evolution.asm"
 INCLUDE "audio/music/printer.asm"
 
 
-SECTION "Songs 4", ROMX, BANK[SONGS_4]
+SECTION "Songs 4", ROMX[$4000], BANK[SONGS_4]
 
 INCLUDE "audio/music/viridiancity.asm"
 INCLUDE "audio/music/celadoncity.asm"
@@ -127,7 +127,7 @@ INCLUDE "audio/music/pokeflutechannel.asm"
 INCLUDE "audio/music/bugcatchingcontest.asm"
 
 
-SECTION "Songs 5", ROMX, BANK[SONGS_5]
+SECTION "Songs 5", ROMX[$401F], BANK[SONGS_5]
 
 INCLUDE "audio/music/mobileadaptermenu.asm"
 INCLUDE "audio/music/buenaspassword.asm"
@@ -140,31 +140,31 @@ INCLUDE "audio/music/mobilecenter.asm"
 
 
 
-SECTION "Extra Songs 1", ROMX, BANK[EXTRA_SONGS_1]
+SECTION "Extra Songs 1", ROMX[$731C], BANK[EXTRA_SONGS_1]
 
 INCLUDE "audio/music/credits.asm"
 INCLUDE "audio/music/clair.asm"
 INCLUDE "audio/music/mobileadapter.asm"
 
 
-SECTION "Extra Songs 2", ROMX, BANK[EXTRA_SONGS_2]
+SECTION "Extra Songs 2", ROMX[$7D9E], BANK[EXTRA_SONGS_2]
 
 INCLUDE "audio/music/postcredits.asm"
 
 
 
-SECTION "Sound Effects", ROMX, BANK[SOUND_EFFECTS]
+SECTION "Sound Effects", ROMX[$4941], BANK[SOUND_EFFECTS]
 
 INCLUDE "audio/sfx.asm"
 
 
-SECTION "Crystal Sound Effects", ROMX, BANK[CRYSTAL_SOUND_EFFECTS]
+SECTION "Crystal Sound Effects", ROMX[$582D], BANK[CRYSTAL_SOUND_EFFECTS]
 
 INCLUDE "audio/sfx_crystal.asm"
 
 
 
-SECTION "Cries", ROMX, BANK[CRIES]
+SECTION "Cries", ROMX[$6787], BANK[CRIES]
 
 CryHeaders:: INCLUDE "audio/cry_headers.asm"
 

--- a/data/egg_moves.asm
+++ b/data/egg_moves.asm
@@ -1,7 +1,7 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Egg Moves", ROMX, BANK[EGG_MOVES]
+SECTION "Egg Moves", ROMX[$7B11], BANK[EGG_MOVES]
 
 ; All instances of Charm, Steel Wing, Sweet Scent, and Lovely Kiss were
 ; removed from egg move lists in Crystal, because they are also TMs.

--- a/data/evos_attacks.asm
+++ b/data/evos_attacks.asm
@@ -1,7 +1,7 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Evolutions and Attacks", ROMX, BANK[EVOS_ATTACKS]
+SECTION "Evolutions and Attacks", ROMX[$65B1], BANK[EVOS_ATTACKS]
 
 
 INCLUDE "data/evos_attacks_pointers.asm"

--- a/data/pokedex/entries.asm
+++ b/data/pokedex/entries.asm
@@ -1,25 +1,25 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Pokedex Entries 001-064", ROMX, BANK[POKEDEX_ENTRIES_1]
+SECTION "Pokedex Entries 001-064", ROMX[$5695], BANK[POKEDEX_ENTRIES_1]
 
 PokedexEntries1::
 INCLUDE "data/pokedex/entries_1.asm"
 
 
-SECTION "Pokedex Entries 065-128", ROMX, BANK[POKEDEX_ENTRIES_2]
+SECTION "Pokedex Entries 065-128", ROMX[$4000], BANK[POKEDEX_ENTRIES_2]
 
 PokedexEntries2::
 INCLUDE "data/pokedex/entries_2.asm"
 
 
-SECTION "Pokedex Entries 129-192", ROMX, BANK[POKEDEX_ENTRIES_3]
+SECTION "Pokedex Entries 129-192", ROMX[$4000], BANK[POKEDEX_ENTRIES_3]
 
 PokedexEntries3::
 INCLUDE "data/pokedex/entries_3.asm"
 
 
-SECTION "Pokedex Entries 193-251", ROMX, BANK[POKEDEX_ENTRIES_4]
+SECTION "Pokedex Entries 193-251", ROMX[$4000], BANK[POKEDEX_ENTRIES_4]
 
 PokedexEntries4::
 INCLUDE "data/pokedex/entries_4.asm"

--- a/engine/credits.asm
+++ b/engine/credits.asm
@@ -1,6 +1,6 @@
 INCLUDE "includes.asm"
 
-SECTION "Credits", ROMX, BANK[CREDITS]
+SECTION "Credits", ROMX[$5847], BANK[CREDITS]
 
 	const_def
 	const SATOSHI_TAJIRI

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -1,6 +1,6 @@
 INCLUDE "includes.asm"
 
-SECTION "Events", ROMX, BANK[EVENTS]
+SECTION "Events", ROMX[$66B0], BANK[EVENTS]
 
 OverworldLoop:: ; 966b0
 	xor a

--- a/gfx/pics.asm
+++ b/gfx/pics.asm
@@ -10,12 +10,12 @@ SECTION "Unown Pic Pointers", ROMX[$4000], BANK[UNOWN_PIC_POINTERS]
 UnownPicPointers:: INCLUDE "gfx/pics/unown_pic_pointers.asm"
 
 
-SECTION "Trainer Pic Pointers", ROMX, BANK[TRAINER_PIC_POINTERS]
+SECTION "Trainer Pic Pointers", ROMX[$4000], BANK[TRAINER_PIC_POINTERS]
 TrainerPicPointers:: INCLUDE "gfx/pics/trainer_pic_pointers.asm"
 
 
 
-SECTION "Pics 1", ROMX, BANK[PICS_1]
+SECTION "Pics 1", ROMX[$45EE], BANK[PICS_1]
 
 HoOhFrontpic:        INCBIN "gfx/pics/ho_oh/front.2bpp.lz"
 MachampFrontpic:     INCBIN "gfx/pics/machamp/front.2bpp.lz"
@@ -33,7 +33,7 @@ TyphlosionFrontpic:  INCBIN "gfx/pics/typhlosion/front.2bpp.lz"
 ; 123ffa
 
 
-SECTION "Pics 2", ROMX, BANK[PICS_2]
+SECTION "Pics 2", ROMX[$409C], BANK[PICS_2]
 
 BlastoiseFrontpic:   INCBIN "gfx/pics/blastoise/front.2bpp.lz"
 RapidashFrontpic:    INCBIN "gfx/pics/rapidash/front.2bpp.lz"
@@ -54,7 +54,7 @@ QuilavaFrontpic:     INCBIN "gfx/pics/quilava/front.2bpp.lz"
 ; 127ffe
 
 
-SECTION "Pics 3", ROMX, BANK[PICS_3]
+SECTION "Pics 3", ROMX[$40C9], BANK[PICS_3]
 
 SteelixFrontpic:     INCBIN "gfx/pics/steelix/front.2bpp.lz"
 AlakazamFrontpic:    INCBIN "gfx/pics/alakazam/front.2bpp.lz"
@@ -77,7 +77,7 @@ OmastarBackpic:      INCBIN "gfx/pics/omastar/back.2bpp.lz"
 ; 12bffe
 
 
-SECTION "Pics 4", ROMX, BANK[PICS_4]
+SECTION "Pics 4", ROMX[$4000], BANK[PICS_4]
 
 DodrioFrontpic:      INCBIN "gfx/pics/dodrio/front.2bpp.lz"
 SlowkingFrontpic:    INCBIN "gfx/pics/slowking/front.2bpp.lz"
@@ -102,7 +102,7 @@ UnownEFrontpic:      INCBIN "gfx/pics/unown_e/front.2bpp.lz"
 ; 130000
 
 
-SECTION "Pics 5", ROMX, BANK[PICS_5]
+SECTION "Pics 5", ROMX[$4000], BANK[PICS_5]
 
 GolbatFrontpic:      INCBIN "gfx/pics/golbat/front.2bpp.lz"
 KinglerFrontpic:     INCBIN "gfx/pics/kingler/front.2bpp.lz"
@@ -128,7 +128,7 @@ HeracrossFrontpic:   INCBIN "gfx/pics/heracross/front.2bpp.lz"
 ; 133fff
 
 
-SECTION "Pics 6", ROMX, BANK[PICS_6]
+SECTION "Pics 6", ROMX[$4000], BANK[PICS_6]
 
 AriadosFrontpic:     INCBIN "gfx/pics/ariados/front.2bpp.lz"
 NoctowlFrontpic:     INCBIN "gfx/pics/noctowl/front.2bpp.lz"
@@ -156,7 +156,7 @@ DunsparceFrontpic:   INCBIN "gfx/pics/dunsparce/front.2bpp.lz"
 ; 137fff
 
 
-SECTION "Pics 7", ROMX, BANK[PICS_7]
+SECTION "Pics 7", ROMX[$4000], BANK[PICS_7]
 
 VaporeonFrontpic:    INCBIN "gfx/pics/vaporeon/front.2bpp.lz"
 GirafarigFrontpic:   INCBIN "gfx/pics/girafarig/front.2bpp.lz"
@@ -186,7 +186,7 @@ KangaskhanBackpic:   INCBIN "gfx/pics/kangaskhan/back.2bpp.lz"
 ; 13c000
 
 
-SECTION "Pics 8", ROMX, BANK[PICS_8]
+SECTION "Pics 8", ROMX[$4000], BANK[PICS_8]
 
 SeelFrontpic:        INCBIN "gfx/pics/seel/front.2bpp.lz"
 CrobatFrontpic:      INCBIN "gfx/pics/crobat/front.2bpp.lz"
@@ -218,7 +218,7 @@ QuagsireFrontpic:    INCBIN "gfx/pics/quagsire/front.2bpp.lz"
 ; 13fff7
 
 
-SECTION "Pics 9", ROMX, BANK[PICS_9]
+SECTION "Pics 9", ROMX[$4000], BANK[PICS_9]
 
 EkansFrontpic:       INCBIN "gfx/pics/ekans/front.2bpp.lz"
 SudowoodoFrontpic:   INCBIN "gfx/pics/sudowoodo/front.2bpp.lz"
@@ -254,7 +254,7 @@ ParasectBackpic:     INCBIN "gfx/pics/parasect/back.2bpp.lz"
 ; 144000
 
 
-SECTION "Pics 10", ROMX, BANK[PICS_10]
+SECTION "Pics 10", ROMX[$4000], BANK[PICS_10]
 
 MisdreavusFrontpic:  INCBIN "gfx/pics/misdreavus/front.2bpp.lz"
 HoundourFrontpic:    INCBIN "gfx/pics/houndour/front.2bpp.lz"
@@ -294,7 +294,7 @@ UnownFBackpic:       INCBIN "gfx/pics/unown_f/back.2bpp.lz"
 ; 148000
 
 
-SECTION "Pics 11", ROMX, BANK[PICS_11]
+SECTION "Pics 11", ROMX[$4000], BANK[PICS_11]
 
 DodrioBackpic:       INCBIN "gfx/pics/dodrio/back.2bpp.lz"
 ClefairyFrontpic:    INCBIN "gfx/pics/clefairy/front.2bpp.lz"
@@ -337,7 +337,7 @@ SnorlaxBackpic:      INCBIN "gfx/pics/snorlax/back.2bpp.lz"
 ; 14bffb
 
 
-SECTION "Pics 12", ROMX, BANK[PICS_12]
+SECTION "Pics 12", ROMX[$4000], BANK[PICS_12]
 
 VenusaurBackpic:     INCBIN "gfx/pics/venusaur/back.2bpp.lz"
 MoltresBackpic:      INCBIN "gfx/pics/moltres/back.2bpp.lz"
@@ -383,7 +383,7 @@ StarmieBackpic:      INCBIN "gfx/pics/starmie/back.2bpp.lz"
 ; 150000
 
 
-SECTION "Pics 13", ROMX, BANK[PICS_13]
+SECTION "Pics 13", ROMX[$4000], BANK[PICS_13]
 
 OmanyteBackpic:      INCBIN "gfx/pics/omanyte/back.2bpp.lz"
 PidgeyBackpic:       INCBIN "gfx/pics/pidgey/back.2bpp.lz"
@@ -431,7 +431,7 @@ ElectrodeFrontpic:   INCBIN "gfx/pics/electrode/front.2bpp.lz"
 ; 153fe3
 
 
-SECTION "Pics 14", ROMX, BANK[PICS_14]
+SECTION "Pics 14", ROMX[$4000], BANK[PICS_14]
 
 SudowoodoBackpic:    INCBIN "gfx/pics/sudowoodo/back.2bpp.lz"
 FlaaffyBackpic:      INCBIN "gfx/pics/flaaffy/back.2bpp.lz"
@@ -482,7 +482,7 @@ SwinubBackpic:       INCBIN "gfx/pics/swinub/back.2bpp.lz"
 ; 158000
 
 
-SECTION "Pics 15", ROMX, BANK[PICS_15]
+SECTION "Pics 15", ROMX[$4000], BANK[PICS_15]
 
 MewtwoBackpic:       INCBIN "gfx/pics/mewtwo/back.2bpp.lz"
 PokemonProfPic:      INCBIN "gfx/trainers/oak.2bpp.lz"
@@ -536,7 +536,7 @@ MagnemiteBackpic:    INCBIN "gfx/pics/magnemite/back.2bpp.lz"
 ; 15bffa
 
 
-SECTION "Pics 16", ROMX, BANK[PICS_16]
+SECTION "Pics 16", ROMX[$4000], BANK[PICS_16]
 
 HoothootBackpic:     INCBIN "gfx/pics/hoothoot/back.2bpp.lz"
 NoctowlBackpic:      INCBIN "gfx/pics/noctowl/back.2bpp.lz"
@@ -594,7 +594,7 @@ UnownHBackpic:       INCBIN "gfx/pics/unown_h/back.2bpp.lz"
 ; 15ffff
 
 
-SECTION "Pics 17", ROMX, BANK[PICS_17]
+SECTION "Pics 17", ROMX[$4000], BANK[PICS_17]
 
 ParasBackpic:        INCBIN "gfx/pics/paras/back.2bpp.lz"
 VaporeonBackpic:     INCBIN "gfx/pics/vaporeon/back.2bpp.lz"
@@ -660,7 +660,7 @@ UnownDBackpic:       INCBIN "gfx/pics/unown_d/back.2bpp.lz"
 ; 163ffc
 
 
-SECTION "Pics 18", ROMX, BANK[PICS_18]
+SECTION "Pics 18", ROMX[$4000], BANK[PICS_18]
 
 SpinarakBackpic:     INCBIN "gfx/pics/spinarak/back.2bpp.lz"
 RaikouBackpic:       INCBIN "gfx/pics/raikou/back.2bpp.lz"
@@ -725,7 +725,7 @@ UnownRBackpic:       INCBIN "gfx/pics/unown_r/back.2bpp.lz"
 ; 1669d3
 
 
-SECTION "Pics 19", ROMX, BANK[PICS_19]
+SECTION "Pics 19", ROMX[$4000], BANK[PICS_19]
 
 ; Seems to be an accidental copy of the previous bank
 

--- a/lib/mobile/main.asm
+++ b/lib/mobile/main.asm
@@ -4,7 +4,7 @@ charmap "<CR>", $d
 
 INCLUDE "gbhw.asm"
 
-SECTION "Main", ROMX
+SECTION "Main", ROMX[$4000], BANK[$44]
 
 Function110000: ; 110000 (44:4000)
 ; Copy b bytes from hl to de

--- a/main.asm
+++ b/main.asm
@@ -1,6 +1,6 @@
 INCLUDE "includes.asm"
 
-SECTION "bank1", ROMX, BANK[$1]
+SECTION "bank1", ROMX[$4000], BANK[$1]
 
 PlaceWaitingText:: ; 4000
 	hlcoord 3, 10
@@ -246,14 +246,14 @@ Predef1: ; 747a
 ; not used
 	ret
 
-SECTION "bank2", ROMX, BANK[$2]
+SECTION "bank2", ROMX[$4000], BANK[$2]
 
 INCLUDE "engine/player_object.asm"
 INCLUDE "engine/sine.asm"
 INCLUDE "engine/predef.asm"
 INCLUDE "engine/color.asm"
 
-SECTION "bank3", ROMX, BANK[$3]
+SECTION "bank3", ROMX[$4000], BANK[$3]
 
 CheckTime:: ; c000
 	ld a, [TimeOfDay]
@@ -380,7 +380,7 @@ KnowsMove: ; f9ea
 	text_jump UnknownText_0x1c5ea8
 	db "@"
 
-SECTION "bank4", ROMX, BANK[$4]
+SECTION "bank4", ROMX[$4000], BANK[$4]
 
 INCLUDE "engine/pack.asm"
 INCLUDE "engine/time.asm"
@@ -603,7 +603,7 @@ root	set 1
 root	set root+1
 	endr
 
-SECTION "bank5", ROMX, BANK[$5]
+SECTION "bank5", ROMX[$4000], BANK[$5]
 
 INCLUDE "engine/rtc.asm"
 INCLUDE "engine/overworld.asm"
@@ -620,27 +620,27 @@ INCLUDE "event/daycare.asm"
 INCLUDE "event/photo.asm"
 INCLUDE "engine/breeding/egg.asm"
 
-SECTION "Tileset Data 1", ROMX, BANK[TILESETS_1]
+SECTION "Tileset Data 1", ROMX[$4000], BANK[TILESETS_1]
 
 INCLUDE "tilesets/data_1.asm"
 
-SECTION "Roofs", ROMX, BANK[ROOFS]
+SECTION "Roofs", ROMX[$4000], BANK[ROOFS]
 
 INCLUDE "tilesets/roofs.asm"
 
-SECTION "Tileset Data 2", ROMX, BANK[TILESETS_2]
+SECTION "Tileset Data 2", ROMX[$430C], BANK[TILESETS_2]
 
 INCLUDE "tilesets/data_2.asm"
 
-SECTION "bank8", ROMX, BANK[$8]
+SECTION "bank8", ROMX[$4000], BANK[$8]
 
 INCLUDE "engine/clock_reset.asm"
 
-SECTION "Tileset Data 3", ROMX, BANK[TILESETS_3]
+SECTION "Tileset Data 3", ROMX[$4181], BANK[TILESETS_3]
 
 INCLUDE "tilesets/data_3.asm"
 
-SECTION "bank9", ROMX, BANK[$9]
+SECTION "bank9", ROMX[$4000], BANK[$9]
 
 StringBufferPointers:: ; 24000
 	dw StringBuffer3
@@ -1159,7 +1159,7 @@ Kurt_SelectQuantity_InterpretJoypad: ; 27a28
 	ld b, a
 	ret
 
-SECTION "bankA", ROMX, BANK[$A]
+SECTION "bankA", ROMX[$4000], BANK[$A]
 
 INCLUDE "engine/link.asm"
 
@@ -1183,7 +1183,7 @@ INCBIN "gfx/misc/player.6x6.2bpp.lz"
 DudeBackpic: ; 2bbaa
 INCBIN "gfx/misc/dude.6x6.2bpp.lz"
 
-SECTION "bankB", ROMX, BANK[$B]
+SECTION "bankB", ROMX[$4000], BANK[$B]
 
 INCLUDE "battle/trainer_huds.asm"
 
@@ -1618,15 +1618,15 @@ PlaceGraphic: ; 2ef6e
 	jr nz, .x2
 	ret
 
-SECTION "Tileset Data 4", ROMX, BANK[TILESETS_4]
+SECTION "Tileset Data 4", ROMX[$4000], BANK[TILESETS_4]
 
 INCLUDE "tilesets/data_4.asm"
 
-SECTION "Effect Commands", ROMX, BANK[$D]
+SECTION "Effect Commands", ROMX[$4000], BANK[$D]
 
 INCLUDE "battle/effect_commands.asm"
 
-SECTION "Enemy Trainers", ROMX, BANK[$E]
+SECTION "Enemy Trainers", ROMX[$4000], BANK[$E]
 
 INCLUDE "battle/ai/items.asm"
 
@@ -1706,13 +1706,13 @@ INCLUDE "trainers/trainer_pointers.asm"
 
 INCLUDE "trainers/trainers.asm"
 
-SECTION "Battle Core", ROMX, BANK[$F]
+SECTION "Battle Core", ROMX[$4000], BANK[$F]
 
 INCLUDE "battle/core.asm"
 
 INCLUDE "battle/effect_command_pointers.asm"
 
-SECTION "bank10", ROMX, BANK[$10]
+SECTION "bank10", ROMX[$4000], BANK[$10]
 
 INCLUDE "engine/pokedex.asm"
 
@@ -1720,7 +1720,7 @@ INCLUDE "battle/moves/moves.asm"
 
 INCLUDE "engine/evolve.asm"
 
-SECTION "bank11", ROMX, BANK[$11]
+SECTION "bank11", ROMX[$4000], BANK[$11]
 
 INCLUDE "engine/fruit_trees.asm"
 
@@ -1946,7 +1946,7 @@ INCLUDE "data/pokedex/entry_pointers.asm"
 
 INCLUDE "engine/mail.asm"
 
-SECTION "Crystal Unique", ROMX, BANK[$12]
+SECTION "Crystal Unique", ROMX[$4000], BANK[$12]
 
 INCLUDE "engine/init_gender.asm"
 
@@ -2153,7 +2153,7 @@ Buena_ExitMenu: ; 4ae5e
 	ld [hOAMUpdate], a
 	ret
 
-SECTION "bank13", ROMX, BANK[$13]
+SECTION "bank13", ROMX[$4000], BANK[$13]
 
 SwapTextboxPalettes:: ; 4c000
 	hlcoord 0, 0
@@ -3538,7 +3538,7 @@ INCLUDE "misc/gbc_only.asm"
 
 INCLUDE "event/poke_seer.asm"
 
-SECTION "bank14", ROMX, BANK[$14]
+SECTION "bank14", ROMX[$4000], BANK[$14]
 
 INCLUDE "engine/party_menu.asm"
 INCLUDE "event/poisonstep.asm"
@@ -4666,11 +4666,11 @@ UnknownEggPic:: ; 53d9c
 ; Another egg pic. This is shifted up a few pixels.
 INCBIN "gfx/misc/unknown_egg.5x5.2bpp.lz"
 
-SECTION "bank19", ROMX, BANK[$19]
+SECTION "bank19", ROMX[$4000], BANK[$19]
 
 INCLUDE "text/phone/extra.asm"
 
-SECTION "bank20", ROMX, BANK[$20]
+SECTION "bank20", ROMX[$4000], BANK[$20]
 
 INCLUDE "engine/player_movement.asm"
 
@@ -4683,7 +4683,7 @@ INCLUDE "text/battle.asm"
 
 INCLUDE "engine/debug.asm"
 
-SECTION "bank21", ROMX, BANK[$21]
+SECTION "bank21", ROMX[$4000], BANK[$21]
 
 INCLUDE "engine/printer.asm"
 
@@ -4691,7 +4691,7 @@ INCLUDE "battle/anim_gfx.asm"
 
 INCLUDE "event/halloffame.asm"
 
-SECTION "bank22", ROMX, BANK[$22]
+SECTION "bank22", ROMX[$4000], BANK[$22]
 
 INCLUDE "event/kurt.asm"
 
@@ -4969,7 +4969,7 @@ INCLUDE "event/dratini.asm"
 INCLUDE "event/battle_tower.asm"
 INCLUDE "misc/mobile_22_2.asm"
 
-SECTION "bank23", ROMX, BANK[$23]
+SECTION "bank23", ROMX[$4000], BANK[$23]
 
 Predef35: ; 8c000
 Predef36:
@@ -4998,7 +4998,7 @@ INCLUDE "engine/sprites.asm"
 
 INCLUDE "engine/mon_icons.asm"
 
-SECTION "bank24", ROMX, BANK[$24]
+SECTION "bank24", ROMX[$4000], BANK[$24]
 
 INCLUDE "engine/phone.asm"
 INCLUDE "engine/timeset.asm"
@@ -5007,12 +5007,12 @@ INCLUDE "engine/pokegear.asm"
 INCLUDE "engine/fish.asm"
 INCLUDE "engine/slot_machine.asm"
 
-SECTION "Phone Engine", ROMX, BANK[$28]
+SECTION "Phone Engine", ROMX[$4000], BANK[$28]
 
 INCLUDE "engine/more_phone_scripts.asm"
 INCLUDE "engine/buena_phone_scripts.asm"
 
-SECTION "Phone Text", ROMX, BANK[$29]
+SECTION "Phone Text", ROMX[$4000], BANK[$29]
 
 INCLUDE "text/phone/anthony_overworld.asm"
 INCLUDE "text/phone/todd_overworld.asm"
@@ -5032,11 +5032,11 @@ INCLUDE "text/phone/kenji_overworld.asm"
 INCLUDE "text/phone/parry_overworld.asm"
 INCLUDE "text/phone/erin_overworld.asm"
 
-SECTION "Tileset Data 5", ROMX, BANK[TILESETS_5]
+SECTION "Tileset Data 5", ROMX[$4000], BANK[TILESETS_5]
 
 INCLUDE "tilesets/data_5.asm"
 
-SECTION "bank2E", ROMX, BANK[$2E]
+SECTION "bank2E", ROMX[$4000], BANK[$2E]
 
 INCLUDE "engine/events_3.asm"
 
@@ -5044,7 +5044,7 @@ INCLUDE "engine/radio.asm"
 
 INCLUDE "gfx/mail.asm"
 
-SECTION "bank2F", ROMX, BANK[$2F]
+SECTION "bank2F", ROMX[$4000], BANK[$2F]
 
 INCLUDE "engine/std_scripts.asm"
 
@@ -5082,15 +5082,15 @@ StartBattleWithMapTrainerScript: ; 0xbe68a
 AlreadyBeatenTrainerScript:
 	scripttalkafter
 
-SECTION "bank30", ROMX, BANK[$30]
+SECTION "bank30", ROMX[$4000], BANK[$30]
 
 INCLUDE "gfx/overworld/sprites_1.asm"
 
-SECTION "bank31", ROMX, BANK[$31]
+SECTION "bank31", ROMX[$4000], BANK[$31]
 
 INCLUDE "gfx/overworld/sprites_2.asm"
 
-SECTION "bank32", ROMX, BANK[$32]
+SECTION "bank32", ROMX[$4000], BANK[$32]
 
 INCLUDE "battle/bg_effects.asm"
 
@@ -5148,7 +5148,7 @@ LoadPoisonBGPals: ; cbcdd
 TheEndGFX:: ; cbd2e
 INCBIN "gfx/credits/theend.2bpp"
 
-SECTION "bank33", ROMX, BANK[$33]
+SECTION "bank33", ROMX[$4000], BANK[$33]
 
 DisplayCaughtContestMonStats: ; cc000
 
@@ -5263,7 +5263,7 @@ INCLUDE "battle/anim_commands.asm"
 
 INCLUDE "battle/anim_objects.asm"
 
-SECTION "Pic Animations 1", ROMX, BANK[$34]
+SECTION "Pic Animations 1", ROMX[$4000], BANK[$34]
 
 INCLUDE "gfx/pics/animation.asm"
 
@@ -5303,26 +5303,26 @@ INCLUDE "gfx/pics/bitmasks.asm"
 INCLUDE "gfx/pics/unown_bitmask_pointers.asm"
 INCLUDE "gfx/pics/unown_bitmasks.asm"
 
-SECTION "Pic Animations 2", ROMX, BANK[$35]
+SECTION "Pic Animations 2", ROMX[$4000], BANK[$35]
 
 INCLUDE "gfx/pics/frame_pointers.asm"
 INCLUDE "gfx/pics/kanto_frames.asm"
 
-SECTION "bank36", ROMX, BANK[$36]
+SECTION "bank36", ROMX[$4000], BANK[$36]
 
 FontInversed: INCBIN "gfx/misc/font_inversed.1bpp"
 
-SECTION "Pic Animations 3", ROMX, BANK[$36]
+SECTION "Pic Animations 3", ROMX[$4400], BANK[$36]
 
 INCLUDE "gfx/pics/johto_frames.asm"
 INCLUDE "gfx/pics/unown_frame_pointers.asm"
 INCLUDE "gfx/pics/unown_frames.asm"
 
-SECTION "Tileset Data 6", ROMX, BANK[TILESETS_6]
+SECTION "Tileset Data 6", ROMX[$4000], BANK[TILESETS_6]
 
 INCLUDE "tilesets/data_6.asm"
 
-SECTION "bank38", ROMX, BANK[$38]
+SECTION "bank38", ROMX[$4000], BANK[$38]
 
 RotateUnownFrontpic: ; e0000
 ; something to do with Unown printer
@@ -5449,7 +5449,7 @@ INCLUDE "engine/unown_puzzle.asm"
 INCLUDE "engine/dummy_game.asm"
 INCLUDE "engine/billspc.asm"
 
-SECTION "bank39", ROMX, BANK[$39]
+SECTION "bank39", ROMX[$4000], BANK[$39]
 
 CopyrightGFX:: ; e4000
 INCBIN "gfx/misc/copyright.2bpp"
@@ -5457,7 +5457,7 @@ INCBIN "gfx/misc/copyright.2bpp"
 INCLUDE "engine/options_menu.asm"
 INCLUDE "engine/crystal_intro.asm"
 
-SECTION "bank3E", ROMX, BANK[$3E]
+SECTION "bank3E", ROMX[$4000], BANK[$3E]
 
 INCLUDE "gfx/font.asm"
 INCLUDE "engine/time_capsule/conversion.asm"
@@ -5468,7 +5468,7 @@ INCLUDE "battle/hidden_power.asm"
 
 INCLUDE "battle/misc.asm"
 
-SECTION "bank3F", ROMX, BANK[$3F]
+SECTION "bank3F", ROMX[$4000], BANK[$3F]
 
 INCLUDE "tilesets/animations.asm"
 
@@ -5476,11 +5476,11 @@ INCLUDE "engine/npctrade.asm"
 
 INCLUDE "event/mom_phone.asm"
 
-SECTION "bank40", ROMX, BANK[$40]
+SECTION "bank40", ROMX[$4000], BANK[$40]
 
 INCLUDE "misc/mobile_40.asm"
 
-SECTION "bank41", ROMX, BANK[$41]
+SECTION "bank41", ROMX[$4000], BANK[$41]
 
 INCLUDE "misc/gfx_41.asm"
 
@@ -5492,11 +5492,11 @@ INCLUDE "battle/used_move_text.asm"
 
 INCLUDE "misc/mobile_41.asm"
 
-SECTION "bank42", ROMX, BANK[$42]
+SECTION "bank42", ROMX[$4000], BANK[$42]
 
 INCLUDE "misc/mobile_42.asm"
 
-SECTION "Intro Logo", ROMX, BANK[$42]
+SECTION "Intro Logo", ROMX[$5407], BANK[$42]
 
 IntroLogoGFX: ; 109407
 INCBIN "gfx/intro/logo.2bpp.lz"
@@ -5508,24 +5508,24 @@ INCLUDE "engine/title.asm"
 INCLUDE "misc/mobile_45.asm"
 INCLUDE "misc/mobile_46.asm"
 
-SECTION "bank47", ROMX, BANK[$47]
+SECTION "bank47", ROMX[$4000], BANK[$47]
 
 INCLUDE "misc/battle_tower_47.asm"
 
-SECTION "bank5B", ROMX, BANK[$5B]
+SECTION "bank5B", ROMX[$4000], BANK[$5B]
 
 INCLUDE "misc/mobile_5b.asm"
 INCLUDE "engine/link_trade.asm"
 
-SECTION "bank5C", ROMX, BANK[$5C]
+SECTION "bank5C", ROMX[$4000], BANK[$5C]
 
 INCLUDE "misc/mobile_5c.asm"
 
-SECTION "bank5D", ROMX, BANK[$5D]
+SECTION "bank5D", ROMX[$4000], BANK[$5D]
 
 INCLUDE "text/phone/extra3.asm"
 
-SECTION "bank5E", ROMX, BANK[$5E]
+SECTION "bank5E", ROMX[$4000], BANK[$5E]
 
 _UpdateBattleHUDs:
 	callba DrawPlayerHUD
@@ -5539,7 +5539,7 @@ _UpdateBattleHUDs:
 
 INCLUDE "misc/mobile_5f.asm"
 
-SECTION "Common Text 1", ROMX, BANK[$6C]
+SECTION "Common Text 1", ROMX[$4000], BANK[$6C]
 
 INCLUDE "text/stdtext.asm"
 INCLUDE "text/phone/jack_overworld.asm"
@@ -5554,14 +5554,14 @@ INCLUDE "text/phone/wade_overworld.asm"
 INCLUDE "text/phone/ralph_overworld.asm"
 INCLUDE "text/phone/liz_overworld.asm"
 
-SECTION "bank6D", ROMX, BANK[$6D]
+SECTION "bank6D", ROMX[$4000], BANK[$6D]
 
 INCLUDE "text/phone/mom.asm"
 INCLUDE "text/phone/bill.asm"
 INCLUDE "text/phone/elm.asm"
 INCLUDE "text/phone/trainers1.asm"
 
-SECTION "bank72", ROMX, BANK[$72]
+SECTION "bank72", ROMX[$4000], BANK[$72]
 
 ItemNames::
 INCLUDE "items/item_names.asm"
@@ -5573,7 +5573,7 @@ INCLUDE "battle/move_names.asm"
 
 INCLUDE "engine/landmarks.asm"
 
-SECTION "bank77", ROMX, BANK[$77]
+SECTION "bank77", ROMX[$4000], BANK[$77]
 
 UnownFont: ; 1dc000
 INCBIN "gfx/misc/unown_font.2bpp"
@@ -5586,11 +5586,11 @@ INCBIN "gfx/mobile/hp.1bpp"
 MobileLvIcon: ; 1dc599
 INCBIN "gfx/mobile/lv.1bpp"
 
-SECTION "Tileset Data 7", ROMX, BANK[TILESETS_7]
+SECTION "Tileset Data 7", ROMX[$45A1], BANK[TILESETS_7]
 
 INCLUDE "tilesets/data_7.asm"
 
-SECTION "bank77_2", ROMX, BANK[$77]
+SECTION "bank77_2", ROMX[$56A9], BANK[$77]
 
 Function1dd6a9: ; 1dd6a9
 ; XXX
@@ -6021,19 +6021,19 @@ LeggiPostaInglese:
 	jr nz, .loop
 	ret
 
-SECTION "Tileset Data 8", ROMX, BANK[TILESETS_8]
+SECTION "Tileset Data 8", ROMX[$4000], BANK[TILESETS_8]
 
 INCLUDE "tilesets/data_8.asm"
 
-SECTION "bank7B", ROMX, BANK[$7B]
+SECTION "bank7B", ROMX[$4000], BANK[$7B]
 
 INCLUDE "text/battle_tower.asm"
 
-SECTION "bank7C", ROMX, BANK[$7C]
+SECTION "bank7C", ROMX[$4000], BANK[$7C]
 
 INCLUDE "data/battle_tower_2.asm"
 
-SECTION "bank7D", ROMX, BANK[$7D]
+SECTION "bank7D", ROMX[$4000], BANK[$7D]
 
 	db $cc, $6b, $1e ; XXX
 
@@ -6078,12 +6078,12 @@ Function1f5d9f: ; 1f5d9f
 .unknown_data
 INCBIN "unknown/1f5db4.bin"
 
-SECTION "bank7E", ROMX, BANK[$7E]
+SECTION "bank7E", ROMX[$4000], BANK[$7E]
 
 INCLUDE "data/battle_tower.asm"
 INCLUDE "data/odd_eggs.asm"
 
-SECTION "bank7F", ROMX, BANK[$7F]
+SECTION "bank7F", ROMX[$4000], BANK[$7F]
 
 SECTION "stadium2", ROMX[$8000-$220], BANK[$7F]
 

--- a/maps.asm
+++ b/maps.asm
@@ -1,30 +1,30 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Map Headers", ROMX, BANK[MAP_HEADERS]
+SECTION "Map Headers", ROMX[$4000], BANK[MAP_HEADERS]
 
 INCLUDE "maps/map_headers.asm"
 INCLUDE "maps/second_map_headers.asm"
 
 
 
-SECTION "Map Blockdata 1", ROMX, BANK[MAPS_1]
+SECTION "Map Blockdata 1", ROMX[$4000], BANK[MAPS_1]
 
 INCLUDE "maps/blockdata_1.asm"
 
 
-SECTION "Map Blockdata 2", ROMX, BANK[MAPS_2]
+SECTION "Map Blockdata 2", ROMX[$4000], BANK[MAPS_2]
 
 INCLUDE "maps/blockdata_2.asm"
 
 
-SECTION "Map Blockdata 3", ROMX, BANK[MAPS_3]
+SECTION "Map Blockdata 3", ROMX[$4000], BANK[MAPS_3]
 
 INCLUDE "maps/blockdata_3.asm"
 
 
 
-SECTION "Map Scripts 1", ROMX, BANK[MAP_SCRIPTS_1]
+SECTION "Map Scripts 1", ROMX[$4000], BANK[MAP_SCRIPTS_1]
 
 INCLUDE "maps/GoldenrodGym.asm"
 INCLUDE "maps/GoldenrodBikeShop.asm"
@@ -45,7 +45,7 @@ INCLUDE "maps/GoldenrodDeptStoreRoof.asm"
 INCLUDE "maps/GoldenrodGameCorner.asm"
 
 
-SECTION "Map Scripts 2", ROMX, BANK[MAP_SCRIPTS_2]
+SECTION "Map Scripts 2", ROMX[$4000], BANK[MAP_SCRIPTS_2]
 
 INCLUDE "maps/RuinsofAlphOutside.asm"
 INCLUDE "maps/RuinsofAlphHoOhChamber.asm"
@@ -73,7 +73,7 @@ INCLUDE "maps/OlivineLighthouse3F.asm"
 INCLUDE "maps/OlivineLighthouse4F.asm"
 
 
-SECTION "Map Scripts 3", ROMX, BANK[MAP_SCRIPTS_3]
+SECTION "Map Scripts 3", ROMX[$4000], BANK[MAP_SCRIPTS_3]
 
 INCLUDE "maps/NationalPark.asm"
 INCLUDE "maps/NationalParkBugContest.asm"
@@ -83,7 +83,7 @@ INCLUDE "maps/RadioTower3F.asm"
 INCLUDE "maps/RadioTower4F.asm"
 
 
-SECTION "Map Scripts 4", ROMX, BANK[MAP_SCRIPTS_4]
+SECTION "Map Scripts 4", ROMX[$4000], BANK[MAP_SCRIPTS_4]
 
 INCLUDE "maps/RadioTower5F.asm"
 INCLUDE "maps/OlivineLighthouse5F.asm"
@@ -95,7 +95,7 @@ INCLUDE "maps/Route34IlexForestGate.asm"
 INCLUDE "maps/DayCare.asm"
 
 
-SECTION "Map Scripts 5", ROMX, BANK[MAP_SCRIPTS_5]
+SECTION "Map Scripts 5", ROMX[$4000], BANK[MAP_SCRIPTS_5]
 
 INCLUDE "maps/Route11.asm"
 INCLUDE "maps/VioletMart.asm"
@@ -112,7 +112,7 @@ INCLUDE "maps/Route36RuinsofAlphgate.asm"
 INCLUDE "maps/Route36NationalParkgate.asm"
 
 
-SECTION "Map Scripts 6", ROMX, BANK[MAP_SCRIPTS_6]
+SECTION "Map Scripts 6", ROMX[$4000], BANK[MAP_SCRIPTS_6]
 
 INCLUDE "maps/Route8.asm"
 INCLUDE "maps/MahoganyMart1F.asm"
@@ -122,7 +122,7 @@ INCLUDE "maps/TeamRocketBaseB3F.asm"
 INCLUDE "maps/IlexForest.asm"
 
 
-SECTION "Map Scripts 7", ROMX, BANK[MAP_SCRIPTS_7]
+SECTION "Map Scripts 7", ROMX[$4000], BANK[MAP_SCRIPTS_7]
 
 INCLUDE "maps/LakeofRage.asm"
 INCLUDE "maps/CeladonDeptStore1F.asm"
@@ -149,7 +149,7 @@ INCLUDE "maps/Route7SaffronGate.asm"
 INCLUDE "maps/Route1718Gate.asm"
 
 
-SECTION "Map Scripts 8", ROMX, BANK[MAP_SCRIPTS_8]
+SECTION "Map Scripts 8", ROMX[$4000], BANK[MAP_SCRIPTS_8]
 
 INCLUDE "maps/DiglettsCave.asm"
 INCLUDE "maps/MountMoon.asm"
@@ -173,7 +173,7 @@ INCLUDE "maps/MountMoonGiftShop.asm"
 INCLUDE "maps/TinTowerRoof.asm"
 
 
-SECTION "Map Scripts 9", ROMX, BANK[MAP_SCRIPTS_9]
+SECTION "Map Scripts 9", ROMX[$4000], BANK[MAP_SCRIPTS_9]
 
 INCLUDE "maps/Route34.asm"
 INCLUDE "maps/ElmsLab.asm"
@@ -187,7 +187,7 @@ INCLUDE "maps/Route27SandstormHouse.asm"
 INCLUDE "maps/Route2946Gate.asm"
 
 
-SECTION "Map Scripts 10", ROMX, BANK[MAP_SCRIPTS_10]
+SECTION "Map Scripts 10", ROMX[$4000], BANK[MAP_SCRIPTS_10]
 
 INCLUDE "maps/Route22.asm"
 INCLUDE "maps/WarehouseEntrance.asm"
@@ -215,7 +215,7 @@ INCLUDE "maps/Route8SaffronGate.asm"
 INCLUDE "maps/Route12SuperRodHouse.asm"
 
 
-SECTION "Map Scripts 11", ROMX, BANK[MAP_SCRIPTS_11]
+SECTION "Map Scripts 11", ROMX[$4000], BANK[MAP_SCRIPTS_11]
 
 INCLUDE "maps/EcruteakHouse.asm"
 INCLUDE "maps/WiseTriosRoom.asm"
@@ -237,7 +237,7 @@ INCLUDE "maps/Route2Gate.asm"
 INCLUDE "maps/VictoryRoadGate.asm"
 
 
-SECTION "Map Scripts 12", ROMX, BANK[MAP_SCRIPTS_12]
+SECTION "Map Scripts 12", ROMX[$4000], BANK[MAP_SCRIPTS_12]
 
 INCLUDE "maps/OlivinePokeCenter1F.asm"
 INCLUDE "maps/OlivineGym.asm"
@@ -265,7 +265,7 @@ INCLUDE "maps/Route40BattleTowerGate.asm"
 INCLUDE "maps/BattleTowerOutside.asm"
 
 
-SECTION "Map Scripts 13", ROMX, BANK[MAP_SCRIPTS_13]
+SECTION "Map Scripts 13", ROMX[$4000], BANK[MAP_SCRIPTS_13]
 
 INCLUDE "maps/IndigoPlateauPokeCenter1F.asm"
 INCLUDE "maps/WillsRoom.asm"
@@ -276,7 +276,7 @@ INCLUDE "maps/LancesRoom.asm"
 INCLUDE "maps/HallOfFame.asm"
 
 
-SECTION "Map Scripts 14", ROMX, BANK[MAP_SCRIPTS_14]
+SECTION "Map Scripts 14", ROMX[$4000], BANK[MAP_SCRIPTS_14]
 
 INCLUDE "maps/CeruleanCity.asm"
 INCLUDE "maps/SproutTower1F.asm"
@@ -295,7 +295,7 @@ INCLUDE "maps/BurnedTower1F.asm"
 INCLUDE "maps/BurnedTowerB1F.asm"
 
 
-SECTION "Map Scripts 15", ROMX, BANK[MAP_SCRIPTS_15]
+SECTION "Map Scripts 15", ROMX[$4000], BANK[MAP_SCRIPTS_15]
 
 INCLUDE "maps/CeruleanGymBadgeSpeechHouse.asm"
 INCLUDE "maps/CeruleanPoliceStation.asm"
@@ -323,7 +323,7 @@ INCLUDE "maps/Route5SaffronCityGate.asm"
 INCLUDE "maps/Route5CleanseTagSpeechHouse.asm"
 
 
-SECTION "Map Scripts 16", ROMX, BANK[MAP_SCRIPTS_16]
+SECTION "Map Scripts 16", ROMX[$4000], BANK[MAP_SCRIPTS_16]
 
 INCLUDE "maps/PewterCity.asm"
 INCLUDE "maps/WhirlIslandNW.asm"
@@ -351,7 +351,7 @@ INCLUDE "maps/KurtsHouse.asm"
 INCLUDE "maps/AzaleaGym.asm"
 
 
-SECTION "Map Scripts 17", ROMX, BANK[MAP_SCRIPTS_17]
+SECTION "Map Scripts 17", ROMX[$4000], BANK[MAP_SCRIPTS_17]
 
 INCLUDE "maps/MahoganyTown.asm"
 INCLUDE "maps/Route32.asm"
@@ -373,7 +373,7 @@ INCLUDE "maps/MobileTradeRoomMobile.asm"
 INCLUDE "maps/MobileBattleRoom.asm"
 
 
-SECTION "Map Scripts 18", ROMX, BANK[MAP_SCRIPTS_18]
+SECTION "Map Scripts 18", ROMX[$4000], BANK[MAP_SCRIPTS_18]
 
 INCLUDE "maps/Route36.asm"
 INCLUDE "maps/FuchsiaCity.asm"
@@ -402,7 +402,7 @@ INCLUDE "maps/MrPokemonsHouse.asm"
 INCLUDE "maps/Route31VioletGate.asm"
 
 
-SECTION "Map Scripts 19", ROMX, BANK[MAP_SCRIPTS_19]
+SECTION "Map Scripts 19", ROMX[$4000], BANK[MAP_SCRIPTS_19]
 
 INCLUDE "maps/AzaleaTown.asm"
 INCLUDE "maps/GoldenrodCity.asm"
@@ -421,7 +421,7 @@ INCLUDE "maps/BluesHouse.asm"
 INCLUDE "maps/OaksLab.asm"
 
 
-SECTION "Map Scripts 20", ROMX, BANK[MAP_SCRIPTS_20]
+SECTION "Map Scripts 20", ROMX[$4000], BANK[MAP_SCRIPTS_20]
 
 INCLUDE "maps/CherrygroveCity.asm"
 INCLUDE "maps/Route35.asm"
@@ -432,7 +432,7 @@ INCLUDE "maps/Route19.asm"
 INCLUDE "maps/Route25.asm"
 
 
-SECTION "Map Scripts 21", ROMX, BANK[MAP_SCRIPTS_21]
+SECTION "Map Scripts 21", ROMX[$4000], BANK[MAP_SCRIPTS_21]
 
 INCLUDE "maps/CianwoodCity.asm"
 INCLUDE "maps/Route27.asm"
@@ -448,7 +448,7 @@ INCLUDE "maps/PewterPokeCEnter2FBeta.asm"
 INCLUDE "maps/PewterSnoozeSpeechHouse.asm"
 
 
-SECTION "Map Scripts 22", ROMX, BANK[MAP_SCRIPTS_22]
+SECTION "Map Scripts 22", ROMX[$4000], BANK[MAP_SCRIPTS_22]
 
 INCLUDE "maps/EcruteakCity.asm"
 INCLUDE "maps/BlackthornCity.asm"
@@ -461,7 +461,7 @@ INCLUDE "maps/Route41.asm"
 INCLUDE "maps/Route12.asm"
 
 
-SECTION "Map Scripts 23", ROMX, BANK[MAP_SCRIPTS_23]
+SECTION "Map Scripts 23", ROMX[$4000], BANK[MAP_SCRIPTS_23]
 
 INCLUDE "maps/NewBarkTown.asm"
 INCLUDE "maps/VioletCity.asm"
@@ -480,7 +480,7 @@ INCLUDE "maps/Route19FuchsiaGate.asm"
 INCLUDE "maps/SeafoamGym.asm"
 
 
-SECTION "Map Scripts 24", ROMX, BANK[MAP_SCRIPTS_24]
+SECTION "Map Scripts 24", ROMX[$4000], BANK[MAP_SCRIPTS_24]
 
 INCLUDE "maps/Route33.asm"
 INCLUDE "maps/Route2.asm"
@@ -506,7 +506,7 @@ INCLUDE "maps/SilverCavePokeCenter1F.asm"
 INCLUDE "maps/Route28FamousSpeechHouse.asm"
 
 
-SECTION "Map Scripts 25", ROMX, BANK[MAP_SCRIPTS_25]
+SECTION "Map Scripts 25", ROMX[$6042], BANK[MAP_SCRIPTS_25]
 
 INCLUDE "maps/SilverCaveOutside.asm"
 INCLUDE "maps/Route10North.asm"

--- a/misc/crystal_misc.asm
+++ b/misc/crystal_misc.asm
@@ -1,7 +1,7 @@
 INCLUDE "includes.asm"
 
 
-SECTION "Misc Crystal", ROMX, BANK[MISC_CRYSTAL]
+SECTION "Misc Crystal", ROMX[$59EF], BANK[MISC_CRYSTAL]
 
 MobileAdapterGFX::
 INCBIN "gfx/misc/mobile_adapter.2bpp"

--- a/misc/mobile_40.asm
+++ b/misc/mobile_40.asm
@@ -1784,7 +1784,7 @@ Function100ae7: ; 100ae7
 ; 100b0a
 
 
-SECTION "tetsuji", ROMX, BANK[$40]
+SECTION "tetsuji", ROMX[$4B0A], BANK[$40]
 
 	charmap " ", $20 ; revert to ascii
 
@@ -1793,7 +1793,7 @@ Unknown_100b0a: ; 100b0a
 ; 100b12
 
 
-SECTION "bank40_2", ROMX, BANK[$40]
+SECTION "bank40_2", ROMX[$4B12], BANK[$40]
 
 Function100b12: ; 100b12
 	call Function100dd8
@@ -3831,7 +3831,7 @@ Function101826: ; 101826
 ; 10186f
 
 
-SECTION "ascii 10186f", ROMX, BANK[$40]
+SECTION "ascii 10186f", ROMX[$586F], BANK[$40]
 
 	charmap " ", $20 ; revert to ascii
 
@@ -3852,7 +3852,7 @@ Unknown_101895:
 ; 1018a8
 
 
-SECTION "bank40_3", ROMX, BANK[$40]
+SECTION "bank40_3", ROMX[$58A8], BANK[$40]
 
 Function1018a8: ; 1018a8
 	ld hl, wccb5

--- a/misc/mobile_41.asm
+++ b/misc/mobile_41.asm
@@ -1,4 +1,4 @@
-SECTION "bank41_2", ROMX, BANK[$41]
+SECTION "bank41_2", ROMX[$5EF6], BANK[$41]
 
 ; These functions deal with miscellaneous statistics
 ; which were used for Trainer Rankings in Pokémon News.

--- a/misc/mobile_45.asm
+++ b/misc/mobile_45.asm
@@ -1,5 +1,5 @@
 
-SECTION "bank45", ROMX, BANK[$45]
+SECTION "bank45", ROMX[$4000], BANK[$45]
 
 	charmap " ", $20 ; revert to ascii
 
@@ -6835,7 +6835,7 @@ Unknown_117356: ; 117356
 ; 117656
 
 
-SECTION "Mobile Stadium", ROMX, BANK[$45]
+SECTION "Mobile Stadium", ROMX[$7656], BANK[$45]
 
 Special_GiveOddEgg: ; 117656
 	callba GiveOddEgg

--- a/misc/mobile_46.asm
+++ b/misc/mobile_46.asm
@@ -1,4 +1,4 @@
-SECTION "bank46", ROMX, BANK[$46]
+SECTION "bank46", ROMX[$4000], BANK[$46]
 
 Function118000: ; 118000
 	ld a, $1
@@ -3014,7 +3014,7 @@ Unknown_1196b8: ; 1196b8
 	db "Sun"
 ; 1196cd
 
-SECTION "bank46_2", ROMX, BANK[$46]
+SECTION "bank46_2", ROMX[$56CD], BANK[$46]
 ; A hack to use ascii above.
 
 Function1196cd: ; 1196cd (46:56cd)

--- a/misc/mobile_5f.asm
+++ b/misc/mobile_5f.asm
@@ -1,5 +1,5 @@
 
-SECTION "bank5F", ROMX, BANK[$5F]
+SECTION "bank5F", ROMX[$4000], BANK[$5F]
 
 Function17c000: ; 17c000
 

--- a/misc/unused_title.asm
+++ b/misc/unused_title.asm
@@ -1,5 +1,5 @@
 
-SECTION "bank43", ROMX, BANK[$43]
+SECTION "bank43", ROMX[$4000], BANK[$43]
 
 UnusedTitleScreen: ; 10c000
 

--- a/sram.asm
+++ b/sram.asm
@@ -3,7 +3,7 @@ SRAM_End   EQU $c000
 GLOBAL SRAM_Begin, SRAM_End
 
 
-SECTION "Scratch", SRAM, BANK [0]
+SECTION "Scratch", SRAM[$A000], BANK [0]
 sScratch::
 
 
@@ -98,7 +98,7 @@ s0_bf0f:: ds 1 ; loaded with 0x7f, used to check save corruption
 sStackTop:: ds 2
 
 
-SECTION "Save", SRAM, BANK [1]
+SECTION "Save", SRAM[$A000], BANK[1]
 
 sOptions:: ds OptionsEnd - Options
 
@@ -117,13 +117,13 @@ sGameDataEnd::
 sChecksum::   ds 2
 s1_ad0f::     ds 1 ; loaded with 0x7f, used to check save corruption
 
-SECTION "Active Box", SRAM, BANK [1]
+SECTION "Active Box", SRAM[$AD10], BANK [1]
 ; ad10
 	box sBox
 ; b160
 
 	ds $f4
-SECTION "Link Battle Data", SRAM, BANK [1]
+SECTION "Link Battle Data", SRAM[$B254], BANK[1]
 sLinkBattleResults:: ds $c
 
 sLinkBattleStats:: ; b260
@@ -145,7 +145,7 @@ sLinkBattleRecord4:: link_battle_record sLinkBattleRecord4
 sLinkBattleRecord5:: link_battle_record sLinkBattleRecord5
 sLinkBattleStatsEnd::
 
-SECTION "SRAM Hall of Fame", SRAM, BANK [1]
+SECTION "SRAM Hall of Fame", SRAM[$B2C0], BANK [1]
 sHallOfFame:: ; b2c0
 ; temporary until I can find a way to macrofy it
 	hall_of_fame sHallOfFame01
@@ -193,14 +193,14 @@ sHallOfFame:: ; b2c0
 ; endr
 sHallOfFameEnd::
 
-SECTION "SRAM Crystal Data", SRAM, BANK [1]
+SECTION "SRAM Crystal Data", SRAM[$BE3C], BANK [1]
 sMobileEventIndex:: ds 1 ; be3c
 
 sCrystalData::
 	ds wCrystalDataEnd - wCrystalData
 sMobileEventIndexBackup:: ds 1
 
-SECTION "SRAM Battle Tower", SRAM, BANK [1]
+SECTION "SRAM Battle Tower", SRAM[$BE45], BANK [1]
 ; data of the BattleTower must be in SRAM because you can save and leave between battles
 sBattleTowerChallengeState:: ds 1
 ; 0: normal
@@ -226,7 +226,7 @@ sBTPkmnPrevPrevTrainer2:: ds 1
 sBTPkmnPrevPrevTrainer3:: ds 1
 
 
-SECTION "Boxes 1-7",  SRAM, BANK [2]
+SECTION "Boxes 1-7",  SRAM[$A000], BANK[2]
 	box sBox1
 	box sBox2
 	box sBox3
@@ -235,7 +235,7 @@ SECTION "Boxes 1-7",  SRAM, BANK [2]
 	box sBox6
 	box sBox7
 
-SECTION "Boxes 8-14", SRAM, BANK [3]
+SECTION "Boxes 8-14", SRAM[$A000], BANK[3]
 	box sBox8
 	box sBox9
 	box sBox10

--- a/text/common_text.asm
+++ b/text/common_text.asm
@@ -1,12 +1,12 @@
 INCLUDE "includes.asm"
 
-SECTION "Text 1", ROMX, BANK[$6F]
+SECTION "Text 1", ROMX[$4000], BANK[$6F]
 INCLUDE "text/common_1.asm"
 
-SECTION "Text 2", ROMX, BANK[$70]
+SECTION "Text 2", ROMX[$4000], BANK[$70]
 INCLUDE "text/common_2.asm"
 INCLUDE "text/common_3.asm"
 
-SECTION "Text 3", ROMX, BANK[$71]
+SECTION "Text 3", ROMX[$4000], BANK[$71]
 INCLUDE "text/common_4.asm"
 INCLUDE "text/common_5.asm"

--- a/wram.asm
+++ b/wram.asm
@@ -2,7 +2,7 @@ INCLUDE "includes.asm"
 INCLUDE "macros/wram.asm"
 INCLUDE "vram.asm"
 
-SECTION "Stack", WRAM0
+SECTION "Stack", WRAM0[$C000]
 wc000::
 StackBottom::
 	ds $100 - 1
@@ -11,7 +11,7 @@ StackTop::
 	ds 1
 
 
-SECTION "Audio", WRAM0
+SECTION "Audio", WRAM0[$C100]
 wMusic::
 MusicPlaying:: ; c100
 ; nonzero if playing
@@ -134,7 +134,7 @@ wMapMusic:: ; c2c0
 wDontPlayMapMusicOnReload:: ds 1
 wMusicEnd::
 
-SECTION "WRAM", WRAM0
+SECTION "WRAM", WRAM0[$C2C2]
 
 wLZAddress:: dw ; c2c2
 wLZBank::    db ; c2c4
@@ -330,7 +330,7 @@ Sprites:: ; c400
 SpritesEnd::
 
 
-SECTION "Tilemap", WRAM0
+SECTION "Tilemap", WRAM0[$C4A0]
 
 TileMap:: ; c4a0
 ; 20x18 grid of 8x8 tiles
@@ -338,7 +338,7 @@ TileMap:: ; c4a0
 TileMapEnd::
 
 
-SECTION "Battle", WRAM0
+SECTION "Battle", WRAM0[$C608]
 wc608::
 wOddEgg:: party_struct OddEgg
 wOddEggName:: ds PKMN_NAME_LENGTH
@@ -1111,7 +1111,7 @@ wccb8:: ds 1
 wccb9:: ds 1
 wccba:: ds 102
 
-SECTION "Video", WRAM0
+SECTION "Video", WRAM0[$CD20]
 CreditsPos::
 BGMapBuffer::
 wMobileMonSpeciesPointerBuffer:: dw
@@ -1514,7 +1514,7 @@ wDaysSince:: ds 1
 wRAM0End:: ; cfd8
 
 
-SECTION "WRAM 1", WRAMX, BANK [1]
+SECTION "WRAM 1", WRAMX[$D000], BANK[1]
 
 wd000:: ds 1
 DefaultSpawnpoint::
@@ -2193,7 +2193,7 @@ TimeOfDay:: ; d269
 
 	ds 1
 
-SECTION "Enemy Party", WRAMX, BANK [1]
+SECTION "Enemy Party", WRAMX[$D26B], BANK [1]
 wPokedexShowPointerAddr::
 wd26b:: ds 1
 wd26c:: ds 1
@@ -2808,7 +2808,7 @@ wScreenSave:: ds 6 * 5
 wMapDataEnd::
 
 
-SECTION "Party", WRAMX, BANK [1]
+SECTION "Party", WRAMX[$DCD7], BANK [1]
 
 wPokemonData::
 
@@ -2907,7 +2907,7 @@ wMagikarpRecordHoldersName:: ds NAME_LENGTH
 wPokemonDataEnd::
 wGameDataEnd::
 
-SECTION "Pic Animations", WRAMX, BANK [2]
+SECTION "Pic Animations", WRAMX[$D000], BANK [2]
 
 TempTileMap::
 ; 20x18 grid of 8x8 tiles
@@ -2946,7 +2946,7 @@ wPokeAnimBitmaskBuffer:: ds 7
 wPokeAnimStructEnd::
 
 
-SECTION "Battle Tower", WRAMX, BANK [3]
+SECTION "Battle Tower", WRAMX[$D000], BANK [3]
 
 w3_d000:: ds 1 ; d000
 w3_d001:: ds 1
@@ -2997,7 +2997,7 @@ w3_dd68:: ds SCREEN_WIDTH * SCREEN_HEIGHT
 w3_dfec:: ds $10
 w3_dffc:: ds 4
 
-SECTION "GBC Video", WRAMX, BANK [5]
+SECTION "GBC Video", WRAMX[$D000], BANK [5]
 
 ; 8 4-color palettes
 UnknBGPals:: ds 8 palettes ; d000
@@ -3098,7 +3098,7 @@ w5_MobileOpponentBattleStartMessage:: ds $c ; dc26
 w5_MobileOpponentBattleWinMessage:: ds $c ; dc32
 w5_MobileOpponentBattleLossMessage:: ds $c ; dc3e
 
-SECTION "WRAM 6", WRAMX, BANK [6]
+SECTION "WRAM 6", WRAMX[$D000], BANK [6]
 
 wDecompressScratch::
 wScratchTileMap::
@@ -3109,6 +3109,6 @@ w6_d800::
 
 INCLUDE "sram.asm"
 
-SECTION "WRAM 7", WRAMX, BANK [7]
+SECTION "WRAM 7", WRAMX[$D000], BANK [7]
 wWindowStack:: ds $1000 - 1
 wWindowStackBottom:: ds 1


### PR DESCRIPTION
Fixes #356. Hope this helps to recover from the recent changes to rgbds.

This guarantees that each section will be in the same place as the original game, without the risk of different linker versions repositioning sections.

This works with the current version of rgbds (`947d767c6487bbb131fa038ecc287ceb4c620fc5`), and will produce the correct v1.0 ROM (md5: `9f2922b235a5eeb78d65594e82ef5dde`), and the correct v1.1 checksum (`301899b8087289a6436b0a241fbbb474`) with this version.

As I've endeavoured to remove all 'floating' sections, there may be some unnecessary fixed sections (e.g. if there's only one section in a bank) – feel free to fix these if necessary.