### PR TITLE
Fix unused Constant for Happiness

### DIFF
--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -119,7 +119,7 @@ EvolveAfterBattle_MasterLoop
 
 .happiness
 	ld a, [TempMonHappiness]
-	cp 220
+	cp HAPPINESS_TO_EVOLVE
 	jp c, .dont_evolve_2
 
 	call IsMonHoldingEverstone


### PR DESCRIPTION
The HAPPINESS_TO_EVOLVE constant is what's supposed to be used to give the number for when a Pokemon should evolve by happiness. The constant was not put in place so it is never used, instead the original 220 was put.