### PR TITLE
Fix hardcoded BaseData offsets

### DIFF
--- a/battle/core.asm
+++ b/battle/core.asm
@@ -3484,7 +3484,7 @@ IsThePlayerPkmnTypesEffectiveAgainstOTPkmn: ; 3d618
 	add hl, bc
 	ld a, [hl]
 	dec a
-	ld hl, BaseData + 7 ; type
+	ld hl, BaseData + BaseType - CurBaseData
 	ld bc, BaseData1 - BaseData0
 	call AddNTimes
 	ld de, EnemyMonType

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -737,7 +737,7 @@ Link_PrepPartyData_Gen1: ; 28499
 .skip_steel
 	push bc
 	dec a
-	ld hl, BaseData + 7 ; type
+	ld hl, BaseData + BaseType - CurBaseData
 	ld bc, BaseData1 - BaseData0
 	call AddNTimes
 	ld bc, 2

--- a/home.asm
+++ b/home.asm
@@ -1888,7 +1888,7 @@ Function392d:: ; 392d
 	dec a
 	ld b, 0
 	add hl, bc
-	ld hl, BaseData + 0
+	ld hl, BaseData + BaseDexNo - CurBaseData
 	ld bc, BaseData1 - BaseData0
 	call AddNTimes
 	ld a, BANK(BaseData)


### PR DESCRIPTION
A few BaseData offsets were hardcoded. Now they're using the structure
as defined in wram.asm, like other pieces of code are.