### PR TITLE
Constants for TextBoxFlags

### DIFF
--- a/constants/wram_constants.asm
+++ b/constants/wram_constants.asm
@@ -31,8 +31,8 @@ TEXT_DELAY_SLOW EQU 5
 
 ; TextBoxFlags:
 	const_def
-	const TEXT_DELAY_F    ; 0
-	const NO_TEXT_DELAY_F ; 1
+	const FAST_TEXT_DELAY_F ; 0
+	const NO_TEXT_DELAY_F   ; 1
 
 ; Options2:
 	const_def

--- a/constants/wram_constants.asm
+++ b/constants/wram_constants.asm
@@ -29,6 +29,11 @@ TEXT_DELAY_SLOW EQU 5
 	const FRAME_7 ; 6
 	const FRAME_8 ; 7
 
+; TextBoxFlags:
+	const_def
+	const TEXT_DELAY_F    ; 0
+	const NO_TEXT_DELAY_F ; 1
+
 ; Options2:
 	const_def
 	const MENU_ACCOUNT ; 0

--- a/data/default_options.asm
+++ b/data/default_options.asm
@@ -5,12 +5,12 @@ DefaultOptions: ; 14f7c
 	db $00
 ; TextBoxFrame: frame 1
 	db FRAME_1
-; TextBoxFlags: ??
-	db $01
+; TextBoxFlags: use text speed
+	db 1 << TEXT_DELAY_F
 ; GBPrinter: normal brightness
 	db GBPRINTER_NORMAL
 ; Options2: menu account on
-	db $01
+	db 1 << MENU_ACCOUNT
 ; $cfd2: ??
 	db $00
 ; $cfd3: ??

--- a/data/default_options.asm
+++ b/data/default_options.asm
@@ -6,7 +6,7 @@ DefaultOptions: ; 14f7c
 ; TextBoxFrame: frame 1
 	db FRAME_1
 ; TextBoxFlags: use text speed
-	db 1 << TEXT_DELAY_F
+	db 1 << FAST_TEXT_DELAY_F
 ; GBPrinter: normal brightness
 	db GBPRINTER_NORMAL
 ; Options2: menu account on

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -875,10 +875,10 @@ CheckMenuOW: ; 96b30
 	ld [hMenuReturn + 1], a
 	ld a, [hJoyPressed]
 
-	bit 2, a ; SELECT
+	bit SELECT_F, a
 	jr nz, .Select
 
-	bit 3, a ; START
+	bit START_F, a
 	jr z, .NoMenu
 
 	ld a, BANK(StartMenuScript)

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -262,19 +262,19 @@ SetMagnetTrainPals: ; 8cdc3
 
 	; bushes
 	hlbgcoord 0, 0
-	ld bc, 4 bgrows
+	ld bc, 4 * BG_MAP_WIDTH
 	ld a, $2
 	call ByteFill
 
 	; train
 	hlbgcoord 0, 4
-	ld bc, 10 bgrows
+	ld bc, 10 * BG_MAP_WIDTH
 	xor a
 	call ByteFill
 
 	; more bushes
 	hlbgcoord 0, 14
-	ld bc, 4 bgrows
+	ld bc, 4 * BG_MAP_WIDTH
 	ld a, $2
 	call ByteFill
 

--- a/engine/mon_menu.asm
+++ b/engine/mon_menu.asm
@@ -89,9 +89,9 @@ MonMenuLoop: ; 24d59
 	ld de, SFX_READ_TEXT_2
 	call PlaySFX
 	ld a, [hJoyPressed]
-	bit 0, a ; A
+	bit A_BUTTON_F, a
 	jr nz, .select
-	bit 1, a ; B
+	bit B_BUTTON_F, a
 	jr nz, .cancel
 	jr .loop
 

--- a/engine/scrolling_menu.asm
+++ b/engine/scrolling_menu.asm
@@ -65,21 +65,21 @@ ScrollingMenuJoyAction: ; 24609
 	ld a, [hJoyPressed]
 	and BUTTONS
 	or b
-	bit 0, a ; A
+	bit A_BUTTON_F, a
 	jp nz, .a_button
-	bit 1, a ; B
+	bit B_BUTTON_F, a
 	jp nz, .b_button
-	bit 2, a ; Select
+	bit SELECT_F, a
 	jp nz, .select
-	bit 3, a ; Start
+	bit START_F, a
 	jp nz, .start
-	bit 4, a ; Right
+	bit D_RIGHT_F, a
 	jp nz, .d_right
-	bit 5, a ; Left
+	bit D_LEFT_F, a
 	jp nz, .d_left
-	bit 6, a ; Up
+	bit D_UP_F, a
 	jp nz, .d_up
-	bit 7, a ; Down
+	bit D_DOWN_F, a
 	jp nz, .d_down
 	jr .loop
 ; 24640

--- a/engine/title.asm
+++ b/engine/title.asm
@@ -32,7 +32,7 @@ _TitleScreen: ; 10ed67
 
 ; Clear screen palettes
 	hlbgcoord 0, 0
-	ld bc, 20 bgrows
+	ld bc, 20 * BG_MAP_WIDTH
 	xor a
 	call ByteFill
 
@@ -43,7 +43,7 @@ _TitleScreen: ; 10ed67
 
 ; line 0 (copyright)
 	hlbgcoord 0, 0, vBGMap1
-	ld bc, 1 bgrows
+	ld bc, BG_MAP_WIDTH
 	ld a, 7 ; palette
 	call ByteFill
 
@@ -54,27 +54,27 @@ _TitleScreen: ; 10ed67
 
 ; lines 3-4
 	hlbgcoord 0, 3
-	ld bc, 2 bgrows
+	ld bc, 2 * BG_MAP_WIDTH
 	ld a, 2
 	call ByteFill
 ; line 5
 	hlbgcoord 0, 5
-	ld bc, 1 bgrows
+	ld bc, BG_MAP_WIDTH
 	ld a, 3
 	call ByteFill
 ; line 6
 	hlbgcoord 0, 6
-	ld bc, 1 bgrows
+	ld bc, BG_MAP_WIDTH
 	ld a, 4
 	call ByteFill
 ; line 7
 	hlbgcoord 0, 7
-	ld bc, 1 bgrows
+	ld bc, BG_MAP_WIDTH
 	ld a, 5
 	call ByteFill
 ; lines 8-9
 	hlbgcoord 0, 8
-	ld bc, 2 bgrows
+	ld bc, 2 * BG_MAP_WIDTH
 	ld a, 6
 	call ByteFill
 
@@ -87,7 +87,7 @@ _TitleScreen: ; 10ed67
 
 ; Suicune gfx
 	hlbgcoord 0, 12
-	ld bc, 6 bgrows ; the rest of the screen
+	ld bc, 6 * BG_MAP_WIDTH ; the rest of the screen
 	ld a, 0 | VRAM_BANK_1
 	call ByteFill
 
@@ -110,7 +110,7 @@ _TitleScreen: ; 10ed67
 
 ; Clear screen tiles
 	hlbgcoord 0, 0
-	ld bc, 64 bgrows
+	ld bc, 64 * BG_MAP_WIDTH
 	ld a, " "
 	call ByteFill
 

--- a/home.asm
+++ b/home.asm
@@ -332,7 +332,7 @@ PrintLetterDelay:: ; 313d
 	jr .updatedelay
 
 .fast
-	ld a, 1
+	ld a, TEXT_DELAY_FAST
 
 .updatedelay
 	ld [TextDelayFrames], a
@@ -347,11 +347,11 @@ PrintLetterDelay:: ; 313d
 
 ; Wait one frame if holding A or B.
 	ld a, [hJoyDown]
-	bit 0, a ; A_BUTTON
+	bit A_BUTTON_F, a
 	jr z, .checkb
 	jr .delay
 .checkb
-	bit 1, a ; B_BUTTON
+	bit B_BUTTON_F, a
 	jr z, .wait
 
 .delay

--- a/home.asm
+++ b/home.asm
@@ -323,7 +323,7 @@ PrintLetterDelay:: ; 313d
 
 ; force fast scroll?
 	ld a, [TextBoxFlags]
-	bit TEXT_DELAY_F, a
+	bit FAST_TEXT_DELAY_F, a
 	jr z, .fast
 
 ; text speed

--- a/home.asm
+++ b/home.asm
@@ -306,7 +306,7 @@ PrintLetterDelay:: ; 313d
 
 ; non-scrolling text?
 	ld a, [TextBoxFlags]
-	bit 1, a
+	bit NO_TEXT_DELAY_F, a
 	ret z
 
 	push hl
@@ -323,7 +323,7 @@ PrintLetterDelay:: ; 313d
 
 ; force fast scroll?
 	ld a, [TextBoxFlags]
-	bit 0, a
+	bit TEXT_DELAY_F, a
 	jr z, .fast
 
 ; text speed

--- a/home/joypad.asm
+++ b/home/joypad.asm
@@ -442,10 +442,10 @@ ButtonSound:: ; aaf
 	jr .load_cursor_state
 
 .cursor_off
-	ld a, [TileMap + 17 + 17 * SCREEN_WIDTH]
+	lda_coord 17, 17
 
 .load_cursor_state
-	ld [TileMap + 18 + 17 * SCREEN_WIDTH], a
+	ldcoord_a 18, 17
 	ret
 ; b06
 

--- a/home/text.asm
+++ b/home/text.asm
@@ -697,7 +697,7 @@ PokeFluteTerminatorCharacter:: ; 13e0
 PlaceHLTextAtBC:: ; 13e5
 	ld a, [TextBoxFlags]
 	push af
-	set 1, a
+	set NO_TEXT_DELAY_F, a
 	ld [TextBoxFlags], a
 
 	call DoTextUntilTerminator

--- a/macros/coords.asm
+++ b/macros/coords.asm
@@ -1,51 +1,55 @@
+screenrows EQUS "* SCREEN_WIDTH"
+bgrows     EQUS "* BG_MAP_WIDTH"
+
+hlcoord EQUS "coord hl,"
 bccoord EQUS "coord bc,"
 decoord EQUS "coord de,"
-hlcoord EQUS "coord hl,"
 
 coord: MACRO
 ; register, x, y[, origin]
 	if _NARG < 4
-	ld \1, TileMap + SCREEN_WIDTH * (\3) + (\2)
+	ld \1, (\3) screenrows + (\2) + TileMap
 	else
-	ld \1, \4 + SCREEN_WIDTH * (\3) + (\2)
+	ld \1, (\3) screenrows + (\2) + \4
+	endc
+ENDM
+
+hlbgcoord EQUS "bgcoord hl,"
+bcbgcoord EQUS "bgcoord bc,"
+debgcoord EQUS "bgcoord de,"
+
+bgcoord: MACRO
+; register, x, y[, origin]
+	if _NARG < 4
+	ld \1, (\3) bgrows + (\2) + vBGMap0
+	else
+	ld \1, (\3) bgrows + (\2) + \4
 	endc
 ENDM
 
 dwcoord: MACRO
+; x, y
 	rept _NARG / 2
-	dw TileMap + SCREEN_WIDTH * (\2) + (\1)
+	dw (\2) screenrows + (\1) + TileMap
 	shift
 	shift
 	endr
 ENDM
 
 ldcoord_a: MACRO
+; x, y[, origin]
 	if _NARG < 3
-	ld [TileMap + SCREEN_WIDTH * (\2) + (\1)], a
+	ld [(\2) screenrows + (\1) + TileMap], a
 	else
-	ld [\3 + SCREEN_WIDTH * (\2) + (\1)], a
+	ld [(\2) screenrows + (\1) + \3], a
 	endc
 ENDM
 
 lda_coord: MACRO
+; x, y[, origin]
 	if _NARG < 3
-	ld a, [TileMap + SCREEN_WIDTH * (\2) + (\1)]
+	ld a, [(\2) screenrows + (\1) + TileMap]
 	else
-	ld a, [\3 + SCREEN_WIDTH * (\2) + (\1)]
-	endc
-ENDM
-
-
-bgrows EQUS "* $20" ; SCREEN_WIDTH
-
-hlbgcoord EQUS "bgcoord hl,"
-debgcoord EQUS "bgcoord de,"
-bcbgcoord EQUS "bgcoord bc,"
-
-bgcoord: MACRO
-	if _NARG >= 4
-	ld \1, \3 bgrows + \2 + \4
-	else
-	ld \1, \3 bgrows + \2 + vBGMap0
+	ld a, [(\2) screenrows + (\1) + \3]
 	endc
 ENDM

--- a/macros/coords.asm
+++ b/macros/coords.asm
@@ -1,6 +1,3 @@
-screenrows EQUS "* SCREEN_WIDTH"
-bgrows     EQUS "* BG_MAP_WIDTH"
-
 hlcoord EQUS "coord hl,"
 bccoord EQUS "coord bc,"
 decoord EQUS "coord de,"
@@ -8,9 +5,9 @@ decoord EQUS "coord de,"
 coord: MACRO
 ; register, x, y[, origin]
 	if _NARG < 4
-	ld \1, (\3) screenrows + (\2) + TileMap
+	ld \1, (\3) * SCREEN_WIDTH + (\2) + TileMap
 	else
-	ld \1, (\3) screenrows + (\2) + \4
+	ld \1, (\3) * SCREEN_WIDTH + (\2) + \4
 	endc
 ENDM
 
@@ -21,25 +18,16 @@ debgcoord EQUS "bgcoord de,"
 bgcoord: MACRO
 ; register, x, y[, origin]
 	if _NARG < 4
-	ld \1, (\3) bgrows + (\2) + vBGMap0
+	ld \1, (\3) * BG_MAP_WIDTH + (\2) + vBGMap0
 	else
-	ld \1, (\3) bgrows + (\2) + \4
+	ld \1, (\3) * BG_MAP_WIDTH + (\2) + \4
 	endc
-ENDM
-
-hldims EQUS "dims hl,"
-bcdims EQUS "dims bc,"
-dedims EQUS "dims de,"
-
-dims: MACRO
-; register, width, height
-	lb \1, \3, \2
 ENDM
 
 dwcoord: MACRO
 ; x, y
 	rept _NARG / 2
-	dw (\2) screenrows + (\1) + TileMap
+	dw (\2) * SCREEN_WIDTH + (\1) + TileMap
 	shift
 	shift
 	endr
@@ -48,17 +36,17 @@ ENDM
 ldcoord_a: MACRO
 ; x, y[, origin]
 	if _NARG < 3
-	ld [(\2) screenrows + (\1) + TileMap], a
+	ld [(\2) * SCREEN_WIDTH + (\1) + TileMap], a
 	else
-	ld [(\2) screenrows + (\1) + \3], a
+	ld [(\2) * SCREEN_WIDTH + (\1) + \3], a
 	endc
 ENDM
 
 lda_coord: MACRO
 ; x, y[, origin]
 	if _NARG < 3
-	ld a, [(\2) screenrows + (\1) + TileMap]
+	ld a, [(\2) * SCREEN_WIDTH + (\1) + TileMap]
 	else
-	ld a, [(\2) screenrows + (\1) + \3]
+	ld a, [(\2) * SCREEN_WIDTH + (\1) + \3]
 	endc
 ENDM

--- a/macros/coords.asm
+++ b/macros/coords.asm
@@ -27,6 +27,15 @@ bgcoord: MACRO
 	endc
 ENDM
 
+hldims EQUS "dims hl,"
+bcdims EQUS "dims bc,"
+dedims EQUS "dims de,"
+
+dims: MACRO
+; register, width, height
+	lb \1, \3, \2
+ENDM
+
 dwcoord: MACRO
 ; x, y
 	rept _NARG / 2
@@ -52,9 +61,4 @@ lda_coord: MACRO
 	else
 	ld a, [(\2) screenrows + (\1) + \3]
 	endc
-ENDM
-
-ld_dims: MACRO
-; register, width, height
-	lb \1, \3, \2
 ENDM

--- a/macros/coords.asm
+++ b/macros/coords.asm
@@ -53,3 +53,8 @@ lda_coord: MACRO
 	ld a, [(\2) screenrows + (\1) + \3]
 	endc
 ENDM
+
+ld_dims: MACRO
+; register, width, height
+	lb \1, \3, \2
+ENDM

--- a/wram.asm
+++ b/wram.asm
@@ -1480,7 +1480,10 @@ wSaveFileExists:: db
 TextBoxFrame:: ; cfce
 ; bits 0-2: textbox frame 0-7
 	db
-TextBoxFlags:: db
+TextBoxFlags::
+; bit 0: 1-frame text delay
+; bit 4: no text delay
+	db
 GBPrinter:: ; cfd0
 ; bit 0-6: brightness
 ;   lightest: $00


### PR DESCRIPTION
From home.asm:

```
PrintLetterDelay:: ; 313d
; Wait before printing the next letter.

; The text speed setting in Options is actually a frame count:
; 	fast: 1 frame
; 	mid:  3 frames
; 	slow: 5 frames

; TextBoxFlags[!0] and A or B override text speed with a one-frame delay.
; Options[4] and TextBoxFlags[!1] disable the delay.
```