### PR TITLE
Use macro for all occurrences of box address tables.

### DIFF
--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -2216,21 +2216,7 @@ GetBoxPointer: ; e3396 (38:7396)
 ; e33a6 (38:73a6)
 
 .boxes ; e33a6
-	;  bank, address
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table
 ; e33d0
 
 BillsPC_ApplyPalettes: ; e33d0 (38:73d0)
@@ -2455,20 +2441,7 @@ GetBoxCount: ; e366c (38:766c)
 ; e36a5 (38:76a5)
 
 .boxbanks ; e36a5
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table
 ; e36cf
 
 BillsPC_PrintBoxName: ; e36cf (38:76cf)

--- a/engine/billspctop.asm
+++ b/engine/billspctop.asm
@@ -372,17 +372,4 @@ Functione5d9: ; unreferenced
 	ret
 
 .BoxAddrs: ; e66e
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -191,20 +191,7 @@ Special_CheckForLuckyNumberWinners: ; 4d87a
 	ret
 
 .BoxBankAddresses: ; 4d99f
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table
 
 .FoundPartymonText: ; 0x4d9c9
 	; Congratulations! We have a match with the ID number of @  in your party.

--- a/engine/search.asm
+++ b/engine/search.asm
@@ -249,20 +249,7 @@ endr
 ; 0x4a810
 
 BoxAddressTable1: ; 4a810
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table
 ; 4a83a
 
 UpdateOTPointer: ; 0x4a83a

--- a/macros.asm
+++ b/macros.asm
@@ -8,6 +8,7 @@ INCLUDE "macros/coords.asm"
 INCLUDE "macros/color.asm"
 INCLUDE "macros/base_stats.asm"
 INCLUDE "macros/tilesets.asm"
+INCLUDE "macros/boxes.asm"
 
 INCLUDE "macros/scripts/audio.asm"
 INCLUDE "macros/scripts/maps.asm"

--- a/macros/boxes.asm
+++ b/macros/boxes.asm
@@ -1,0 +1,16 @@
+box_address_table: MACRO
+	dba sBox1
+	dba sBox2
+	dba sBox3
+	dba sBox4
+	dba sBox5
+	dba sBox6
+	dba sBox7
+	dba sBox8
+	dba sBox9
+	dba sBox10
+	dba sBox11
+	dba sBox12
+	dba sBox13
+	dba sBox14
+ENDM

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -133,20 +133,7 @@ MobileCheckOwnMonAnywhere: ; 4a843
 ; 4a8f4
 
 .BoxAddrs: ; 4a8f4
-	dba sBox1
-	dba sBox2
-	dba sBox3
-	dba sBox4
-	dba sBox5
-	dba sBox6
-	dba sBox7
-	dba sBox8
-	dba sBox9
-	dba sBox10
-	dba sBox11
-	dba sBox12
-	dba sBox13
-	dba sBox14
+	box_address_table
 ; 4a91e
 
 .CopyName: ; 4a91e


### PR DESCRIPTION
The exact same address table appears six times and should be consolidated:

```
	dba sBox1
	dba sBox2
	dba sBox3
	dba sBox4
	dba sBox5
	dba sBox6
	dba sBox7
	dba sBox8
	dba sBox9
	dba sBox10
	dba sBox11
	dba sBox12
	dba sBox13
	dba sBox14
```

I have no idea where the macro should go, though.