### PR TITLE
Use more palette(s) constants, rename BG/OBP wram addresses, and rBGPI+rOBPI auto-increment constants (from Rangi)

### DIFF
--- a/constants/credits_constants.asm
+++ b/constants/credits_constants.asm
@@ -1,4 +1,4 @@
-; CreditsStrings indexes (see data/credits_text.asm)
+; CreditsStrings indexes (see data/credits_strings.asm)
 	const_def
 	const SATOSHI_TAJIRI
 	const JUNICHI_MASUDA

--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -145,8 +145,10 @@ rHDMA4      EQU $ff54 ; CGB Mode Only - New DMA Destination, Low
 rHDMA5      EQU $ff55 ; CGB Mode Only - New DMA Length/Mode/Start
 rRP         EQU $ff56 ; CGB Mode Only - Infrared Communications Port
 rBGPI       EQU $ff68 ; CGB Mode Only - Background Palette Index
+rBGPI_AUTO_INCREMENT EQU 7 ; increment rBGPI after write to rBGPD
 rBGPD       EQU $ff69 ; CGB Mode Only - Background Palette Data
 rOBPI       EQU $ff6a ; CGB Mode Only - Sprite Palette Index
+rOBPI_AUTO_INCREMENT EQU 7 ; increment rOBPI after write to rOBPD
 rOBPD       EQU $ff6b ; CGB Mode Only - Sprite Palette Data
 rUNKNOWN1   EQU $ff6c ; (FEh) Bit 0 (Read/Write) - CGB Mode Only
 rSVBK       EQU $ff70 ; CGB Mode Only - WRAM Bank

--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -50,7 +50,7 @@ OAM_X_FLIP    EQU 5
 OAM_Y_FLIP    EQU 6
 OAM_PRIORITY  EQU 7 ; 0: OBJ above BG, 1: OBJ behind BG (colors 1-3)
 
-; BP Map attribute flags
+; BG Map attribute flags
 PALETTE_MASK EQU %111
 VRAM_BANK_1  EQU 1 << OAM_TILE_BANK ; $08
 OBP_NUM      EQU 1 << OAM_OBP_NUM   ; $10
@@ -60,7 +60,7 @@ BEHIND_BG    EQU 1 << OAM_PRIORITY  ; $80
 
 ; Other useful constants
 LCDC_DEFAULT EQU %11100011
-LY_VBLANK EQU 144
+LY_VBLANK    EQU 144
 
 ; Hardware registers
 rJOYP       EQU $ff00 ; Joypad (R/W)

--- a/constants/map_constants.asm
+++ b/constants/map_constants.asm
@@ -21,7 +21,7 @@ ENDM
 ; `mapgroup` indexes are for the sub-tables of MapGroupPointers (see maps/map_headers.asm)
 	const_def
 
-	newgroup                                                    ;  1
+	newgroup                                                     ;  1
 
 	mapgroup OLIVINE_POKECENTER_1F,                        4,  5 ;  1
 	mapgroup OLIVINE_GYM,                                  8,  5 ;  2
@@ -38,7 +38,7 @@ ENDM
 	mapgroup ROUTE_39,                                    18, 10 ; 13
 	mapgroup OLIVINE_CITY,                                18, 20 ; 14
 
-	newgroup                                                    ;  2
+	newgroup                                                     ;  2
 
 	mapgroup MAHOGANY_RED_GYARADOS_SPEECH_HOUSE,           4,  4 ;  1
 	mapgroup MAHOGANY_GYM,                                 9,  5 ;  2
@@ -48,7 +48,7 @@ ENDM
 	mapgroup ROUTE_44,                                     9, 30 ;  6
 	mapgroup MAHOGANY_TOWN,                                9, 10 ;  7
 
-	newgroup                                                    ;  3
+	newgroup                                                     ;  3
 
 	mapgroup SPROUT_TOWER_1F,                              8, 10 ;  1
 	mapgroup SPROUT_TOWER_2F,                              8, 10 ;  2
@@ -142,7 +142,7 @@ ENDM
 	mapgroup SAFARI_ZONE_BETA,                            18, 10 ; 90
 	mapgroup VICTORY_ROAD,                                36, 10 ; 91
 
-	newgroup                                                    ;  4
+	newgroup                                                     ;  4
 
 	mapgroup ECRUTEAK_HOUSE,                               9, 10 ;  1
 	mapgroup WISE_TRIOS_ROOM,                              4,  4 ;  2
@@ -154,7 +154,7 @@ ENDM
 	mapgroup ECRUTEAK_ITEMFINDER_HOUSE,                    4,  4 ;  8
 	mapgroup ECRUTEAK_CITY,                               18, 20 ;  9
 
-	newgroup                                                    ;  5
+	newgroup                                                     ;  5
 
 	mapgroup BLACKTHORN_GYM_1F,                            9,  5 ;  1
 	mapgroup BLACKTHORN_GYM_2F,                            9,  5 ;  2
@@ -167,7 +167,7 @@ ENDM
 	mapgroup ROUTE_46,                                    18, 10 ;  9
 	mapgroup BLACKTHORN_CITY,                             18, 20 ; 10
 
-	newgroup                                                    ;  6
+	newgroup                                                     ;  6
 
 	mapgroup CINNABAR_POKECENTER_1F,                       4,  5 ;  1
 	mapgroup CINNABAR_POKECENTER_2F_BETA,                  4,  8 ;  2
@@ -178,7 +178,7 @@ ENDM
 	mapgroup ROUTE_21,                                    18, 10 ;  7
 	mapgroup CINNABAR_ISLAND,                              9, 10 ;  8
 
-	newgroup                                                    ;  7
+	newgroup                                                     ;  7
 
 	mapgroup CERULEAN_GYM_BADGE_SPEECH_HOUSE,              4,  4 ;  1
 	mapgroup CERULEAN_POLICE_STATION,                      4,  4 ;  2
@@ -198,7 +198,7 @@ ENDM
 	mapgroup ROUTE_25,                                     9, 30 ; 16
 	mapgroup CERULEAN_CITY,                               18, 20 ; 17
 
-	newgroup                                                    ;  8
+	newgroup                                                     ;  8
 
 	mapgroup AZALEA_POKECENTER_1F,                         4,  5 ;  1
 	mapgroup CHARCOAL_KILN,                                4,  4 ;  2
@@ -208,7 +208,7 @@ ENDM
 	mapgroup ROUTE_33,                                     9, 10 ;  6
 	mapgroup AZALEA_TOWN,                                  9, 20 ;  7
 
-	newgroup                                                    ;  9
+	newgroup                                                     ;  9
 
 	mapgroup LAKE_OF_RAGE_HIDDEN_POWER_HOUSE,              4,  4 ;  1
 	mapgroup LAKE_OF_RAGE_MAGIKARP_HOUSE,                  4,  4 ;  2
@@ -217,7 +217,7 @@ ENDM
 	mapgroup ROUTE_43,                                    27, 10 ;  5
 	mapgroup LAKE_OF_RAGE,                                18, 20 ;  6
 
-	newgroup                                                    ; 10
+	newgroup                                                     ; 10
 
 	mapgroup ROUTE_32,                                    45, 10 ;  1
 	mapgroup ROUTE_35,                                    18, 10 ;  2
@@ -237,7 +237,7 @@ ENDM
 	mapgroup ROUTE_36_RUINS_OF_ALPH_GATE,                  4,  5 ; 16
 	mapgroup ROUTE_36_NATIONAL_PARK_GATE,                  4,  5 ; 17
 
-	newgroup                                                    ; 11
+	newgroup                                                     ; 11
 
 	mapgroup ROUTE_34,                                    27, 10 ;  1
 	mapgroup GOLDENROD_CITY,                              18, 20 ;  2
@@ -264,7 +264,7 @@ ENDM
 	mapgroup ROUTE_34_ILEX_FOREST_GATE,                    4,  5 ; 23
 	mapgroup DAY_CARE,                                     4,  5 ; 24
 
-	newgroup                                                    ; 12
+	newgroup                                                     ; 12
 
 	mapgroup ROUTE_6,                                      9, 10 ;  1
 	mapgroup ROUTE_11,                                     9, 20 ;  2
@@ -280,7 +280,7 @@ ENDM
 	mapgroup ROUTE_6_SAFFRON_GATE,                         4,  5 ; 12
 	mapgroup ROUTE_6_UNDERGROUND_PATH_ENTRANCE,            4,  4 ; 13
 
-	newgroup                                                    ; 13
+	newgroup                                                     ; 13
 
 	mapgroup ROUTE_1,                                     18, 10 ;  1
 	mapgroup PALLET_TOWN,                                  9, 10 ;  2
@@ -289,7 +289,7 @@ ENDM
 	mapgroup BLUES_HOUSE,                                  4,  4 ;  5
 	mapgroup OAKS_LAB,                                     6,  5 ;  6
 
-	newgroup                                                    ; 14
+	newgroup                                                     ; 14
 
 	mapgroup ROUTE_3,                                      9, 30 ;  1
 	mapgroup PEWTER_CITY,                                 18, 20 ;  2
@@ -300,7 +300,7 @@ ENDM
 	mapgroup PEWTER_POKECENTER_2F_BETA,                    4,  8 ;  7
 	mapgroup PEWTER_SNOOZE_SPEECH_HOUSE,                   4,  4 ;  8
 
-	newgroup                                                    ; 15
+	newgroup                                                     ; 15
 
 	mapgroup OLIVINE_PORT,                                18, 10 ;  1
 	mapgroup VERMILION_PORT,                              18, 10 ;  2
@@ -315,7 +315,7 @@ ENDM
 	mapgroup MOUNT_MOON_GIFT_SHOP,                         4,  4 ; 11
 	mapgroup TIN_TOWER_ROOF,                               9, 10 ; 12
 
-	newgroup                                                    ; 16
+	newgroup                                                     ; 16
 
 	mapgroup ROUTE_23,                                     9, 10 ;  1
 	mapgroup INDIGO_PLATEAU_POKECENTER_1F,                 7,  9 ;  2
@@ -326,7 +326,7 @@ ENDM
 	mapgroup LANCES_ROOM,                                 12,  5 ;  7
 	mapgroup HALL_OF_FAME,                                 7,  5 ;  8
 
-	newgroup                                                    ; 17
+	newgroup                                                     ; 17
 
 	mapgroup ROUTE_13,                                     9, 30 ;  1
 	mapgroup ROUTE_14,                                    18, 10 ;  2
@@ -342,7 +342,7 @@ ENDM
 	mapgroup SAFARI_ZONE_WARDENS_HOME,                     4,  5 ; 12
 	mapgroup ROUTE_15_FUCHSIA_GATE,                        4,  5 ; 13
 
-	newgroup                                                    ; 18
+	newgroup                                                     ; 18
 
 	mapgroup ROUTE_8,                                      9, 20 ;  1
 	mapgroup ROUTE_12,                                    27, 10 ;  2
@@ -359,14 +359,14 @@ ENDM
 	mapgroup ROUTE_8_SAFFRON_GATE,                         4,  5 ; 13
 	mapgroup ROUTE_12_SUPER_ROD_HOUSE,                     4,  4 ; 14
 
-	newgroup                                                    ; 19
+	newgroup                                                     ; 19
 
 	mapgroup ROUTE_28,                                     9, 20 ;  1
 	mapgroup SILVER_CAVE_OUTSIDE,                         18, 20 ;  2
 	mapgroup SILVER_CAVE_POKECENTER_1F,                    4,  5 ;  3
 	mapgroup ROUTE_28_FAMOUS_SPEECH_HOUSE,                 4,  4 ;  4
 
-	newgroup                                                    ; 20
+	newgroup                                                     ; 20
 
 	mapgroup POKECENTER_2F,                                4,  8 ;  1
 	mapgroup TRADE_CENTER,                                 4,  5 ;  2
@@ -375,7 +375,7 @@ ENDM
 	mapgroup MOBILE_TRADE_ROOM_MOBILE,                     4,  5 ;  5
 	mapgroup MOBILE_BATTLE_ROOM,                           4,  5 ;  6
 
-	newgroup                                                    ; 21
+	newgroup                                                     ; 21
 
 	mapgroup ROUTE_7,                                      9, 10 ;  1
 	mapgroup ROUTE_16,                                     9, 10 ;  2
@@ -404,7 +404,7 @@ ENDM
 	mapgroup ROUTE_7_SAFFRON_GATE,                         4,  5 ; 25
 	mapgroup ROUTE_17_18_GATE,                             4,  5 ; 26
 
-	newgroup                                                    ; 22
+	newgroup                                                     ; 22
 
 	mapgroup ROUTE_40,                                    18, 10 ;  1
 	mapgroup ROUTE_41,                                    27, 25 ;  2
@@ -423,7 +423,7 @@ ENDM
 	mapgroup ROUTE_40_BATTLE_TOWER_GATE,                   4,  5 ; 15
 	mapgroup BATTLE_TOWER_OUTSIDE,                        14, 10 ; 16
 
-	newgroup                                                    ; 23
+	newgroup                                                     ; 23
 
 	mapgroup ROUTE_2,                                     27, 10 ;  1
 	mapgroup ROUTE_22,                                     9, 20 ;  2
@@ -439,7 +439,7 @@ ENDM
 	mapgroup ROUTE_2_GATE,                                 4,  5 ; 12
 	mapgroup VICTORY_ROAD_GATE,                            9, 10 ; 13
 
-	newgroup                                                    ; 24
+	newgroup                                                     ; 24
 
 	mapgroup ROUTE_26,                                    54, 10 ;  1
 	mapgroup ROUTE_27,                                     9, 40 ;  2
@@ -455,7 +455,7 @@ ENDM
 	mapgroup ROUTE_27_SANDSTORM_HOUSE,                     4,  4 ; 12
 	mapgroup ROUTE_29_46_GATE,                             4,  5 ; 13
 
-	newgroup                                                    ; 25
+	newgroup                                                     ; 25
 
 	mapgroup ROUTE_5,                                      9, 10 ;  1
 	mapgroup SAFFRON_CITY,                                18, 20 ;  2
@@ -473,7 +473,7 @@ ENDM
 	mapgroup ROUTE_5_SAFFRON_CITY_GATE,                    4,  5 ; 14
 	mapgroup ROUTE_5_CLEANSE_TAG_SPEECH_HOUSE,             4,  4 ; 15
 
-	newgroup                                                    ; 26
+	newgroup                                                     ; 26
 
 	mapgroup ROUTE_30,                                    27, 10 ;  1
 	mapgroup ROUTE_31,                                     9, 20 ;  2

--- a/docs/battle_anim_commands.md
+++ b/docs/battle_anim_commands.md
@@ -1,6 +1,6 @@
 # Battle Animation Commands
 
-Defined in [macros/scripts/battle_anims.asm](/macros/scripts/battle_anims.asm) and [data/moves/animations.asm:BattleAnimations](/data/moves/animations.asm).
+Defined in [macros/scripts/battle_anims.asm](/macros/scripts/battle_anims.asm) and [engine/battle_anims/anim_commands.asm:BattleAnimCommands](/engine/battle_anims/anim_commands.asm).
 
 
 ## `$00`−`$CF`: `anim_wait` *length*
@@ -80,7 +80,7 @@ Temporarily creates sprites from the top row of the player backpic, so that the 
 
 ## `$DB`: `anim_checkpokeball`
 
-Sets `var` to the result of [GetPokeBallWobble](/engine/battle_anims/getpokeballwobble.asm).
+Sets `BattleAnimVar` to the result of [GetPokeBallWobble](/engine/battle_anims/getpokeballwobble.asm).
 
 
 ## `$DC`: `anim_transform`
@@ -190,19 +190,19 @@ Does nothing. Unused.
 
 ## `$F8`: `anim_if_param_equal` *value*, *address*
 
-Jumps to another script if `wKickCounter` is equal to *value*.
+Jumps to another script if `wBattleAnimParam` (aka `wKickCounter` or `wPresentPower`) is equal to *value*.
 
 ## `$F9`: `anim_setvar` *value*
 
-Sets `var` to *value*.
+Sets `BattleAnimVar` to *value*.
 
 ## `$FA`: `anim_incvar`
 
-Increments `var` by 1.
+Increments `BattleAnimVar` by 1.
 
 ## `$FB`: `anim_if_var_equal` *value*, *address*
 
-Jumps to another script if `var` is equal to *value*.
+Jumps to another script if `BattleAnimVar` is equal to *value*.
 
 ## `$FC`: `anim_jump` *address*
 

--- a/docs/map_scripts.md
+++ b/docs/map_scripts.md
@@ -65,7 +65,7 @@ Callback types:
 
 ## `.CoordEvents: db` *N*
 
-- **`coord_event` *x*, *y*, *scene id*, *script***
+- **`coord_event` *x*, *y*, *scene_id*, *script***
 
 
 ## `.BGEvents: db` *N*
@@ -90,7 +90,7 @@ BG event types:
 
 ## `.ObjectEvents: db` *N*
 
-- **`object_event` *x*, *y*, *sprite*, *movement*, *ry*, *rx*, *h1*, *h2*, *palette*, *type*, *range*, *script*, *event_flag***
+- **`object_event` *x*, *y*, *sprite*, *movement*, *rx*, *ry*, *h1*, *h2*, *palette*, *type*, *range*, *script*, *event_flag***
 
 Movement types:
 

--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -45,7 +45,7 @@ _AnimateHPBar: ; d627
 	and a
 	jr nz, .player
 	ld a, [wCurHPAnimMaxHP]
-	cp 6 * 8
+	cp HP_BAR_LENGTH_PX
 	jr nc, .player
 	and a
 	ret
@@ -203,7 +203,7 @@ LongAnim_UpdateVariables: ; d6f5
 
 ShortHPBarAnim_UpdateTiles: ; d730
 	call HPBarAnim_UpdateHPRemaining
-	ld d, $6
+	ld d, HP_BAR_LENGTH
 	ld a, [wWhichHPBar]
 	and $1
 	ld b, a
@@ -229,7 +229,7 @@ LongHPBarAnim_UpdateTiles: ; d749
 	ld d, a
 	call ComputeHPBarPixels
 	ld c, e
-	ld d, $6
+	ld d, HP_BAR_LENGTH
 	ld a, [wWhichHPBar]
 	and $1
 	ld b, a
@@ -377,7 +377,7 @@ ShortHPBar_CalcPixelFrame: ; d839
 	ld b, 0
 	ld hl, 0
 	ld a, [wCurHPBarPixels]
-	cp 6 * 8
+	cp HP_BAR_LENGTH_PX
 	jr nc, .return_max
 	and a
 	jr z, .return_zero
@@ -388,7 +388,7 @@ ShortHPBar_CalcPixelFrame: ; d839
 ; by 48, the loop runs one extra time. To fix, uncomment the line below.
 .loop
 	ld a, l
-	sub 6 * 8
+	sub HP_BAR_LENGTH_PX
 	ld l, a
 	ld a, h
 	sbc $0
@@ -404,7 +404,7 @@ ShortHPBar_CalcPixelFrame: ; d839
 	add hl, bc
 	pop bc
 	ld a, l
-	sub 6 * 8
+	sub HP_BAR_LENGTH_PX
 	ld l, a
 	ld a, h
 	sbc $0

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -26,7 +26,7 @@ Predef_StartBattle: ; 8c20f
 	ld a, $5
 	ld [rSVBK], a
 
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld bc, 8 palettes
 	xor a
 	call ByteFill
@@ -651,11 +651,11 @@ StartTrainerBattle_LoadPokeBallGraphics: ; 8c5dc (23:45dc)
 	ld [rSVBK], a
 	call .copypals
 	push hl
-	ld de, UnknBGPals palette PAL_BG_TEXT
+	ld de, wBGPals1 palette PAL_BG_TEXT
 	ld bc, 1 palettes
 	call CopyBytes
 	pop hl
-	ld de, BGPals palette PAL_BG_TEXT
+	ld de, wBGPals2 palette PAL_BG_TEXT
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
@@ -670,17 +670,17 @@ StartTrainerBattle_LoadPokeBallGraphics: ; 8c5dc (23:45dc)
 	ret
 
 .copypals ; 8c677 (23:4677)
-	ld de, UnknBGPals palette PAL_BG_TEXT
+	ld de, wBGPals1 palette PAL_BG_TEXT
 	call .copy
-	ld de, BGPals palette PAL_BG_TEXT
+	ld de, wBGPals2 palette PAL_BG_TEXT
 	call .copy
-	ld de, UnknOBPals palette PAL_OW_TREE
+	ld de, wOBPals1 palette PAL_OW_TREE
 	call .copy
-	ld de, OBPals palette PAL_OW_TREE
+	ld de, wOBPals2 palette PAL_OW_TREE
 	call .copy
-	ld de, UnknOBPals palette PAL_OW_ROCK
+	ld de, wOBPals1 palette PAL_OW_ROCK
 	call .copy
-	ld de, OBPals palette PAL_OW_ROCK
+	ld de, wOBPals2 palette PAL_OW_ROCK
 
 .copy ; 8c698 (23:4698)
 	push hl

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -1433,14 +1433,14 @@ BattleAnim_SetBGPals: ; cc91a
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
-	ld de, UnknBGPals
+	ld hl, wBGPals2
+	ld de, wBGPals1
 	ld a, [rBGP]
 	ld b, a
 	ld c, 7
 	call CopyPals
-	ld hl, OBPals
-	ld de, UnknOBPals
+	ld hl, wOBPals2
+	ld de, wOBPals1
 	ld a, [rBGP]
 	ld b, a
 	ld c, 2
@@ -1461,8 +1461,8 @@ BattleAnim_SetOBPals: ; cc94b
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, OBPals palette PAL_BATTLE_OB_GRAY
-	ld de, UnknOBPals palette PAL_BATTLE_OB_GRAY
+	ld hl, wOBPals2 palette PAL_BATTLE_OB_GRAY
+	ld de, wOBPals1 palette PAL_BATTLE_OB_GRAY
 	ld a, [rOBP0]
 	ld b, a
 	ld c, 2

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -2588,8 +2588,8 @@ BGEffects_LoadBGPal0_OBPal1: ; c8e52 (32:4e52)
 	ld b, a
 	ld c, $1
 	call CopyPals
-	ld hl, OBPals + 8
-	ld de, UnknOBPals + 8
+	ld hl, OBPals palette 1
+	ld de, UnknOBPals palette 1
 	pop af
 	ld b, a
 	ld c, $1
@@ -2610,8 +2610,8 @@ BGEffects_LoadBGPal1_OBPal0: ; c8e7f (32:4e7f)
 	ld a, h
 	push bc
 	push af
-	ld hl, BGPals + 8
-	ld de, UnknBGPals + 8
+	ld hl, BGPals palette 1
+	ld de, UnknBGPals palette 1
 	ld b, a
 	ld c, $1
 	call CopyPals

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -2583,13 +2583,13 @@ BGEffects_LoadBGPal0_OBPal1: ; c8e52 (32:4e52)
 	ld a, h
 	push bc
 	push af
-	ld hl, BGPals
-	ld de, UnknBGPals
+	ld hl, wBGPals2
+	ld de, wBGPals1
 	ld b, a
 	ld c, $1
 	call CopyPals
-	ld hl, OBPals palette 1
-	ld de, UnknOBPals palette 1
+	ld hl, wOBPals2 palette 1
+	ld de, wOBPals1 palette 1
 	pop af
 	ld b, a
 	ld c, $1
@@ -2610,13 +2610,13 @@ BGEffects_LoadBGPal1_OBPal0: ; c8e7f (32:4e7f)
 	ld a, h
 	push bc
 	push af
-	ld hl, BGPals palette 1
-	ld de, UnknBGPals palette 1
+	ld hl, wBGPals2 palette 1
+	ld de, wBGPals1 palette 1
 	ld b, a
 	ld c, $1
 	call CopyPals
-	ld hl, OBPals ; OBPals
-	ld de, UnknOBPals ; wd040
+	ld hl, wOBPals2
+	ld de, wOBPals1
 	pop af
 	ld b, a
 	ld c, $1

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -1652,7 +1652,7 @@ CardFlip_InitAttrPals: ; e0c37 (38:4c37)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, .palettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 9 palettes
 	call CopyBytes
 	pop af

--- a/engine/cgb_layouts.asm
+++ b/engine/cgb_layouts.asm
@@ -68,21 +68,21 @@ Predef_LoadSGBLayoutCGB: ; 8d59
 
 _CGB_BattleGrayscale: ; 8db8
 	ld hl, PalPacket_9c66 + 1
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld c, 4
 	call CopyPalettes
 	ld hl, PalPacket_9c66 + 1
-	ld de, UnknBGPals palette PAL_BATTLE_BG_EXP
+	ld de, wBGPals1 palette PAL_BATTLE_BG_EXP
 	ld c, 4
 	call CopyPalettes
 	ld hl, PalPacket_9c66 + 1
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld c, 2
 	call CopyPalettes
 	jr _CGB_FinishBattleScreenLayout
 
 _CGB_BattleColors: ; 8ddb
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	call GetBattlemonBackpicPalettePointer
 	push hl
 	call LoadPalette_White_Col1_Col2_Black ; PAL_BATTLE_BG_PLAYER
@@ -107,7 +107,7 @@ _CGB_BattleColors: ; 8ddb
 	call LoadPalette_White_Col1_Col2_Black ; PAL_BATTLE_BG_PLAYER_HP
 	ld hl, ExpBarPalette
 	call LoadPalette_White_Col1_Col2_Black ; PAL_BATTLE_BG_EXP
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	pop hl
 	call LoadPalette_White_Col1_Col2_Black ; PAL_BATTLE_OB_ENEMY
 	pop hl
@@ -146,9 +146,9 @@ _CGB_FinishBattleScreenLayout: ; 8e23
 	ld a, PAL_BATTLE_BG_TEXT
 	call ByteFill
 	ld hl, BattleObjectPals
-	ld de, UnknOBPals palette PAL_BATTLE_OB_GRAY
+	ld de, wOBPals1 palette PAL_BATTLE_OB_GRAY
 	ld bc, 6 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	call ApplyAttrMap
 	ret
@@ -162,9 +162,9 @@ Mobile_InitPartyMenuBGPal7: ; 8e8b
 	jr nc, .not_mobile
 	ld hl, Palette_b309
 .not_mobile
-	ld de, UnknBGPals palette 7
+	ld de, wBGPals1 palette 7
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 ; 8e9f
@@ -175,9 +175,9 @@ InitPartyMenuBGPal0: ; 8e9f
 	jr nc, .not_mobile
 	ld hl, Palette_b309
 .not_mobile
-	ld de, UnknBGPals palette 0
+	ld de, wBGPals1 palette 0
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 ; 8eb9
@@ -192,9 +192,9 @@ _CGB_PokegearPals: ; 8eb9
 .male
 	ld hl, MalePokegearPals
 .got_pals
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 6 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call ApplyPals
 	ld a, $1
@@ -203,7 +203,7 @@ _CGB_PokegearPals: ; 8eb9
 ; 8edb
 
 _CGB_StatsScreenHPPals: ; 8edb
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, [wCurHPPal]
 	ld l, a
 	ld h, $0
@@ -219,9 +219,9 @@ _CGB_StatsScreenHPPals: ; 8edb
 	ld hl, ExpBarPalette
 	call LoadPalette_White_Col1_Col2_Black ; exp palette
 	ld hl, StatsScreenPagePals
-	ld de, UnknBGPals palette 3
+	ld de, wBGPals1 palette 3
 	ld bc, 3 palettes ; pink, green, and blue page palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call WipeAttrMap
 
@@ -285,7 +285,7 @@ StatsScreenPals: ; 8f6a
 ; 8f70
 
 _CGB_Pokedex: ; 8f70
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $1d
 	call GetPredefPal
 	call LoadHLPaletteIntoDE ; dex interface palette
@@ -307,9 +307,9 @@ _CGB_Pokedex: ; 8f70
 	call FillBoxCGB
 	call InitPartyMenuOBPals
 	ld hl, .PokedexCursorPalette
-	ld de, UnknOBPals palette 7 ; green cursor palette
+	ld de, wOBPals1 palette 7 ; green cursor palette
 	ld bc, 1 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	call ApplyAttrMap
 	call ApplyPals
@@ -332,7 +332,7 @@ _CGB_Pokedex: ; 8f70
 ; 8fca
 
 _CGB_BillsPC: ; 8fca
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $1d
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -392,7 +392,7 @@ _CGB_BillsPC: ; 8fca
 ; 903e
 
 _CGB_PokedexUnownMode: ; 903e
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $1d
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -414,9 +414,9 @@ _CGB_PokedexUnownMode: ; 903e
 
 _CGB_SlotMachine: ; 906e
 	ld hl, SlotMachinePals
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call WipeAttrMap
 	hlcoord 0, 2, AttrMap
@@ -470,7 +470,7 @@ _CGB06: ; 90f8
 	ld hl, PalPacket_9ca6 + 1
 	call CopyFourPalettes
 	call WipeAttrMap
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $3c
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -504,12 +504,12 @@ _CGB07: ; 9122
 
 .Function9133: ; 9133
 	ld hl, .Palette_914e
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	call LoadHLPaletteIntoDE
 	ld hl, .Palette_9156
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 2 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	call WipeAttrMap
 	ret
@@ -534,12 +534,12 @@ _CGB07: ; 9122
 ; 9166
 
 .Function9166: ; 9166
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $38
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
 
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $39
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -550,7 +550,7 @@ _CGB07: ; 9122
 .Function9180: ; 9180
 	ld hl, PalPacket_9c36 + 1
 	call CopyFourPalettes
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $3a
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -560,9 +560,9 @@ _CGB07: ; 9122
 
 _CGB11: ; 9195
 	ld hl, Palettes_b789
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 5 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call ApplyPals
 	call WipeAttrMap
@@ -572,9 +572,9 @@ _CGB11: ; 9195
 
 _CGB_Diploma: ; 91ad
 	ld hl, DiplomaPalettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 
 	ld hl, PalPacket_9cb6 + 1
@@ -602,7 +602,7 @@ _CGB_PartyMenu: ; 91d1
 ; 91e4
 
 _CGB_Evolution: ; 91e4
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, c
 	and a
 	jr z, .pokemon
@@ -622,9 +622,9 @@ _CGB_Evolution: ; 91e4
 	call GetPlayerOrMonPalettePointer
 	call LoadPalette_White_Col1_Col2_Black
 	ld hl, BattleObjectPals
-	ld de, UnknOBPals palette PAL_BATTLE_OB_GRAY
+	ld de, wOBPals1 palette PAL_BATTLE_OB_GRAY
 	ld bc, 6 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 
 .got_palette
@@ -638,14 +638,14 @@ _CGB_Evolution: ; 91e4
 
 _CGB0c: ; 9228
 	ld hl, Palettes_b6f1
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 5 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ld hl, Palettes_b719
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 2 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	ld a, SCGB_DIPLOMA
 	ld [SGBPredef], a
@@ -666,15 +666,15 @@ _CGB0d: ; 9251
 _CGB_UnownPuzzle: ; 925e
 	ld hl, PalPacket_9bc6 + 1
 	call CopyFourPalettes
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $4c
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	ld [rSVBK], a
-	ld hl, UnknOBPals
+	ld hl, wOBPals1
 	ld a, $1f
 	ld [hli], a
 	ld a, $0
@@ -687,7 +687,7 @@ _CGB_UnownPuzzle: ; 925e
 ; 9289
 
 _CGB_TrainerCard: ; 9289
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	xor a ; CHRIS
 	call GetTrainerPalettePointer
 	call LoadPalette_White_Col1_Col2_Black
@@ -793,7 +793,7 @@ _CGB_TrainerCard: ; 9289
 ; 9373
 
 _CGB_MoveList: ; 9373
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $10
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -829,7 +829,7 @@ _CGB0f: ; 93a6
 ; 93ba
 
 _CGB_PokedexSearchOption: ; 93ba
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $1d
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -858,9 +858,9 @@ _CGB_PackPals: ; 93d3
 	ld hl, .ChrisPackPals
 
 .got_gender
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes ; 6 palettes?
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call WipeAttrMap
 	hlcoord 0, 0, AttrMap
@@ -953,15 +953,15 @@ _CGB13: ; 94d0
 ; 94fa
 
 _CGB_GamefreakLogo: ; 94fa
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, $4e
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
 	ld hl, .Palette
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	call LoadHLPaletteIntoDE
 	ld hl, .Palette
-	ld de, UnknOBPals palette 1
+	ld de, wOBPals1 palette 1
 	call LoadHLPaletteIntoDE
 	call WipeAttrMap
 	call ApplyAttrMap
@@ -977,7 +977,7 @@ _CGB_GamefreakLogo: ; 94fa
 ; 9529
 
 _CGB_PlayerOrMonFrontpicPals: ; 9529
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, [CurPartySpecies]
 	ld bc, TempMonDVs
 	call GetPlayerOrMonPalettePointer
@@ -989,7 +989,7 @@ _CGB_PlayerOrMonFrontpicPals: ; 9529
 ; 9542
 
 _CGB1e: ; 9542
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, [CurPartySpecies]
 	call GetMonPalettePointer_
 	call LoadPalette_White_Col1_Col2_Black
@@ -1002,11 +1002,11 @@ _CGB_TradeTube: ; 9555
 	ld hl, PalPacket_9cc6 + 1
 	call CopyFourPalettes
 	ld hl, PartyMenuOBPals
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 1 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
-	ld de, UnknOBPals palette 7
+	ld de, wOBPals1 palette 7
 	ld a, $1c
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
@@ -1015,7 +1015,7 @@ _CGB_TradeTube: ; 9555
 ; 9578
 
 _CGB_TrainerOrMonFrontpicPals: ; 9578
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, [CurPartySpecies]
 	ld bc, TempMonDVs
 	call GetFrontpicPalettePointer
@@ -1028,9 +1028,9 @@ _CGB_TrainerOrMonFrontpicPals: ; 9578
 
 _CGB_MysteryGift: ; 9591
 	ld hl, .Palettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 2 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call ApplyPals
 	call WipeAttrMap

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -142,13 +142,13 @@ Function8b07:
 	ret z
 ; CGB only
 	ld hl, .BGPal
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM
 
 	ld hl, .OBPal
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -191,7 +191,7 @@ Function8b4d:
 	jp PushSGBPals_
 
 .cgb
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $3b
 	call GetPredefPal
 	jp LoadHLPaletteIntoDE
@@ -207,7 +207,7 @@ Function8b67:
 	jp PushSGBPals_
 
 .cgb
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, $3c
 	call GetPredefPal
 	jp LoadHLPaletteIntoDE
@@ -239,7 +239,7 @@ Function8b81:
 	jp PushSGBPals_
 
 .cgb
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld a, c
 	call GetMonPalettePointer_
 	call LoadPalette_White_Col1_Col2_Black
@@ -265,7 +265,7 @@ LoadMonPaletteAsNthBGPal:
 
 got_palette_pointer_8bd7
 	push hl
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld de, 1 palettes
 .loop
 	and a
@@ -327,7 +327,7 @@ ApplyMonOrTrainerPals:
 	call GetTrainerPalettePointer
 
 .load_palettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	call LoadPalette_White_Col1_Col2_Black
 	call WipeAttrMap
 	call ApplyAttrMap
@@ -345,11 +345,11 @@ ApplyHPBarPals:
 	ret
 
 .Enemy:
-	ld de, BGPals palette PAL_BATTLE_BG_ENEMY_HP + 2
+	ld de, wBGPals2 palette PAL_BATTLE_BG_ENEMY_HP + 2
 	jr .okay
 
 .Player:
-	ld de, BGPals palette PAL_BATTLE_BG_PLAYER_HP + 2
+	ld de, wBGPals2 palette PAL_BATTLE_BG_PLAYER_HP + 2
 
 .okay
 	ld l, c
@@ -397,11 +397,11 @@ LoadStatsScreenPals:
 	ld a, $5
 	ld [rSVBK], a
 	ld a, [hli]
-	ld [UnknBGPals palette 0], a
-	ld [UnknBGPals palette 2], a
+	ld [wBGPals1 palette 0], a
+	ld [wBGPals1 palette 2], a
 	ld a, [hl]
-	ld [UnknBGPals palette 0 + 1], a
-	ld [UnknBGPals palette 2 + 1], a
+	ld [wBGPals1 palette 0 + 1], a
+	ld [wBGPals1 palette 2 + 1], a
 	pop af
 	ld [rSVBK], a
 	call ApplyPals
@@ -441,7 +441,7 @@ LoadMailPalettes:
 	ret
 
 .cgb
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -458,7 +458,7 @@ INCLUDE "engine/cgb_layouts.asm"
 Function95f0:
 ; XXX
 	ld hl, .Palette
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -474,7 +474,7 @@ Function95f0:
 	RGB 00, 03, 19
 
 CopyFourPalettes:
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld c, $4
 
 CopyPalettes:
@@ -575,7 +575,7 @@ ResetBGPals:
 	ld a, $5
 	ld [rSVBK], a
 
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld c, 1 palettes
 .loop
 	ld a, $ff
@@ -608,8 +608,8 @@ WipeAttrMap:
 	ret
 
 ApplyPals:
-	ld hl, UnknBGPals
-	ld de, BGPals
+	ld hl, wBGPals1
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -686,7 +686,7 @@ CGB_ApplyPartyMenuHPPals: ; 96f3
 
 InitPartyMenuOBPals:
 	ld hl, PartyMenuOBPals
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 2 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -759,7 +759,7 @@ Function9779: mobile
 	dec c
 	jr nz, .loop
 	ld hl, BattleObjectPals
-	ld de, UnknOBPals palette 2
+	ld de, wOBPals1 palette 2
 	ld bc, 2 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -932,9 +932,9 @@ InitCGBPals::
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call .LoadWhitePals
-	ld hl, BGPals
+	ld hl, wBGPals2
 	call .LoadWhitePals
 	pop af
 	ld [rSVBK], a
@@ -1253,7 +1253,7 @@ LoadMapPals:
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld b, 8
 .outer_loop
 	ld a, [de] ; lookup index for TilesetBGPalette
@@ -1289,9 +1289,9 @@ LoadMapPals:
 	ld bc, 8 palettes
 	ld hl, MapObjectPals
 	call AddNTimes
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 8 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 
 	ld a, [wEnvironment]
@@ -1316,7 +1316,7 @@ rept 4
 	inc hl
 endr
 .morn_day
-	ld de, UnknBGPals palette PAL_BG_ROOF + 2
+	ld de, wBGPals1 palette PAL_BG_ROOF + 2
 	ld bc, 4
 	ld a, $5
 	call FarCopyWRAM

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -908,7 +908,7 @@ InitCGBPals::
 	call ByteFill
 	ld a, $0
 	ld [rVBK], a
-	ld a, $80
+	ld a, 1 << rBGPI_AUTO_INCREMENT
 	ld [rBGPI], a
 	ld c, 4 * 8
 .bgpals_loop
@@ -918,7 +918,7 @@ InitCGBPals::
 	ld [rBGPD], a
 	dec c
 	jr nz, .bgpals_loop
-	ld a, $80
+	ld a, 1 << rOBPI_AUTO_INCREMENT
 	ld [rOBPI], a
 	ld c, 4 * 8
 .obpals_loop

--- a/engine/credits.asm
+++ b/engine/credits.asm
@@ -520,20 +520,20 @@ GetCreditsPalette: ; 109b2c
 ; Update the first three colors in both palette buffers.
 	push af
 	push hl
-	add LOW(UnknBGPals)
+	add LOW(wBGPals1)
 	ld e, a
 	ld a, 0
-	adc HIGH(UnknBGPals)
+	adc HIGH(wBGPals1)
 	ld d, a
 	ld bc, 24
 	call CopyBytes
 
 	pop hl
 	pop af
-	add LOW(BGPals)
+	add LOW(wBGPals2)
 	ld e, a
 	ld a, 0
-	adc HIGH(BGPals)
+	adc HIGH(wBGPals2)
 	ld d, a
 	ld bc, 24
 	call CopyBytes

--- a/engine/crystal_colors.asm
+++ b/engine/crystal_colors.asm
@@ -54,15 +54,15 @@ MG_Mobile_Layout_WipeAttrMap: ; 49346 (12:5346)
 	ret
 
 MG_Mobile_Layout_LoadPals: ; 49351 (12:5351)
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld hl, Palette_493e1
 	ld bc, 5 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
-	ld de, UnknBGPals palette PAL_BG_TEXT
+	ld de, wBGPals1 palette PAL_BG_TEXT
 	ld hl, Palette_TextBG7
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 
@@ -118,9 +118,9 @@ INCLUDE "data/palettes/mg_mobile.pal"
 
 LoadOW_BGPal7:: ; 49409
 	ld hl, Palette_TextBG7
-	ld de, UnknBGPals palette PAL_BG_TEXT
+	ld de, wBGPals1 palette PAL_BG_TEXT
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 ; 49418
@@ -131,19 +131,19 @@ INCLUDE "data/palettes/overworld/bg_text.pal"
 
 Function49420:: ; 49420 (12:5420)
 	ld hl, MansionPalette4
-	ld de, UnknBGPals palette PAL_BG_ROOF
+	ld de, wBGPals1 palette PAL_BG_ROOF
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 ; 4942f (12:542f)
 
 MG_Mobile_Layout01: ; 4942f
 	call MG_Mobile_Layout_LoadPals
-	ld de, UnknBGPals palette PAL_BG_TEXT
+	ld de, wBGPals1 palette PAL_BG_TEXT
 	ld hl, .Palette_49478
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call MG_Mobile_Layout_WipeAttrMap
 	hlcoord 0, 0, AttrMap
@@ -208,17 +208,17 @@ INCLUDE "tilesets/special_palettes.asm"
 
 MG_Mobile_Layout02: ; 49706
 	ld hl, .Palette_49732
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 1 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	farcall ApplyPals
 	call MG_Mobile_Layout_WipeAttrMap
 	farcall ApplyAttrMap
 	ld hl, .Palette_4973a
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 1 palettes
-	ld a, BANK(UnknOBPals)
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	ret
 ; 49732
@@ -239,7 +239,7 @@ MG_Mobile_Layout02: ; 49706
 
 Function49742: ; 49742
 	ld hl, .Palette_49757
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -305,9 +305,9 @@ _InitMG_Mobile_LinkTradePalMap: ; 49797
 
 LoadTradeRoomBGPals: ; 49811
 	ld hl, TradeRoomPalette
-	ld de, UnknBGPals palette PAL_BG_GREEN
+	ld de, wBGPals1 palette PAL_BG_GREEN
 	ld bc, 6 palettes
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	farcall ApplyPals
 	ret

--- a/engine/crystal_intro.asm
+++ b/engine/crystal_intro.asm
@@ -1532,7 +1532,7 @@ Intro_Scene24_ApplyPaletteFade: ; e5172 (39:5172)
 	ld b, 8 ; number of BG pals
 .loop1
 	push hl
-	ld c, 8 ; number of bytes per pal
+	ld c, 1 palettes
 .loop2
 	ld a, [hli]
 	ld [de], a
@@ -1735,7 +1735,7 @@ Intro_Scene20_AppearUnown: ; e5348 (39:5348)
 	adc d
 	ld d, a
 
-	ld bc, 8
+	ld bc, 1 palettes
 	call CopyBytes
 	pop bc
 
@@ -1747,7 +1747,7 @@ Intro_Scene20_AppearUnown: ; e5348 (39:5348)
 	adc d
 	ld d, a
 
-	ld bc, 8
+	ld bc, 1 palettes
 	call CopyBytes
 
 	pop af
@@ -1950,7 +1950,7 @@ Intro_ClearBGPals: ; e54a3 (39:54a3)
 	ld [rSVBK], a
 
 	ld hl, BGPals
-	ld bc, 16 * 8
+	ld bc, 16 palettes
 	xor a
 	call ByteFill
 

--- a/engine/crystal_intro.asm
+++ b/engine/crystal_intro.asm
@@ -322,9 +322,9 @@ GameFreakLogoScene4: ; e4776 (39:4776)
 	ld a, $5
 	ld [rSVBK], a
 	ld a, [hli]
-	ld [OBPals + 12], a
+	ld [wOBPals2 + 12], a
 	ld a, [hli]
-	ld [OBPals + 13], a
+	ld [wOBPals2 + 13], a
 	pop af
 	ld [rSVBK], a
 	ld a, $1
@@ -483,11 +483,11 @@ IntroScene1: ; e495b (39:495b)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_365ad
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_365ad
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -556,11 +556,11 @@ IntroScene3: ; e49fd (39:49fd)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e5edd
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e5edd
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -622,11 +622,11 @@ IntroScene5: ; e4a7a (39:4a7a)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_365ad
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_365ad
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -729,12 +729,12 @@ IntroScene7: ; e4b3f (39:4b3f)
 	ld [rSVBK], a
 
 	ld hl, Palette_e5edd
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 
 	ld hl, Palette_e5edd
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 
@@ -887,11 +887,11 @@ IntroScene11: ; e4c86 (39:4c86)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_365ad
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_365ad
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1014,11 +1014,11 @@ IntroScene13: ; e4d6d (39:4d6d)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e5edd
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e5edd
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1123,11 +1123,11 @@ IntroScene15: ; e4e40 (39:4e40)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e77dd
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e77dd
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1197,11 +1197,11 @@ IntroScene17: ; e4ef5 (39:4ef5)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e6d6d
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e6d6d
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1271,11 +1271,11 @@ IntroScene19: ; e4f7e (39:4f7e)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e77dd
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e77dd
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1441,11 +1441,11 @@ IntroScene26: ; e50bb (39:50bb)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_e679d
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	ld hl, Palette_e679d
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
@@ -1516,7 +1516,7 @@ IntroScene28: ; e5152 (39:5152)
 	ret
 
 Intro_Scene24_ApplyPaletteFade: ; e5172 (39:5172)
-; load the (a)th palette from .FadePals to all BGPals
+; load the (a)th palette from .FadePals to all wBGPals2
 	ld hl, .FadePals
 	add l
 	ld l, a
@@ -1528,7 +1528,7 @@ Intro_Scene24_ApplyPaletteFade: ; e5172 (39:5172)
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld de, BGPals
+	ld de, wBGPals2
 	ld b, 8 ; number of BG pals
 .loop1
 	push hl
@@ -1599,7 +1599,7 @@ CrystalIntro_UnownFade: ; e5223 (39:5223)
 	add a
 	ld e, a
 	ld d, $0
-	ld hl, BGPals
+	ld hl, wBGPals2
 	add hl, de
 	inc hl
 	inc hl
@@ -1622,7 +1622,7 @@ CrystalIntro_UnownFade: ; e5223 (39:5223)
 
 	push hl
 	push bc
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld bc, 8 palettes
 	xor a
 	call ByteFill
@@ -1726,7 +1726,7 @@ Intro_Scene20_AppearUnown: ; e5348 (39:5348)
 	ld [rSVBK], a
 
 	push bc
-	ld de, BGPals
+	ld de, wBGPals2
 
 	ld a, c
 	add e
@@ -1739,7 +1739,7 @@ Intro_Scene20_AppearUnown: ; e5348 (39:5348)
 	call CopyBytes
 	pop bc
 
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld a, c
 	add e
 	ld e, a
@@ -1779,7 +1779,7 @@ Intro_FadeUnownWordPals: ; e539d (39:539d)
 	add a
 	ld e, a
 	ld d, $0
-	ld hl, BGPals
+	ld hl, wBGPals2
 	add hl, de
 rept 4
 	inc hl
@@ -1949,7 +1949,7 @@ Intro_ClearBGPals: ; e54a3 (39:54a3)
 	ld a, $5
 	ld [rSVBK], a
 
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld bc, 16 palettes
 	xor a
 	call ByteFill

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -158,7 +158,7 @@ Function819a7: ; 819a7
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_819f4
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	ld a, $80
@@ -438,7 +438,7 @@ Function81c33: ; 81c33
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld de, wc608
 	ld c, $1
 	call Function81ee3
@@ -1153,7 +1153,7 @@ Function8220f: ; 8220f
 	add hl, hl
 	add hl, hl
 	add hl, hl
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	add hl, de
 	ld de, wc608
 	ld bc, 8
@@ -1200,7 +1200,7 @@ Function82236: ; 82236
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld a, [wcf64]
 	ld bc, 1 palettes
 	call AddNTimes
@@ -1230,7 +1230,7 @@ Function822a3: ; 822a3
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld a, [wcf64]
 	ld bc, 1 palettes
 	call AddNTimes

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -1202,10 +1202,10 @@ Function82236: ; 82236
 	ld [rSVBK], a
 	ld hl, BGPals
 	ld a, [wcf64]
-	ld bc, 8
+	ld bc, 1 palettes
 	call AddNTimes
 	ld de, wc608
-	ld bc, 8
+	ld bc, 1 palettes
 	call CopyBytes
 	pop af
 	ld [rSVBK], a
@@ -1232,12 +1232,12 @@ Function822a3: ; 822a3
 	ld [rSVBK], a
 	ld hl, BGPals
 	ld a, [wcf64]
-	ld bc, 8
+	ld bc, 1 palettes
 	call AddNTimes
 	ld e, l
 	ld d, h
 	ld hl, wc608
-	ld bc, 8
+	ld bc, 1 palettes
 	call CopyBytes
 	hlcoord 1, 0
 	ld de, wc608

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -161,19 +161,19 @@ Function819a7: ; 819a7
 	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
-	ld a, $80
+	ld a, 1 << rBGPI_AUTO_INCREMENT
 	ld [rBGPI], a
 	ld hl, Palette_819f4
-	ld c, $40
+	ld c, 8 palettes
 	xor a
 .asm_819c8
 	ld [rBGPD], a
 	dec c
 	jr nz, .asm_819c8
-	ld a, $80
+	ld a, 1 << rOBPI_AUTO_INCREMENT
 	ld [rOBPI], a
 	ld hl, Palette_81a34
-	ld c, $40
+	ld c, 8 palettes
 .asm_819d6
 	ld a, [hli]
 	ld [rOBPD], a

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -158,7 +158,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 
 .cgb
 	ld hl, .palettes
-	ld de, OBPals palette PAL_OW_TREE
+	ld de, wOBPals2 palette PAL_OW_TREE
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM
@@ -201,7 +201,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 	ld a, $5
 	ld [rSVBK], a
 
-	ld hl, OBPals palette PAL_OW_TREE
+	ld hl, wOBPals2 palette PAL_OW_TREE
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -28,7 +28,7 @@ LoadPoisonBGPals: ; cbcdd
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld c, 4 palettes
 .loop
 ; RGB 28, 21, 31

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -29,7 +29,7 @@ LoadPoisonBGPals: ; cbcdd
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, BGPals
-	ld c, $20
+	ld c, 4 palettes
 .loop
 ; RGB 28, 21, 31
 	ld a, LOW(palred 28 + palgreen 21 + palblue 31)

--- a/engine/init_gender.asm
+++ b/engine/init_gender.asm
@@ -88,7 +88,7 @@ InitGenderScreen: ; 48e14 (12:4e14)
 
 LoadGenderScreenPal: ; 48e47 (12:4e47)
 	ld hl, .Palette
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 1 palettes
 	ld a, $5
 	call FarCopyWRAM

--- a/engine/init_hof_credits.asm
+++ b/engine/init_hof_credits.asm
@@ -43,7 +43,7 @@ InitDisplayForRedCredits: ; 4e8c2
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	xor a
 	call ByteFill
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld c, 4 tiles
 .load_white_palettes
 	ld a, LOW(palred 31 + palgreen 31 + palblue 31)

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -2351,7 +2351,7 @@ Pokedex_BlackOutBG: ; 41401 (10:5401)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, UnknBGPals
-	ld bc, $40
+	ld bc, 8 palettes
 	xor a
 	call ByteFill
 	pop af

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -2350,7 +2350,7 @@ Pokedex_BlackOutBG: ; 41401 (10:5401)
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld bc, 8 palettes
 	xor a
 	call ByteFill

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -42,7 +42,7 @@ _TimeOfDayPals:: ; 8c011
 	ld [TimeOfDayPal], a
 
 ; save bg palette 7
-	ld hl, UnknBGPals palette PAL_BG_TEXT
+	ld hl, wBGPals1 palette PAL_BG_TEXT
 
 ; save wram bank
 	ld a, [rSVBK]
@@ -73,7 +73,7 @@ _TimeOfDayPals:: ; 8c011
 
 
 ; restore bg palette 7
-	ld hl, UnknOBPals - 1 ; last byte in UnknBGPals
+	ld hl, wOBPals1 - 1 ; last byte in wBGPals1
 
 ; save wram bank
 	ld a, [rSVBK]
@@ -176,12 +176,12 @@ FillWhiteBGColor: ; 8c0c1
 	ld a, $5
 	ld [rSVBK], a
 
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	ld hl, UnknBGPals + 1 palettes
+	ld hl, wBGPals1 + 1 palettes
 	ld c, 6
 .loop
 	ld a, e

--- a/engine/title.asm
+++ b/engine/title.asm
@@ -144,12 +144,12 @@ _TitleScreen: ; 10ed67
 
 ; Update palette colors
 	ld hl, TitleScreenPalettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 
 	ld hl, TitleScreenPalettes
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 
@@ -220,7 +220,7 @@ _TitleScreen: ; 10ed67
 	ld [hBGMapMode], a
 
 	xor a
-	ld [UnknBGPals + 2], a
+	ld [wBGPals1 + 2], a
 
 ; Play starting sound effect
 	call SFXChannelsOff
@@ -231,7 +231,7 @@ _TitleScreen: ; 10ed67
 ; 10eea7
 
 SuicuneFrameIterator: ; 10eea7
-	ld hl, UnknBGPals + 2
+	ld hl, wBGPals1 + 2
 	ld a, [hl]
 	ld c, a
 	inc [hl]

--- a/engine/unused_title.asm
+++ b/engine/unused_title.asm
@@ -67,22 +67,22 @@ UnusedTitleScreen: ; 10c000
 	ld [rSVBK], a
 
 	ld hl, UnusedTitleBG_Palettes
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 
 	ld hl, UnusedTitleFG_Palettes
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 8 palettes
 	call CopyBytes
 
 	ld hl, UnusedTitleBG_Palettes
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 8 palettes
 	call CopyBytes
 
 	ld hl, UnusedTitleFG_Palettes
-	ld de, OBPals
+	ld de, wOBPals2
 	ld bc, 8 palettes
 	call CopyBytes
 

--- a/home.asm
+++ b/home.asm
@@ -680,11 +680,11 @@ ClearPalettes:: ; 3317
 	ld a, [rSVBK]
 	push af
 
-	ld a, BANK(BGPals)
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
-; Fill BGPals and OBPals with $ffff (white)
-	ld hl, BGPals
+; Fill wBGPals2 and wOBPals2 with $ffff (white)
+	ld hl, wBGPals2
 	ld bc, 16 palettes
 	ld a, $ff
 	call ByteFill

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -2,8 +2,8 @@
 
 
 UpdatePalsIfCGB:: ; c2f
-; update bgp data from BGPals
-; update obp data from OBPals
+; update bgp data from wBGPals2
+; update obp data from wOBPals2
 ; return carry if successful
 
 ; check cgb
@@ -24,10 +24,10 @@ ForceUpdateCGBPals:: ; c37
 
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(BGPals)
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
-	ld hl, BGPals
+	ld hl, wBGPals2
 
 ; copy 8 pals to bgpd
 	ld a, %10000000 ; auto increment, index 0
@@ -43,7 +43,7 @@ endr
 	dec b
 	jr nz, .bgp
 
-; hl is now OBPals
+; hl is now wOBPals2
 
 ; copy 8 pals to obpd
 	ld a, %10000000 ; auto increment, index 0
@@ -90,12 +90,12 @@ DmgToCgbBGPals:: ; c9f
 	ld a, [rSVBK]
 	push af
 
-	ld a, BANK(BGPals)
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
 ; copy & reorder bg pal buffer
-	ld hl, BGPals ; to
-	ld de, UnknBGPals ; from
+	ld hl, wBGPals2 ; to
+	ld de, wBGPals1 ; from
 ; order
 	ld a, [rBGP]
 	ld b, a
@@ -138,12 +138,12 @@ DmgToCgbObjPals:: ; ccb
 	ld a, [rSVBK]
 	push af
 
-	ld a, BANK(OBPals)
+	ld a, BANK(wOBPals2)
 	ld [rSVBK], a
 
 ; copy & reorder obj pal buffer
-	ld hl, OBPals ; to
-	ld de, UnknOBPals ; from
+	ld hl, wOBPals2 ; to
+	ld de, wOBPals1 ; from
 ; order
 	ld a, [rOBP0]
 	ld b, a
@@ -178,11 +178,11 @@ DmgToCgbObjPal0:: ; cf8
 
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(OBPals)
+	ld a, BANK(wOBPals2)
 	ld [rSVBK], a
 
-	ld hl, OBPals palette 0
-	ld de, UnknOBPals palette 0
+	ld hl, wOBPals2 palette 0
+	ld de, wOBPals1 palette 0
 	ld a, [rOBP0]
 	ld b, a
 	ld c, 1
@@ -216,11 +216,11 @@ DmgToCgbObjPal1:: ; d24
 
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(OBPals)
+	ld a, BANK(wOBPals2)
 	ld [rSVBK], a
 
-	ld hl, OBPals palette 1
-	ld de, UnknOBPals palette 1
+	ld hl, wOBPals2 palette 1
+	ld de, wOBPals1 palette 1
 	ld a, [rOBP1]
 	ld b, a
 	ld c, 1
@@ -325,9 +325,9 @@ Special_ReloadSpritesNoPalettes:: ; d91
 	ret z
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(BGPals)
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
-	ld hl, BGPals
+	ld hl, wBGPals2
 	ld bc, (8 palettes) + (2 palettes)
 	xor a
 	call ByteFill

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -30,7 +30,7 @@ ForceUpdateCGBPals:: ; c37
 	ld hl, wBGPals2
 
 ; copy 8 pals to bgpd
-	ld a, %10000000 ; auto increment, index 0
+	ld a, 1 << rBGPI_AUTO_INCREMENT
 	ld [rBGPI], a
 	ld c, LOW(rBGPD)
 	ld b, 8 / 2
@@ -46,7 +46,7 @@ endr
 ; hl is now wOBPals2
 
 ; copy 8 pals to obpd
-	ld a, %10000000 ; auto increment, index 0
+	ld a, 1 << rOBPI_AUTO_INCREMENT
 	ld [rOBPI], a
 	ld c, LOW(rOBPD)
 	ld b, 8 / 2

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -2921,7 +2921,7 @@ Function11d323: ; 11d323
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_11d33a
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af

--- a/mobile/mobile_22.asm
+++ b/mobile/mobile_22.asm
@@ -631,7 +631,7 @@ Function8949c: ; 8949c
 	ld a, 5
 	ld [rSVBK], a
 	ld hl, Palette_894b3
-	ld de, UnknBGPals palette 7
+	ld de, wBGPals1 palette 7
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
@@ -682,11 +682,11 @@ Function894dc: ; 894dc
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 3 palettes
 	call CopyBytes
 	ld hl, .Pals345
-	ld de, UnknBGPals + 3 palettes
+	ld de, wBGPals1 + 3 palettes
 	ld bc, 3 palettes
 	call CopyBytes
 
@@ -2161,7 +2161,7 @@ Function89d0d: ; 89d0d (22:5d0d)
 	ld [rSVBK], a
 
 	ld c, 8
-	ld de, UnknBGPals
+	ld de, wBGPals1
 .loop
 	push bc
 	ld hl, .Palette1
@@ -2172,7 +2172,7 @@ Function89d0d: ; 89d0d (22:5d0d)
 	jr nz, .loop
 
 	ld hl, .Palette2
-	ld de, UnknBGPals + 2 palettes
+	ld de, wBGPals1 + 2 palettes
 	ld bc, 1 palettes
 	call CopyBytes
 
@@ -2394,7 +2394,7 @@ Function89e9a: ; 89e9a (22:5e9a)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_89eb1
-	ld de, UnknBGPals palette 5
+	ld de, wBGPals1 palette 5
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
@@ -3399,15 +3399,15 @@ Function8a5b6: ; 8a5b6 (22:65b6)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_8a5e5
-	ld de, UnknBGPals + 4 palettes
+	ld de, wBGPals1 + 4 palettes
 	ld bc, 3 palettes
 	call CopyBytes
 	ld hl, Palette_8a5fd
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 1 palettes
 	call CopyBytes
 	ld hl, Palette_8a605
-	ld de, UnknOBPals + 1 palettes
+	ld de, wOBPals1 + 1 palettes
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
@@ -3452,7 +3452,7 @@ Function8a60d: ; 8a60d
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_8a624
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af

--- a/mobile/mobile_22_2.asm
+++ b/mobile/mobile_22_2.asm
@@ -620,7 +620,7 @@ Function8b6bb: ; 8b6bb
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_8b6d5
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 3 palettes
 	call CopyBytes
 	pop af

--- a/mobile/mobile_22_2.asm
+++ b/mobile/mobile_22_2.asm
@@ -621,7 +621,7 @@ Function8b6bb: ; 8b6bb
 	ld [rSVBK], a
 	ld hl, Palette_8b6d5
 	ld de, UnknBGPals
-	ld bc, $0018
+	ld bc, 3 palettes
 	call CopyBytes
 	pop af
 	ld [rSVBK], a

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -6853,7 +6853,7 @@ Function102dd3: ; 102dd3
 
 Function102dec: ; 102dec
 	ld hl, Palettes_1032e2
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 4 palettes
 	ld a, $05
 	call FarCopyWRAM

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -836,7 +836,7 @@ MobileTradeAnim_02: ; 108638
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_109107
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
@@ -882,7 +882,7 @@ MobileTradeAnim_10: ; 108689
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_109107
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
@@ -926,7 +926,7 @@ MobileTradeAnim_11: ; 1086f4
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_109107
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
@@ -946,7 +946,7 @@ MobileTradeAnim_GiveTrademon1: ; 108763
 	ld de, SFX_GIVE_TRADEMON
 	call PlaySFX
 	ld c, 40
-	ld hl, BGPals palette 6
+	ld hl, wBGPals2 palette 6
 	call Function1082f0
 	call Function108af4
 .loop
@@ -1010,7 +1010,7 @@ MobileTradeAnim_GiveTrademon1: ; 108763
 
 MobileTradeAnim_GiveTrademon2: ; 1087cf
 	ld c, 40
-	ld hl, BGPals + 1 palettes
+	ld hl, wBGPals2 + 1 palettes
 	call Function1082f0
 	call Function108af4
 	call Function108b5a
@@ -1109,12 +1109,12 @@ MobileTradeAnim_GetTrademon1: ; 108863
 
 MobileTradeAnim_GetTrademon2: ; 108894
 	ld c, 20
-	ld hl, BGPals + 1 palettes
+	ld hl, wBGPals2 + 1 palettes
 	call Function1082fa
 	ld de, SFX_GIVE_TRADEMON
 	call PlaySFX
 	ld c, 20
-	ld hl, BGPals + 1 palettes
+	ld hl, wBGPals2 + 1 palettes
 	call Function1082fa
 	call Function108af4
 .asm_1088ad
@@ -1178,7 +1178,7 @@ MobileTradeAnim_GetTrademon2: ; 108894
 
 MobileTradeAnim_GetTrademon3: ; 10890a
 	ld c, 40
-	ld hl, BGPals palette 6
+	ld hl, wBGPals2 palette 6
 	call Function1082f0
 	call Function108af4
 	call GetMobileTradeAnimByte
@@ -1449,22 +1449,22 @@ Function108af4: ; 108af4
 	and $1
 	jr z, .copy_palette_109147
 	ld hl, Palette_109187
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, Palette_109187
-	ld de, OBPals
+	ld de, wOBPals2
 	ld bc, 8 palettes
 	call CopyBytes
 	jr .done_copy
 
 .copy_palette_109147
 	ld hl, Palette_109147
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, Palette_109147
-	ld de, OBPals
+	ld de, wOBPals2
 	ld bc, 8 palettes
 	call CopyBytes
 
@@ -1485,7 +1485,7 @@ Function108b45: ; 108b45
 	ld a, $5
 	ld [rSVBK], a
 	ld de, (31 << 10) + (31 << 5) + 31 ; $7fff
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld a, e
 	ld [hli], a
 	ld d, a
@@ -1501,7 +1501,7 @@ Function108b5a: ; 108b5a
 	ld a, $5
 	ld [rSVBK], a
 	ld de, (15 << 10) + (31 << 5) + 18 ; $3ff2
-	ld hl, BGPals + 4 palettes
+	ld hl, wBGPals2 + 4 palettes
 	ld c, $10
 .loop
 	ld a, e
@@ -1561,7 +1561,7 @@ Function108b98: ; 108b98
 .asm_108bad
 	ld hl, Palette_108b98
 .asm_108bb0
-	ld de, UnknBGPals + 7 palettes
+	ld de, wBGPals1 + 7 palettes
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
@@ -1806,7 +1806,7 @@ Function108d07: ; 108d07
 	ld hl, Palette_1093c7
 	call AddNTimes
 	ld a, $5
-	ld de, UnknBGPals + 4 palettes
+	ld de, wBGPals1 + 4 palettes
 	ld bc, 1 palettes
 	call FarCopyWRAM
 	ret

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -1484,7 +1484,7 @@ Function108b45: ; 108b45
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld de, (31 << 10) + (31 << 5) + 31 ; $7fff
+	ld de, palred 31 + palgreen 31 + palblue 31
 	ld hl, wBGPals1
 	ld a, e
 	ld [hli], a
@@ -1500,7 +1500,7 @@ Function108b5a: ; 108b5a
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld de, (15 << 10) + (31 << 5) + 18 ; $3ff2
+	ld de, palred 18 + palgreen 31 + palblue 15
 	ld hl, wBGPals2 + 4 palettes
 	ld c, $10
 .loop
@@ -1525,11 +1525,11 @@ Function108b78: ; 108b78
 	ld a, c
 	and $2
 	jr z, .Orange
-	ld de, (31 << 10) + (31 << 5) + 31 ; $7fff
+	ld de, palred 31 + palgreen 31 + palblue 31
 	jr .load_pal
 
 .Orange:
-	ld de, ( 1 << 10) + (15 << 5) + 31 ; $05ff
+	ld de, palred 31 + palgreen 15 + palblue 1
 .load_pal
 	ld a, e
 	ld [hli], a

--- a/mobile/mobile_45.asm
+++ b/mobile/mobile_45.asm
@@ -7607,7 +7607,7 @@ Function117c4a:
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld de, 1 palettes
 	ld c, 8
 .loop

--- a/mobile/mobile_45_sprite_engine.asm
+++ b/mobile/mobile_45_sprite_engine.asm
@@ -658,7 +658,7 @@ Function11636e: ; 11636e
 	ld [rSVBK], a
 	ld hl, BGPals
 	ld de, UnknBGPals
-	ld bc, $0040
+	ld bc, 8 palettes
 	call CopyBytes
 	pop af
 	ld [rSVBK], a

--- a/mobile/mobile_45_sprite_engine.asm
+++ b/mobile/mobile_45_sprite_engine.asm
@@ -523,12 +523,12 @@ Function116294: ; 116294
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals palette 6
+	ld hl, wBGPals1 palette 6
 	ld de, $c320
 	ld bc, 2 palettes
 	call CopyBytes
 	ld hl, Palette_11734e
-	ld de, UnknBGPals palette 7
+	ld de, wBGPals1 palette 7
 	ld bc, 1 palettes
 	call CopyBytes
 	call SetPalettes
@@ -550,7 +550,7 @@ Function1162cb: ; 1162cb
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_11730e
-	ld de, UnknOBPals + 2 palettes
+	ld de, wOBPals1 + 2 palettes
 	ld bc, 6 palettes
 	call CopyBytes
 	call SetPalettes
@@ -656,8 +656,8 @@ Function11636e: ; 11636e
 	push af
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, BGPals
-	ld de, UnknBGPals
+	ld hl, wBGPals2
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -3449,7 +3449,7 @@ Function119987: ; 119987
 	ld l, a
 	ld a, [wcf65]
 	ld h, a
-	ld de, BGPals
+	ld de, wBGPals2
 	ld a, $22
 	jp Function119e2b
 

--- a/mobile/mobile_5b.asm
+++ b/mobile/mobile_5b.asm
@@ -187,7 +187,7 @@ MobileSystemSplashScreen_InitGFX: ; 16c108
 ; 16c130
 
 .LoadPals: ; 16c130
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld hl, UnknownMobilePalettes_16c903
 	ld bc, 8
 	ld a, $5
@@ -244,7 +244,7 @@ Function16c943: ; 16c943
 	ld [rSVBK], a
 	ld a, $ff
 	ld bc, 1 palettes
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call ByteFill
 	pop af
 	ld [rSVBK], a
@@ -261,7 +261,7 @@ Function16c943: ; 16c943
 	call Function16cab6
 	call Function16cabb
 	ld d, a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cabb
 	cp d
@@ -275,7 +275,7 @@ Function16c943: ; 16c943
 	jr nz, .asm_16c981
 
 .asm_16c988
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cadc
 
@@ -284,7 +284,7 @@ Function16c943: ; 16c943
 	call Function16cab6
 	call Function16cad8
 	ld d, a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cad8
 	cp d
@@ -298,7 +298,7 @@ Function16c943: ; 16c943
 	jr nz, .asm_16c9a9
 
 .asm_16c9b0
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cb08
 
@@ -307,7 +307,7 @@ Function16c943: ; 16c943
 	call Function16cab6
 	call Function16cac4
 	ld d, a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cac4
 	cp d
@@ -321,7 +321,7 @@ Function16c943: ; 16c943
 	jr nz, .asm_16c9d1
 
 .asm_16c9d8
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cae8
 
@@ -371,7 +371,7 @@ Function16ca11: ; 16ca11
 	ld e, $0
 	ld a, $0
 .asm_16ca28
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cabb
 	cp $1f
@@ -385,12 +385,12 @@ Function16ca11: ; 16ca11
 	jr nz, .asm_16ca37
 
 .asm_16ca3f
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cadc
 
 .asm_16ca48
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cad8
 	cp $1f
@@ -404,12 +404,12 @@ Function16ca11: ; 16ca11
 	jr nz, .asm_16ca57
 
 .asm_16ca5f
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cb08
 
 .asm_16ca68
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cac4
 	cp $1f
@@ -423,7 +423,7 @@ Function16ca11: ; 16ca11
 	jr nz, .asm_16ca77
 
 .asm_16ca7f
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	call Function16cab6
 	call Function16cae8
 
@@ -682,7 +682,7 @@ Function16cbd1: ; 16cbd1
 	ld bc, 2
 	ld hl, Unknown_16cfa3
 	call AddNTimes
-	ld de, UnknBGPals + 1 palettes + 4
+	ld de, wBGPals1 + 1 palettes + 4
 	ld bc, 2
 	ld a, $5
 	call FarCopyWRAM
@@ -717,13 +717,13 @@ Function16cc18: ; 16cc18
 
 Function16cc25: ; 16cc25
 	ld hl, Unknown_16cfa9
-	ld de, UnknBGPals + 1 palettes
+	ld de, wBGPals1 + 1 palettes
 	call .CopyPal
 	ld hl, Unknown_16cfb1
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	call .CopyPal
 	ld hl, Unknown_16cfb9
-	ld de, UnknOBPals + 1 palettes
+	ld de, wOBPals1 + 1 palettes
 	call .CopyPal
 	ret
 ; 16cc41

--- a/mobile/mobile_5b.asm
+++ b/mobile/mobile_5b.asm
@@ -243,7 +243,7 @@ Function16c943: ; 16c943
 	ld a, $5
 	ld [rSVBK], a
 	ld a, $ff
-	ld bc, $0008
+	ld bc, 1 palettes
 	ld hl, UnknBGPals
 	call ByteFill
 	pop af

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -281,7 +281,7 @@ Function170cc6: ; 170cc6
 	ld hl, LZ_1715a4
 	ld de, wd000
 	call Decompress
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld hl, vTiles0
 	lb bc, $6, $53
 	call Get2bpp
@@ -716,7 +716,7 @@ Function171ccd: ; 171ccd (5c:5ccd)
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_171d71
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, EngineBuffer5
@@ -884,11 +884,11 @@ Function172eb9:
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_172edf
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, Palette_172edf
-	ld de, BGPals
+	ld de, wBGPals2
 	ld bc, 8 palettes
 	call CopyBytes
 	call SetPalettes

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -717,7 +717,7 @@ Function171ccd: ; 171ccd (5c:5ccd)
 	ld [rSVBK], a
 	ld hl, Palette_171d71
 	ld de, UnknBGPals
-	ld bc, $40
+	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, EngineBuffer5
 	ld a, $ff
@@ -885,11 +885,11 @@ Function172eb9:
 	ld [rSVBK], a
 	ld hl, Palette_172edf
 	ld de, UnknBGPals
-	ld bc, $40
+	ld bc, 8 palettes
 	call CopyBytes
 	ld hl, Palette_172edf
 	ld de, BGPals
-	ld bc, $40
+	ld bc, 8 palettes
 	call CopyBytes
 	call SetPalettes
 	pop af

--- a/mobile/mobile_5e.asm
+++ b/mobile/mobile_5e.asm
@@ -760,26 +760,26 @@ Function17aba0: ; 17aba0 (5e:6ba0)
 Function17abcf: ; 17abcf (5e:6bcf)
 	ld a, [rSVBK]
 	push af
-	ld a, BANK(UnknBGPals)
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, Palette_17ac55
-	ld de, UnknBGPals ; $d000
+	ld de, wBGPals1 ; $d000
 	ld bc, 6 palettes
 	call CopyBytes
 
 	ld hl, Palette_17ac95
-	ld de, UnknOBPals
+	ld de, wOBPals1
 	ld bc, 8 palettes
 	call CopyBytes
 
 	ld hl, GFX_17afa5 + $510
-	ld de, UnknOBPals palette 1
+	ld de, wOBPals1 palette 1
 	ld bc, 2 palettes
 	call CopyBytes
 
 	ld hl, MapObjectPals palette 1
-	ld de, UnknOBPals palette 3
+	ld de, wOBPals1 palette 3
 	ld bc, 1 palettes
 	ld a, BANK(MapObjectPals)
 	call FarCopyBytes

--- a/mobile/mobile_5e.asm
+++ b/mobile/mobile_5e.asm
@@ -765,22 +765,22 @@ Function17abcf: ; 17abcf (5e:6bcf)
 
 	ld hl, Palette_17ac55
 	ld de, UnknBGPals ; $d000
-	ld bc, $30
+	ld bc, 6 palettes
 	call CopyBytes
 
 	ld hl, Palette_17ac95
 	ld de, UnknOBPals
-	ld bc, $40
+	ld bc, 8 palettes
 	call CopyBytes
 
 	ld hl, GFX_17afa5 + $510
-	ld de, UnknOBPals + 2 * 4
-	ld bc, $10
+	ld de, UnknOBPals palette 1
+	ld bc, 2 palettes
 	call CopyBytes
 
-	ld hl, MapObjectPals + 8
-	ld de, UnknOBPals + 6 * 4
-	ld bc, $8
+	ld hl, MapObjectPals palette 1
+	ld de, UnknOBPals palette 3
+	ld bc, 1 palettes
 	ld a, BANK(MapObjectPals)
 	call FarCopyBytes
 

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -49,7 +49,7 @@ Function17c000: ; 17c000
 
 	ld hl, HaveWantPals
 	ld de, UnknBGPals
-	ld bc, $80
+	ld bc, 16 palettes
 	call CopyBytes
 
 	pop af
@@ -1964,8 +1964,8 @@ Function17dcaf:
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, UnknBGPals
-	ld de, $8
-	ld c, $8
+	ld de, 1 palettes
+	ld c, 8
 .asm_17dcbb
 	push hl
 	ld a, $ff

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -44,11 +44,11 @@ Function17c000: ; 17c000
 	ld a, [rSVBK]
 	push af
 
-	ld a, 5 ; BANK(UnknBGPals)
+	ld a, 5 ; BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, HaveWantPals
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 
@@ -662,7 +662,7 @@ Function17d370: ; 17d370
 	ld a, $6
 	call GetSRAMBank
 	ld hl, $a006
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, $1000
 	call CopyBytes
 	call CloseSRAM
@@ -703,7 +703,7 @@ Function17d405:
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, Palette_17eff6
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	call SetPalettes
@@ -970,7 +970,7 @@ Function17d5f6: ; 17d5f6
 	ld a, $5
 	ld [rSVBK], a
 	ld hl, $c608
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld a, $4
@@ -1218,7 +1218,7 @@ Function17d78d: ; 17d78d
 	call GetSRAMBank
 	ld hl, $a006
 	add hl, bc
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld bc, $1000
 	call CopyBytes
 	call CloseSRAM
@@ -1342,7 +1342,7 @@ Function17d85d: ; 17d85d
 	ld a, [hli]
 	ld d, a
 	push hl
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	add hl, de
 	ld de, wcc60
 .asm_17d86c
@@ -1411,7 +1411,7 @@ Function17d85d: ; 17d85d
 	ld a, $3
 	ld [rSVBK], a
 	ld hl, $c608
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	ld b, $0
 	call CopyBytes
 	ld a, $4
@@ -1446,7 +1446,7 @@ Function17d902: ; 17d902
 	call Function17e41e
 	call Function17e32b
 	pop de
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	add hl, de
 	ld de, wcc60
 .asm_17d918
@@ -1963,7 +1963,7 @@ Function17dca9: ; 17dca9
 Function17dcaf:
 	ld a, $5
 	ld [rSVBK], a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	ld de, 1 palettes
 	ld c, 8
 .asm_17dcbb
@@ -3135,7 +3135,7 @@ Function17e409: ; 17e409
 ; 17e40f
 
 Function17e40f: ; 17e40f
-	ld de, UnknBGPals
+	ld de, wBGPals1
 	add hl, de
 	jr Function17e41e
 
@@ -4377,7 +4377,7 @@ Function17f3f0: ; 17f3f0
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	ld hl, UnknBGPals
+	ld hl, wBGPals1
 	add hl, de
 	ld e, l
 	ld d, h

--- a/tilesets/animations.asm
+++ b/tilesets/animations.asm
@@ -935,26 +935,24 @@ TileAnimationPalette: ; fc6d7
 	ret nz
 
 ; Ready for BGPD input...
-	ld a, %10011000 ; auto increment, index $18 (pal 3 color 0)
+
+	ld a, (1 << rBGPI_AUTO_INCREMENT) palette PAL_BG_WATER
 	ld [rBGPI], a
 
 	ld a, [rSVBK]
 	push af
-	ld a, 5 ; wra5: gfx
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 ; Update color 0 in order 0 1 2 1
-
 	ld a, l
 	and %110 ; frames 0 2 4 6
-
 	jr z, .color0
-
 	cp 4
 	jr z, .color2
 
 .color1
-	ld hl, wBGPals1 + palette 3 + 2
+	ld hl, wBGPals1 palette PAL_BG_WATER + 2
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -962,7 +960,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color0
-	ld hl, wBGPals1 + palette 3
+	ld hl, wBGPals1 palette PAL_BG_WATER
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -970,7 +968,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color2
-	ld hl, wBGPals1 + palette 3 + 4
+	ld hl, wBGPals1 palette PAL_BG_WATER + 4
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -999,19 +997,19 @@ FlickeringCaveEntrancePalette: ; fc71e
 
 	ld a, [rSVBK]
 	push af
-	ld a, 5 ; wra5: gfx
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 ; Ready for BGPD input...
-	ld a, %10100000 ; auto-increment, index $20 (pal 4 color 0)
+	ld a, (1 << rBGPI_AUTO_INCREMENT) palette PAL_BG_YELLOW
 	ld [rBGPI], a
 	ld a, [hVBlankCounter]
-	and %00000010
+	and 1 << 1
 	jr nz, .bit1set
-	ld hl, wBGPals1 + palette 4
+	ld hl, wBGPals1 palette PAL_BG_YELLOW
 	jr .okay
 
 .bit1set
-	ld hl, wBGPals1 + palette 4 + 2
+	ld hl, wBGPals1 palette PAL_BG_YELLOW + 2
 
 .okay
 	ld a, [hli]

--- a/tilesets/animations.asm
+++ b/tilesets/animations.asm
@@ -954,7 +954,7 @@ TileAnimationPalette: ; fc6d7
 	jr z, .color2
 
 .color1
-	ld hl, UnknBGPals + $1a ; pal 3 color 1
+	ld hl, UnknBGPals + palette 3 + 2
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -962,7 +962,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color0
-	ld hl, UnknBGPals + $18 ; pal 3 color 0
+	ld hl, UnknBGPals + palette 3
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -970,7 +970,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color2
-	ld hl, UnknBGPals + $1c ; pal 3 color 2
+	ld hl, UnknBGPals + palette 3 + 4
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -1007,11 +1007,11 @@ FlickeringCaveEntrancePalette: ; fc71e
 	ld a, [hVBlankCounter]
 	and %00000010
 	jr nz, .bit1set
-	ld hl, UnknBGPals + $20 ; pal 4 color 0
+	ld hl, UnknBGPals + palette 4
 	jr .okay
 
 .bit1set
-	ld hl, UnknBGPals + $22 ; pal 4 color 2
+	ld hl, UnknBGPals + palette 4 + 2
 
 .okay
 	ld a, [hli]

--- a/tilesets/animations.asm
+++ b/tilesets/animations.asm
@@ -954,7 +954,7 @@ TileAnimationPalette: ; fc6d7
 	jr z, .color2
 
 .color1
-	ld hl, UnknBGPals + palette 3 + 2
+	ld hl, wBGPals1 + palette 3 + 2
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -962,7 +962,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color0
-	ld hl, UnknBGPals + palette 3
+	ld hl, wBGPals1 + palette 3
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -970,7 +970,7 @@ TileAnimationPalette: ; fc6d7
 	jr .end
 
 .color2
-	ld hl, UnknBGPals + palette 3 + 4
+	ld hl, wBGPals1 + palette 3 + 4
 	ld a, [hli]
 	ld [rBGPD], a
 	ld a, [hli]
@@ -1007,11 +1007,11 @@ FlickeringCaveEntrancePalette: ; fc71e
 	ld a, [hVBlankCounter]
 	and %00000010
 	jr nz, .bit1set
-	ld hl, UnknBGPals + palette 4
+	ld hl, wBGPals1 + palette 4
 	jr .okay
 
 .bit1set
-	ld hl, UnknBGPals + palette 4 + 2
+	ld hl, wBGPals1 + palette 4 + 2
 
 .okay
 	ld a, [hli]

--- a/tilesets/special_palettes.asm
+++ b/tilesets/special_palettes.asm
@@ -54,8 +54,8 @@ LoadSpecialMapPalette: ; 494ac
 ; 494f2
 
 LoadPokeComPalette: ; 494f2
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, PokeComPalette
 	ld bc, 8 palettes
 	call FarCopyWRAM
@@ -67,8 +67,8 @@ INCLUDE "data/palettes/tilesets/pokecom_center.pal"
 ; 49541
 
 LoadBattleTowerPalette: ; 49541
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, BattleTowerPalette
 	ld bc, 8 palettes
 	call FarCopyWRAM
@@ -80,8 +80,8 @@ INCLUDE "data/palettes/tilesets/battle_tower.pal"
 ; 49590
 
 LoadIcePathPalette: ; 49590
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, IcePathPalette
 	ld bc, 8 palettes
 	call FarCopyWRAM
@@ -93,8 +93,8 @@ INCLUDE "data/palettes/tilesets/ice_path.pal"
 ; 495df
 
 LoadHousePalette: ; 495df
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, HousePalette
 	ld bc, 8 palettes
 	call FarCopyWRAM
@@ -106,8 +106,8 @@ INCLUDE "data/palettes/tilesets/house_1.pal"
 ; 4962e
 
 LoadRadioTowerPalette: ; 4962e
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, RadioTowerPalette
 	ld bc, 8 palettes
 	call FarCopyWRAM
@@ -169,23 +169,23 @@ MansionPalette4: ; 496bd
 ; 496c5
 
 LoadMansionPalette: ; 496c5
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1
 	ld hl, MansionPalette1
 	ld bc, 8 palettes
 	call FarCopyWRAM
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals palette PAL_BG_YELLOW
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1 palette PAL_BG_YELLOW
 	ld hl, MansionPalette2
 	ld bc, 1 palettes
 	call FarCopyWRAM
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals palette PAL_BG_WATER
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1 palette PAL_BG_WATER
 	ld hl, MansionPalette3
 	ld bc, 1 palettes
 	call FarCopyWRAM
-	ld a, BANK(UnknBGPals)
-	ld de, UnknBGPals palette PAL_BG_ROOF
+	ld a, BANK(wBGPals1)
+	ld de, wBGPals1 palette PAL_BG_ROOF
 	ld hl, MansionPalette4
 	ld bc, 1 palettes
 	call FarCopyWRAM

--- a/wram.asm
+++ b/wram.asm
@@ -2880,10 +2880,10 @@ w3_dffc:: ds 4
 SECTION "GBC Video", WRAMX
 
 ; eight 4-color palettes each
-UnknBGPals:: ds 8 palettes ; d000
-UnknOBPals:: ds 8 palettes ; d040
-BGPals::     ds 8 palettes ; d080
-OBPals::     ds 8 palettes ; d0c0
+wBGPals1:: ds 8 palettes ; d000
+wOBPals1:: ds 8 palettes ; d040
+wBGPals2:: ds 8 palettes ; d080
+wOBPals2:: ds 8 palettes ; d0c0
 
 LYOverrides:: ds SCREEN_HEIGHT_PX ; d100
 LYOverridesEnd:: ; d190


### PR DESCRIPTION
Merged two commits from roukaour/master to avoid late conflicts as we were dealing with some similar things, so this effectively makes #454 redundant.

The reason to rename the four WRAM palette buffers is that their usage appears to be just for redundancy, so it makes more sense to just name them 1 and 2.

`wBGPals1 palette PAL_BG_YELLOW + 2`
Expressions like this one can be changed to e.g. `wBGPals1 palette PAL_BG_YELLOW color 1` but maybe that's overkill?

Merge whenever.