### PR TITLE
Correct constant to remove a bug

### DIFF
--- a/wram.asm
+++ b/wram.asm
@@ -379,9 +379,7 @@ wEnemyTrainerItem1:: ds 1 ; c650
 wEnemyTrainerItem2:: ds 1 ; c651
 wEnemyTrainerBaseReward:: ds 1 ; c652
 wEnemyTrainerAIFlags:: ds 3 ; c653
-OTClassName:: ds NAME_LENGTH ; c656
-
-	ds 2
+OTClassName:: ds TRAINER_CLASS_NAME_LENGTH ; c656
 
 CurOTMon:: ; c663
 	ds 1


### PR DESCRIPTION
If the ds 2 that is behind OTClassName is deleted or decreased, the game will continue to display characters for trainer classes that are 12 or 13 characters long, including the @ terminator. The correct constant has been put in place and the ds 2 removed, but no one would have known it was wrong if they hadn't have removed the ds 2.