### PR TITLE
Replace ‘jp [hl]’ with ‘jp hl’

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -229,7 +229,7 @@ UpdateChannels: ; e8125
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .ChannelFnPtrs:
 	dw .Channel1
@@ -1389,7 +1389,7 @@ ParseMusicCommand: ; e870f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; e8720
 

--- a/battle/ai/items.asm
+++ b/battle/ai/items.asm
@@ -211,7 +211,7 @@ AI_TryItem: ; 38105
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 .callback
 	pop de
 	pop hl

--- a/battle/ai/redundant.asm
+++ b/battle/ai/redundant.asm
@@ -11,7 +11,7 @@ AI_Redundant: ; 2c41a
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Moves: ; 2c42c
 	dbw EFFECT_DREAM_EATER,  .DreamEater

--- a/battle/anim_commands.asm
+++ b/battle/anim_commands.asm
@@ -347,7 +347,7 @@ RunBattleAnimCommand: ; cc25f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; cc2a4
 
 

--- a/battle/bg_effects.asm
+++ b/battle/bg_effects.asm
@@ -75,7 +75,7 @@ DoBattleBGEffectFunction: ; c804a (32:404a)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleBGEffects: ; c805a (32:405a)
 	dw BattleBGEffect_End
@@ -161,7 +161,7 @@ BattleBGEffects_AnonJumptable: ; c80d7 (32:40d7)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleBGEffects_IncrementJumptable: ; c80e5 (32:40e5)
 	ld hl, BG_EFFECT_STRUCT_JT_INDEX
@@ -2059,7 +2059,7 @@ BattleBGEffect_1c: ; c8b00 (32:4b00)
 .cgb
 	ld de, .Jumptable
 	call BatttleBGEffects_GetNamedJumptablePointer
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw .cgb_zero
@@ -2421,7 +2421,7 @@ BGEffect_RapidCyclePals: ; c8d77 (32:4d77)
 	ld de, .Jumptable_DMG
 	call BatttleBGEffects_GetNamedJumptablePointer
 	pop de
-	jp [hl]
+	jp hl
 
 .Jumptable_DMG:
 	dw .zero_dmg
@@ -2484,7 +2484,7 @@ BGEffect_RapidCyclePals: ; c8d77 (32:4d77)
 	ld de, .Jumptable_CGB
 	call BatttleBGEffects_GetNamedJumptablePointer
 	pop de
-	jp [hl]
+	jp hl
 
 .Jumptable_CGB: ; c8ddd (32:4ddd)
 	dw .zero_cgb

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -4331,7 +4331,7 @@ SpikesDamage: ; 3dc23
 	jp WaitBGMap
 
 .hl
-	jp [hl]
+	jp hl
 ; 3dc5b
 
 PursuitSwitch: ; 3dc5b

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -113,7 +113,7 @@ DoMove: ; 3402c
 	jr .ReadMoveEffectCommand
 
 .DoMoveEffectCommand:
-	jp [hl]
+	jp hl
 
 ; 34084
 

--- a/battle/objects/functions.asm
+++ b/battle/objects/functions.asm
@@ -9,7 +9,7 @@ DoBattleAnimFrame: ; ccfbe
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; ccfce
 
 .Jumptable:
@@ -4085,7 +4085,7 @@ BattleAnim_AnonJumptable: ; ce71e (33:671e)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleAnim_IncAnonJumptableIndex: ; ce72c (33:672c)
 	ld hl, BATTLEANIMSTRUCT_ANON_JT_INDEX

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -39,7 +39,7 @@ _DepositPKMN: ; e2391 (38:6391)
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 
 .Jumptable: ; e23df (38:63df)
 
@@ -147,7 +147,7 @@ _DepositPKMN: ; e2391 (38:6391)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BillsPCDepositJumptable: ; e24a1 (38:64a1)
 
@@ -306,7 +306,7 @@ _WithdrawPKMN: ; e2583 (38:6583)
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 
 .Jumptable: ; e25d2 (38:65d2)
 
@@ -415,7 +415,7 @@ BillsPC_Withdraw: ; e2675 (38:6675)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .dw ; e2699 (38:6699) #mark
 	dw .withdraw ; Withdraw
@@ -556,7 +556,7 @@ _MovePKMNWithoutMail: ; e2759
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 ; e27ac
 
 .Jumptable: ; e27ac
@@ -678,7 +678,7 @@ _MovePKMNWithoutMail: ; e2759
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e2881
 
 .Jumptable2: ; e2881
@@ -2014,7 +2014,7 @@ MovePKMNWitoutMail_InsertMon: ; e31e7
 	ld l, a
 	ld de, .dw_return
 	push de
-	jp [hl]
+	jp hl
 ; e322a
 
 .dw_return ; e322a

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -76,7 +76,7 @@ _CardFlip: ; e00ee (38:40ee)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e01a0 (38:41a0)
 
 .Jumptable: ; e01a0
@@ -652,7 +652,7 @@ CardFlip_BlankDiscardedCardSlot: ; e0534
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e0553
 
 .Jumptable: ; e0553
@@ -829,7 +829,7 @@ CardFlip_CheckWinCondition: ; e0637
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e0643
 
 .Jumptable: ; e0643

--- a/engine/credits.asm
+++ b/engine/credits.asm
@@ -263,7 +263,7 @@ Credits_Jumptable: ; 109926
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 109937
 
 

--- a/engine/crystal_intro.asm
+++ b/engine/crystal_intro.asm
@@ -125,7 +125,7 @@ PlaceGameFreakPresents: ; e4670
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e467f
 
 .dw ; e467f
@@ -222,7 +222,7 @@ GameFreakLogoJumper: ; e46ed (39:46ed)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 GameFreakLogoScenes: ; e46fd (39:46fd)
 	dw GameFreakLogoScene1
@@ -438,7 +438,7 @@ IntroSceneJumper: ; e490f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e491e
 
 IntroScenes: ; e491e (39:491e)

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -305,7 +305,7 @@ Function81a74: ; 81a74
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .asm_81a9a
 	call Function81eca
@@ -611,7 +611,7 @@ Function81cc2: ; 81cc2
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .asm_81cdf
 	ld a, $4
@@ -1353,7 +1353,7 @@ Function822f0: ; 822f0
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 82301
 
 .dw ; 82301

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -609,7 +609,7 @@ TryObjectEvent: ; 969b5
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .nope_bugged
 	; pop bc

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -1064,7 +1064,7 @@ StartTitleScreen: ; 6219
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 626a
 
 .dw
@@ -1117,7 +1117,7 @@ TitleScreenScene: ; 62a3
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 62af
 
 .scenes

--- a/engine/map_objects.asm
+++ b/engine/map_objects.asm
@@ -1955,7 +1955,7 @@ JumpMovementPointer: ; 505e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 5065
 
 ContinueReadingMovement: ; 5065

--- a/engine/mon_icons.asm
+++ b/engine/mon_icons.asm
@@ -33,7 +33,7 @@ LoadMenuMonIcon: ; 8e83f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8e854
 
 

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -70,7 +70,7 @@ NamingScreen: ; 116c1
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1172e
 
@@ -405,7 +405,7 @@ NamingScreenJoypadLoop: ; 11915
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 11977
 
@@ -1166,7 +1166,7 @@ INCBIN "gfx/icon/mail2.2bpp"
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 12017 (4:6017)
 	dw .init_blinking_cursor

--- a/engine/options_menu.asm
+++ b/engine/options_menu.asm
@@ -90,7 +90,7 @@ GetOptionPointer: ; e42d6
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl] ; jump to the code of the current highlighted item
+	jp hl ; jump to the code of the current highlighted item
 ; e42e5
 
 .Pointers:

--- a/engine/pack.asm
+++ b/engine/pack.asm
@@ -23,7 +23,7 @@ Pack: ; 10000
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10030
 
@@ -144,7 +144,7 @@ Pack: ; 10000
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10124 (4:4124)
 .MenuDataHeader1: ; 0x10124
@@ -306,7 +306,7 @@ Pack: ; 10000
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10249 (4:4249)
 MenuDataHeader_UsableKeyItem: ; 0x10249
@@ -689,7 +689,7 @@ BattlePack: ; 10493
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 104c3
 
@@ -846,7 +846,7 @@ TMHMSubmenu: ; 105dc (4:45dc)
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10601 (4:4601)
 .UsableMenuDataHeader: ; 0x10601
@@ -997,7 +997,7 @@ DepositSellPack: ; 106be
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 106d1
 
@@ -1144,7 +1144,7 @@ TutorialPack: ; 107bb
 	ld a, [wJumptableIndex]
 	ld hl, .dw
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 107e1
 

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -182,7 +182,7 @@ Pokedex_RunJumptable: ; 4010b
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 
 .Jumptable: ; 40115 (10:4115)
@@ -366,7 +366,7 @@ Pokedex_UpdateDexEntryScreen: ; 40258 (10:4258)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, DexEntryScreen_MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .return_to_prev_screen
 	ld a, [LastVolume]
@@ -545,7 +545,7 @@ Pokedex_UpdateOptionScreen: ; 403be (10:43be)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, .MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .return_to_main_screen
 	call Pokedex_BlackOutBG
@@ -647,7 +647,7 @@ Pokedex_UpdateSearchScreen: ; 40471 (10:4471)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, .MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .cancel
 	call Pokedex_BlackOutBG
@@ -1621,7 +1621,7 @@ Pokedex_OrderMonsByMode: ; 40bdc
 	ld a, [wCurrentDexMode]
 	ld hl, .Jumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 
 .Jumptable: ; 40bf0 (10:4bf0)

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -235,7 +235,7 @@ InitPokegearTilemap: ; 90da8 (24:4da8)
 	ld l, a
 	ld de, .return_from_jumptable
 	push de
-	jp [hl]
+	jp hl
 
 .return_from_jumptable
 	call Pokegear_FinishTilemap
@@ -431,7 +431,7 @@ PokegearJumptable: ; 90f04 (24:4f04)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 90f13 (24:4f13)
 	dw PokegearClock_Init
@@ -1217,7 +1217,7 @@ PokegearPhoneContactSubmenu: ; 91342 (24:5342)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Cancel: ; 913f1
 	ld hl, PokegearText_WhomToCall
@@ -1484,7 +1484,7 @@ UpdateRadioStation: ; 9166f (24:566f)
 	ld l, a
 	ld de, .returnafterstation
 	push de
-	jp [hl]
+	jp hl
 
 .returnafterstation
 	ld a, [wPokegearRadioChannelBank]
@@ -2043,7 +2043,7 @@ PlayRadio: ; 91a53
 	ld l, a
 	ld de, .jump_return
 	push de
-	jp [hl]
+	jp hl
 
 .jump_return
 	push de

--- a/engine/printer/serial.asm
+++ b/engine/printer/serial.asm
@@ -26,7 +26,7 @@ PrinterJumptableIteration: ; 84022
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 84031
 
 
@@ -468,7 +468,7 @@ _PrinterReceive:: ; 842db
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 842ea
 
 

--- a/engine/radio.asm
+++ b/engine/radio.asm
@@ -25,7 +25,7 @@ PlayRadioShow:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 RadioJumptable:
 	dw OaksPkmnTalk1  ; $00

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -796,7 +796,7 @@ Function92bd4: ; 92bd4 (24:6bd4)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 92be4 (24:6be4)
 
@@ -1311,7 +1311,7 @@ Slots_CheckMatchedFirstTwoReels: ; 92e94
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld a, [wFirstTwoReelsMatching]
@@ -1422,7 +1422,7 @@ Slots_CheckMatchedAllThreeReels: ; 92f1d
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld a, [wSlotMatched]
@@ -1855,7 +1855,7 @@ SlotPayoutText: ; 93158 (24:7158)
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld hl, .Text_PrintPayout
@@ -1958,7 +1958,7 @@ SlotMachine_AnimateGolem: ; 9321d (24:721d)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 9322d (24:722d)
 
@@ -2059,7 +2059,7 @@ Slots_AnimateChansey: ; 932ac (24:72ac)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 932bc (24:72bc)
 

--- a/engine/sprite_anims.asm
+++ b/engine/sprite_anims.asm
@@ -9,7 +9,7 @@ DoAnimFrame: ; 8d24b
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8d25b
 
 .Jumptable: ; 8d25b (23:525b)
@@ -134,7 +134,7 @@ DoAnimFrame: ; 8d24b
 
 .four ; 8d302 (23:5302)
 	call .AnonymousJumptable
-	jp [hl]
+	jp hl
 ; 8d306 (23:5306)
 
 ; Anonymous dw (see .AnonymousJumptable)
@@ -418,7 +418,7 @@ DoAnimFrame: ; 8d24b
 
 .sixteen ; 8d483 (23:5483)
 	call .AnonymousJumptable
-	jp [hl]
+	jp hl
 ; 8d487 (23:5487)
 
 ; Anonymous dw (see .AnonymousJumptable)

--- a/engine/startmenu.asm
+++ b/engine/startmenu.asm
@@ -55,7 +55,7 @@ StartMenu:: ; 125cd
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .MenuReturns:
 	dw .Reopen
@@ -227,7 +227,7 @@ StartMenu:: ; 125cd
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 127ef
 
 .MenuString: ; 127ef
@@ -701,7 +701,7 @@ PokemonActionSubmenu: ; 12a88
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .nothing
 	ld a, 0

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -250,7 +250,7 @@ GetTimePalette: ; 8c117
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8c126
 
 .TimePalettes:

--- a/engine/trade/animation.asm
+++ b/engine/trade/animation.asm
@@ -232,7 +232,7 @@ DoTradeAnimation: ; 29082
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 290af
 
 .JumpTable: ; 290af
@@ -549,7 +549,7 @@ TradeAnim_TubeAnimJumptable: ; 29281
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 2928f
 
 .Jumptable: ; 2928f
@@ -1173,7 +1173,7 @@ TradeAnim_AnimateTrademonInTube: ; 29676 (a:5676)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 29686
 
 .Jumptable: ; 29686 (a:5686)

--- a/engine/unown_puzzle.asm
+++ b/engine/unown_puzzle.asm
@@ -183,7 +183,7 @@ UnownPuzzleJumptable: ; e12ca
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e12d9
 
 .Jumptable: ; e12d9

--- a/event/field_moves.asm
+++ b/event/field_moves.asm
@@ -169,7 +169,7 @@ OWCutJumptable: ; 8ca0c
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8ca1b
 
 

--- a/event/magnet_train.asm
+++ b/event/magnet_train.asm
@@ -299,7 +299,7 @@ MagnetTrain_Jumptable: ; 8cdf7
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8ce06
 
 .Jumptable: ; 8ce06

--- a/event/mom.asm
+++ b/event/mom.asm
@@ -28,7 +28,7 @@ Special_BankOfMom: ; 16218
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 16242
 
 .dw ; 16242

--- a/gfx/mail.asm
+++ b/gfx/mail.asm
@@ -107,7 +107,7 @@ ReadAnyMail: ; b9237
 	ld de, .done
 	pop bc
 	push de
-	jp [hl]
+	jp hl
 .done
 	ret
 ; b92f8

--- a/home.asm
+++ b/home.asm
@@ -152,7 +152,7 @@ INCLUDE "home/sram.asm"
 ; Register aliases
 
 _hl_:: ; 2fec
-	jp [hl]
+	jp hl
 ; 2fed
 
 _de_:: ; 2fed

--- a/home/farcall.asm
+++ b/home/farcall.asm
@@ -50,5 +50,5 @@ ReturnFarCall:: ; 2d6e
 ; 2d82
 
 FarJump_hl:: ; 2d82
-	jp [hl]
+	jp hl
 ; 2d83

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -337,7 +337,7 @@ RunMenuItemPrintingFunction:: ; 1eda
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 1eff
 
 InitMenuCursorAndButtonPermissions:: ; 1eff
@@ -470,7 +470,7 @@ MenuJumptable:: ; 1fa7
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 1fb1
 
 GetMenuDataPointerTableEntry:: ; 1fb1

--- a/home/text.asm
+++ b/home/text.asm
@@ -943,7 +943,7 @@ Text_START_ASM:: ; 14c9
 
 	bit 7, h
 	jr nz, .not_rom
-	jp [hl]
+	jp hl
 
 .not_rom
 	ld a, "@"

--- a/items/item_effects.asm
+++ b/items/item_effects.asm
@@ -263,7 +263,7 @@ ParkBall: ; e8a2
 	ld l, a
 	ld de, .skip_or_return_from_ball_fn
 	push de
-	jp [hl]
+	jp hl
 
 .skip_or_return_from_ball_fn
 	ld a, [CurItem]

--- a/macros.asm
+++ b/macros.asm
@@ -281,7 +281,7 @@ jumptable: MACRO
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 endm
 
 maskbits: macro

--- a/main.asm
+++ b/main.asm
@@ -3214,7 +3214,7 @@ CatchTutorial:: ; 4e554
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .dw ; 4e564 (13:6564)
 	dw .DudeTutorial

--- a/misc/battle_tower_5c.asm
+++ b/misc/battle_tower_5c.asm
@@ -222,7 +222,7 @@ _BattleTowerBattle: ; 17022c
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 170249
 
 .dw ; 170249
@@ -692,7 +692,7 @@ Function1704e1: ; 1704e1
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 17051f
 
 .dw ; 17051f
@@ -947,7 +947,7 @@ BattleTowerAction: ; 170687
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 170696
 
 
@@ -1443,7 +1443,7 @@ Function1709bb: ; 1709bb (5c:49bb) BattleTowerAction $10
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .invalid
 	ld a, $5

--- a/misc/fixed_words.asm
+++ b/misc/fixed_words.asm
@@ -2516,7 +2516,7 @@ AnimateEZChatCursor: ; 11d0b6 (47:50b6)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw .zero

--- a/misc/gfx_41.asm
+++ b/misc/gfx_41.asm
@@ -240,7 +240,7 @@ CallInSafeGFXMode: ; 104177
 ; 10419c
 
 ._hl_ ; 10419c
-	jp [hl]
+	jp hl
 ; 10419d
 
 

--- a/misc/mobile_42.asm
+++ b/misc/mobile_42.asm
@@ -377,7 +377,7 @@ MobileTradeAnim_JumptableLoop: ; 10824b
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 10828a
 
 .Jumptable: ; 10828a

--- a/misc/mobile_45.asm
+++ b/misc/mobile_45.asm
@@ -146,7 +146,7 @@ Function114243:: ; 114243
 	ld h, [hl]
 	ld l, a
 	pop de
-	jp [hl]
+	jp hl
 
 ; 11425c
 
@@ -5397,7 +5397,7 @@ Function11659d: ; 11659d
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1165af
 
@@ -6931,7 +6931,7 @@ Function117719: ; 117719 (45:7719)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_117728: ; 117728 (45:7728)
 	dw Function117738
@@ -7419,7 +7419,7 @@ Function117ae9: ; 0x117ae9
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 0x117af8
 	dw Function117b06

--- a/misc/mobile_45_sprite_engine.asm
+++ b/misc/mobile_45_sprite_engine.asm
@@ -380,7 +380,7 @@ Function1161b8: ; 1161b8
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1161c7
 

--- a/misc/mobile_46.asm
+++ b/misc/mobile_46.asm
@@ -5874,7 +5874,7 @@ Function11ad6e: ; 11ad6e
 	ld a, [wJumptableIndex]
 	ld hl, Jumptable_11ad78
 	call Function11b239
-	jp [hl]
+	jp hl
 ; 11ad78
 
 Jumptable_11ad78: ; 11ad78

--- a/misc/mobile_5c.asm
+++ b/misc/mobile_5c.asm
@@ -373,7 +373,7 @@ Function171a36: ; 171a36 (5c:5a36)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_171a45: ; 171a45 (5c:5a45)
 	dw Function171a95

--- a/misc/mobile_5f.asm
+++ b/misc/mobile_5f.asm
@@ -1146,7 +1146,7 @@ Function17d711:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 asm_17d721
 	call Function17e5af
@@ -3746,7 +3746,7 @@ Function17f047: ; 17f047
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .finished
 	scf

--- a/predef/cgb.asm
+++ b/predef/cgb.asm
@@ -25,7 +25,7 @@ Predef_LoadSGBLayoutCGB: ; 8d59
 	ld l, a
 	ld de, .ReturnFromJumpTable
 	push de
-	jp [hl]
+	jp hl
 ; 8d79
 
 .ReturnFromJumpTable: ; 8d79
@@ -491,7 +491,7 @@ _CGB07: ; 9122
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 912d
 
 Jumptable_912d: ; 912d

--- a/predef/crystal.asm
+++ b/predef/crystal.asm
@@ -17,7 +17,7 @@ GetMysteryGift_MobileAdapterLayout: ; 4930f (mobile)
 	ld l, a
 	ld de, .done
 	push de
-	jp [hl]
+	jp hl
 .done
 	ret
 ; 49330 (12:5330)

--- a/predef/sgb.asm
+++ b/predef/sgb.asm
@@ -20,7 +20,7 @@ Predef_LoadSGBLayout: ; 864c
 	ld l, a
 	ld de, .Finish
 	push de
-	jp [hl]
+	jp hl
 ; 866f
 
 .Jumptable: ; 866f

--- a/rst.asm
+++ b/rst.asm
@@ -28,7 +28,7 @@ SECTION "rst28",ROM0[JumpTable]
 	ld h, [hl]
 	ld l, a
 	pop de
-	jp [hl]
+	jp hl
 
 ; SECTION "rst30",ROM0[$30]
 ; rst30 is midst rst28

--- a/tilesets/animations.asm
+++ b/tilesets/animations.asm
@@ -32,7 +32,7 @@ _AnimateTileset:: ; fc000
 	ld h, [hl]
 	ld l, a
 
-	jp [hl]
+	jp hl
 ; fc01b
 
 Tileset00Anim: ; 0xfc01b

--- a/trainers/read_party.asm
+++ b/trainers/read_party.asm
@@ -68,7 +68,7 @@ ReadTrainerParty: ; 39771
 	ld l, a
 	ld bc, .done
 	push bc
-	jp [hl]
+	jp hl
 
 .done
 	jp ComputeTrainerReward


### PR DESCRIPTION
The former is arguably misleading (as you don’t access the memory location in `hl` to retrieve the jump location), and is consequently deprecated in newer versions of rgbds.

This fix silences these deprecation warnings. Also, whilst the warnings are new, the instruction isn't; it's recognised by rgbds v0.2.5 (and below, I think).