### PR TITLE
Made Get*Name functions use wNamedObjectIndexBuffer

### DIFF
--- a/battle/ai/items.asm
+++ b/battle/ai/items.asm
@@ -866,7 +866,7 @@ PrintText_UsedItemOn_AND_AIUpdateHUD: ; 38568
 
 PrintText_UsedItemOn: ; 38571
 	ld a, [CurEnemyItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, StringBuffer1
 	ld de, wMonOrItemNameBuffer

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -1270,7 +1270,7 @@ HandleWrap: ; 3c874
 	ret nz
 
 	ld a, [de]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [FXAnimID], a
 	call GetMoveName
 	dec [hl]
@@ -1325,7 +1325,7 @@ HandleLeftovers: ; 3c8eb
 
 	callfar GetUserItem
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld a, b
 	cp HELD_LEFTOVERS

--- a/data/items/item_descriptions.asm
+++ b/data/items/item_descriptions.asm
@@ -9,7 +9,7 @@ PrintItemDescription: ; 0x1c8955
 	push de
 	farcall GetTMHMItemMove
 	pop hl
-	ld a, [wd265]
+	ld a, [wCurTMHM]
 	ld [CurSpecies], a
 	predef PrintMoveDesc
 	ret

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -1112,7 +1112,7 @@ PCMonInfo: ; e2ac6 (38:6ac6)
 	xor a
 	ld [wBillsPC_MonHasMail], a
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	cp EGG
 	ret z
 
@@ -1948,7 +1948,7 @@ ReleasePKMN_ByePKMN: ; e3180 (38:7180)
 .skip_cry
 
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	hlcoord 1, 16
 	ld de, PCString_ReleasedPKMN

--- a/engine/breeding.asm
+++ b/engine/breeding.asm
@@ -256,7 +256,7 @@ HatchEggs: ; 16f70 (5:6f70)
 	ld a, [CurPartySpecies]
 	dec de
 	ld [de], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [CurSpecies], a
 	call GetPokemonName
 	xor a

--- a/engine/caught_data.asm
+++ b/engine/caught_data.asm
@@ -38,7 +38,7 @@ CheckPartyFullAfterContest: ; 4d9e5
 	ld hl, PlayerName
 	call CopyBytes
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	ld de, wMonOrItemNameBuffer
@@ -105,7 +105,7 @@ CheckPartyFullAfterContest: ; 4d9e5
 	call CopyBytes
 	callfar InsertPokemonIntoBox
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call GiveANickname_YesNo
 	ld hl, StringBuffer1

--- a/engine/decorations.asm
+++ b/engine/decorations.asm
@@ -641,7 +641,7 @@ GetDecoName: ; 26c72
 
 .getpokename ; 26cc0
 	push bc
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop bc
 	jr .copy

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -241,7 +241,7 @@ EvolveAfterBattle_MasterLoop
 	ld [CurSpecies], a
 	ld [TempMonSpecies], a
 	ld [wEvolutionNewSpecies], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	push hl
@@ -355,7 +355,7 @@ UpdateSpeciesNameIfNotNicknamed: ; 42414
 	ld a, [CurSpecies]
 	push af
 	ld a, [BaseDexNo]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop af
 	ld [CurSpecies], a
@@ -376,7 +376,7 @@ UpdateSpeciesNameIfNotNicknamed: ; 42414
 	call AddNTimes
 	push hl
 	ld a, [CurSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	pop de
@@ -481,7 +481,7 @@ LearnLevelMoves: ; 42487
 .learn
 	ld a, d
 	ld [wPutativeTMHMMove], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	predef LearnMove

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -1,6 +1,6 @@
 _DoItemEffect:: ; e722
 	ld a, [CurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	call CopyName1
 	ld a, 1
@@ -589,7 +589,7 @@ ParkBall: ; e8a2
 	call PrintText
 
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	call YesNoBox
@@ -649,7 +649,7 @@ ParkBall: ; e8a2
 	call PrintText
 
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	call YesNoBox
@@ -2559,7 +2559,7 @@ Mysteryberry: ; f5bf
 
 	push hl
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	pop hl

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -1488,7 +1488,7 @@ Function28926: ; 28926
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	hlcoord 0, 12
 	ld b, 4
@@ -1657,7 +1657,7 @@ LinkTrade: ; 28b87
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	ld de, wd004
@@ -1669,7 +1669,7 @@ LinkTrade: ; 28b87
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, UnknownText_0x28eb8
 	bccoord 1, 14
@@ -2093,14 +2093,14 @@ Special_CheckTimeCapsuleCompatibility: ; 29bfb
 	jr .done
 
 .mon_too_new
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld a, $1
 	jr .done
 
 .move_too_new
 	push bc
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	pop bc
@@ -2126,7 +2126,7 @@ Function29c67: ; 29c67
 	ld hl, PartyCount
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ret
 ; 29c7b

--- a/engine/menu_2.asm
+++ b/engine/menu_2.asm
@@ -172,7 +172,7 @@ StartMenu_PrintBugContestStatus: ; 24be7
 	and a
 	ld de, .None
 	jr z, .no_contest_mon
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 .no_contest_mon

--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -51,7 +51,7 @@ TryAddMonToParty: ; d88c
 	and a
 	jr nz, .skipnickname
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, PartyMonNicknames
 	ld a, [hMoveMon]
@@ -938,7 +938,7 @@ SentPkmnIntoBox: ; de6e
 	call CopyBytes
 
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	ld de, sBoxMonNicknames
@@ -1647,7 +1647,7 @@ GivePoke:: ; e277
 
 .done
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [TempEnemyMonSpecies], a
 	call GetPokemonName
 	ld hl, StringBuffer1

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -92,7 +92,7 @@ NamingScreen: ; 116c1
 	ld e, $1
 	rst FarCall ;  ; indirect jump to LoadMenuMonIcon (8e83f (23:683f))
 	ld a, [CurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	hlcoord 5, 2
 	call PlaceString

--- a/engine/npctrade.asm
+++ b/engine/npctrade.asm
@@ -319,7 +319,7 @@ Trade_GetAttributeOfLastPartymon: ; fcdde
 
 GetTradeMonName: ; fcde8
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetBasePokemonName
 	ld hl, StringBuffer1
 	pop de

--- a/engine/print_party.asm
+++ b/engine/print_party.asm
@@ -303,7 +303,7 @@ Function1dc51a: ; 1dc51a
 	and a
 	jr z, .no_move
 
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	jr .got_string
 

--- a/engine/printer.asm
+++ b/engine/printer.asm
@@ -751,7 +751,7 @@ Printer_PrintBoxListSegment: ; 848e7 (21:48e7)
 	ld a, [de]
 	cp $ff
 	jp z, .finish
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [CurPartySpecies], a
 
 	push bc

--- a/engine/scripting.asm
+++ b/engine/scripting.asm
@@ -661,7 +661,7 @@ GetPocketName:
 
 CurItemName:
 	ld a, [CurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ret
 
@@ -1993,7 +1993,7 @@ Script_pokenamemem:
 	jr nz, .gotit
 	ld a, [ScriptVar]
 .gotit
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld de, StringBuffer1
 
@@ -2022,7 +2022,7 @@ Script_itemtotext:
 	jr nz, .ok
 	ld a, [ScriptVar]
 .ok
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld de, StringBuffer1
 	jr ConvertMemToText

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -214,7 +214,7 @@ Special_GameCornerPrizeMonCheckDex: ; c230
 	call SetSeenAndCaughtMon
 	call FadeToMenu
 	ld a, [ScriptVar]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	farcall NewPokedexEntry
 	call ExitAllMenus
 	ret
@@ -343,7 +343,7 @@ Special_GetMysteryGiftItem: ; c309
 	ld [sMysteryGiftItem], a
 	call CloseSRAM
 	ld a, [CurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, .ReceiveItemText
 	call PrintText

--- a/engine/start_menu.asm
+++ b/engine/start_menu.asm
@@ -670,7 +670,7 @@ CantUseItemText: ; 12a67
 
 PartyMonItemName: ; 12a6c
 	ld a, [CurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	call CopyName1
 	ret
@@ -889,17 +889,17 @@ TryGiveItemToPartymon: ; 12bd9
 	ret
 
 .already_holding_item
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, SwitchAlreadyHoldingText
 	call StartMenuYesNo
 	jr c, .abort
 
 	call GiveItemToPokemon
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	push af
 	ld a, [CurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	pop af
 	ld [CurItem], a
 	call ReceiveItemFromPokemon
@@ -907,13 +907,13 @@ TryGiveItemToPartymon: ; 12bd9
 
 	ld hl, TookAndMadeHoldText
 	call MenuTextBoxBackup
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [CurItem], a
 	call GivePartyItem
 	ret
 
 .bag_full
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [CurItem], a
 	call ReceiveItemFromPokemon
 	ld hl, ItemStorageIsFullText
@@ -954,7 +954,7 @@ TakePartyItem: ; 12c60
 	farcall ItemIsMail
 	call GetPartyItemLocation
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [hl], NO_ITEM
 	call GetItemName
 	ld hl, TookFromText

--- a/engine/stats_screen.asm
+++ b/engine/stats_screen.asm
@@ -402,7 +402,7 @@ StatsScreen_InitUpperHalf: ; 4deea (13:5eea)
 	ld a, "/"
 	ld [hli], a
 	ld a, [BaseDexNo]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call PlaceString
 	call StatsScreen_PlaceHorizontalDivider
@@ -721,7 +721,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	ld b, a
 	farcall TimeCapsule_ReplaceTeruSama
 	ld a, b
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ret
 ; 4e1a0 (13:61a0)

--- a/engine/time_capsule.asm
+++ b/engine/time_capsule.asm
@@ -124,7 +124,7 @@ PlaceTradePartnerNamesAndParty: ; fb60d
 	ld a, [de]
 	cp -1
 	ret z
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	push bc
 	push hl
 	push de

--- a/engine/tmhm.asm
+++ b/engine/tmhm.asm
@@ -41,7 +41,7 @@ GetTMHMMove: ; 1166a
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wCurTMHM], a
 	ret
 ; 1167a
 

--- a/engine/tmhm2.asm
+++ b/engine/tmhm2.asm
@@ -259,7 +259,7 @@ TMHM_ShowTMMoveDescription: ; 2c946 (b:4946)
 	jr nc, TMHM_JoypadLoop
 	ld [wd265], a
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wCurTMHM]
 	ld [CurSpecies], a
 	hlcoord 1, 14
 	call PrintMoveDesc
@@ -387,7 +387,7 @@ TMHM_DisplayPocketItems: ; 2c9e2 (b:49e2)
 	ld [wd265], a
 .okay
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wCurTMHM]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	pop hl
@@ -453,7 +453,7 @@ Function2ca95: ; 2ca95
 	ld bc, 3
 	add hl, bc
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	push hl
@@ -523,7 +523,7 @@ Function2cadf: ; 2cadf
 ; 0x2cafa
 
 .CheckHaveRoomForTMHM: ; 2cafa
-	ld a, [wd265]
+	ld a, [wCurTMHM]
 	dec a
 	ld hl, TMsHMs
 	ld b, 0
@@ -539,7 +539,7 @@ Function2cadf: ; 2cadf
 
 ConsumeTM: ; 2cb0c (b:4b0c)
 	call ConvertCurItemIntoCurTMHM
-	ld a, [wd265]
+	ld a, [wCurTMHM]
 	dec a
 	ld hl, TMsHMs
 	ld b, 0

--- a/engine/trade_animation.asm
+++ b/engine/trade_animation.asm
@@ -884,7 +884,7 @@ TradeAnim_GetFrontpic: ; 29491
 
 TradeAnim_GetNickname: ; 294a9
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	pop de

--- a/event/bug_contest/caught_mon.asm
+++ b/event/bug_contest/caught_mon.asm
@@ -12,7 +12,7 @@ BugContest_SetCaughtContestMon: ; e6ce
 .firstcatch
 	call .generatestats
 	ld a, [TempEnemyMonSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, .caughttext
 	call PrintText

--- a/event/bug_contest/display_stats.asm
+++ b/event/bug_contest/display_stats.asm
@@ -36,7 +36,7 @@ DisplayCaughtContestMonStats: ; cc000
 	call PlaceString
 
 	ld a, [wContestMon]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld de, StringBuffer1
 	hlcoord 1, 2

--- a/event/happiness_egg.asm
+++ b/event/happiness_egg.asm
@@ -11,7 +11,7 @@ GetFirstPokemonHappiness: ; 718d
 	jr .loop
 
 .done
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld a, [hl]
 	ld [ScriptVar], a
 	call GetPokemonName
@@ -19,7 +19,7 @@ GetFirstPokemonHappiness: ; 718d
 
 CheckFirstMonIsEgg: ; 71ac
 	ld a, [PartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	cp EGG
 	ld a, $1
 	jr z, .egg

--- a/event/move_deleter.asm
+++ b/event/move_deleter.asm
@@ -28,7 +28,7 @@ MoveDeletion:
 	ld a, [wMenuCursorY]
 	push af
 	ld a, [CurSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	ld hl, .ConfirmDeleteText
 	call PrintText

--- a/event/move_tutor.asm
+++ b/event/move_tutor.asm
@@ -8,7 +8,7 @@ Special_MoveTutor: ; 4925b
 	xor a
 	ld [wItemAttributeParamBuffer], a
 	call .GetMoveTutorMove
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	call CopyName1

--- a/home/names.asm
+++ b/home/names.asm
@@ -24,7 +24,7 @@ GetName:: ; 33c3
 	jr nz, .NotPokeName
 
 	ld a, [CurSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, PKMN_NAME_LENGTH
 	add hl, de
@@ -115,7 +115,7 @@ GetBasePokemonName:: ; 3420
 ; 343b
 
 GetPokemonName:: ; 343b
-; Get Pokemon name wd265.
+; Get Pokemon name wNamedObjectIndexBuffer.
 
 	ld a, [hROMBank]
 	push af
@@ -124,7 +124,7 @@ GetPokemonName:: ; 343b
 	rst Bankswitch
 
 ; Each name is ten characters
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	dec a
 	ld d, 0
 	ld e, a
@@ -153,11 +153,11 @@ GetPokemonName:: ; 343b
 ; 3468
 
 GetItemName:: ; 3468
-; Get item name wd265.
+; Get item name wNamedObjectIndexBuffer.
 
 	push hl
 	push bc
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 
 	cp TM01
 	jr nc, .TM
@@ -177,12 +177,12 @@ GetItemName:: ; 3468
 ; 3487
 
 GetTMHMName:: ; 3487
-; Get TM/HM name by item id wd265.
+; Get TM/HM name by item id wNamedObjectIndexBuffer.
 
 	push hl
 	push de
 	push bc
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	push af
 
 ; TM/HM prefix
@@ -204,7 +204,7 @@ GetTMHMName:: ; 3487
 
 ; TM/HM number
 	push de
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld c, a
 	callfar GetTMHMNumber
 	pop de
@@ -242,7 +242,7 @@ GetTMHMName:: ; 3487
 	ld [de], a
 
 	pop af
-	ld [wd265], a
+	ld [wCurTMHM], a
 	pop bc
 	pop de
 	pop hl

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -268,7 +268,7 @@ CopyMobileEZChatToC608: ; 11c156
 
 .get_name
 	ld a, e
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	ld bc, PKMN_NAME_LENGTH - 1

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -6932,7 +6932,7 @@ Function102e4f: ; 102e4f
 	ld a, [de]
 	cp $ff
 	ret z
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	push bc
 	push hl
 	push de
@@ -6961,7 +6961,7 @@ Function102ea8: ; 102ea8
 	ld hl, PartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	ld de, StringBuffer2
@@ -6974,7 +6974,7 @@ Function102ea8: ; 102ea8
 	ld hl, OTPartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, UnknownText_0x102ee2
 	call PrintTextBoxText
@@ -7054,7 +7054,7 @@ Function102f85: ; 102f85
 	ld hl, OTPartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call Function102dc3
 	ld de, String_102fb2

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -333,7 +333,7 @@ Function108229: ; 108229
 
 MobileTradeAnim_InitSpeciesName: ; 108239
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	pop de

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -4083,7 +4083,7 @@ BattleTower_UbersCheck: ; 119dd1 (46:5dd1)
 .uber_under_70
 	pop af
 	ld a, [de]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, StringBuffer1
 	ld de, wcd49
@@ -6381,7 +6381,7 @@ Function11b099: ; 11b099
 .loop
 	push af
 	ld a, [de]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	push de
 	push hl
 	call .PlaceMonNameOrPlaceholderString

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -4050,7 +4050,7 @@ Function17f1d0: ; 17f1d0
 	ld a, [hl]
 	ld a, $1
 	ld [rSVBK], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop hl
 	call PlaceString
@@ -4171,7 +4171,7 @@ Function17f27b: ; 17f27b
 	ld a, [hl]
 	ld a, $1
 	ld [rSVBK], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	pop hl
 	call PlaceString

--- a/text/types.asm
+++ b/text/types.asm
@@ -79,9 +79,9 @@ PrintType: ; 50953
 
 
 GetTypeName: ; 50964
-; Copy the name of type [wd265] to StringBuffer1.
+; Copy the name of type [wNamedObjectIndexBuffer] to StringBuffer1.
 
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld hl, TypeNames
 	ld e, a
 	ld d, 0


### PR DESCRIPTION
This seems like the appropriate name for these instances.
Also renamed all the easy-to-spot instances of wd265 where this is
applicable.

This one is going to need a slight more bit of review and thinking:
* Have I replaced all instances correctly?
* Is the name of this wram address even appropriate? It's used for storing IDs of things (moves, 'mon, tms/hms, types, etc), mostly, as well as some results of a few calculations.