### PR TITLE
Missing a dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ If you run into trouble, ask on irc ([**freenode#pret**](https://kiwiirc.com/cli
 # Linux
 
 ```bash
-sudo apt-get install make gcc bison git
+sudo apt-get install make gcc bison git libpng-dev
 
 git clone https://github.com/rednex/rgbds
 cd rgbds


### PR DESCRIPTION
Without libpng-dev, sudo make install causes:
In file included from src/gfx/gb.c:20:0:
include/gfx/main.h:20:17: fatal error: png.h: No such file or directory
 #include <png.h>
                 ^
compilation terminated.
Makefile:90: recipe for target 'src/gfx/gb.o' failed
make: *** [src/gfx/gb.o] Error 1