### PR TITLE
Consistent unused content references, and predef and special label names

### DIFF
--- a/data/items/descriptions.asm
+++ b/data/items/descriptions.asm
@@ -11,7 +11,7 @@ PrintItemDescription: ; 0x1c8955
 	pop hl
 	ld a, [wd265]
 	ld [CurSpecies], a
-	predef PrintMoveDesc
+	predef Predef_PrintMoveDesc
 	ret
 
 .not_a_tm

--- a/data/sprite_anims/framesets.asm
+++ b/data/sprite_anims/framesets.asm
@@ -246,45 +246,45 @@ SpriteAnimFrameData: ; 8d6e6
 	frame SPRITE_ANIM_OAMSET_MAGNET_TRAIN_RED_2,  8, OAM_X_FLIP
 	dorestart
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_43,  8
 	frame SPRITE_ANIM_OAMSET_44,  8
 	dorestart
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_45,  8
 	frame SPRITE_ANIM_OAMSET_46,  8
 	dorestart
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_47,  8
 	frame SPRITE_ANIM_OAMSET_48,  8
 	dorestart
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_49,  1
 	frame SPRITE_ANIM_OAMSET_49,  1, OAM_X_FLIP
 	frame SPRITE_ANIM_OAMSET_49,  1, OAM_X_FLIP, OAM_Y_FLIP
 	frame SPRITE_ANIM_OAMSET_49,  1, OAM_Y_FLIP
 	dorestart
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_4A, 32
 	endanim
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_4B, 32
 	endanim
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_4C, 32
 	endanim
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_4D, 32
 	endanim
 
-; XXX
+; unused
 	frame SPRITE_ANIM_OAMSET_4E,  3
 	dorepeat  3
 	dorestart

--- a/data/unknown_table.asm
+++ b/data/unknown_table.asm
@@ -1,0 +1,13 @@
+Unreferenced_53d84:
+	db $1a, $15
+	db $33, $16
+	db $4b, $17
+	db $62, $18
+	db $79, $19
+	db $90, $1a
+	db $a8, $1b
+	db $c4, $1c
+	db $e0, $1d
+	db $f6, $1e
+	db $ff, $1f
+	db $ff, $20

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -545,7 +545,7 @@ AI_Items: ; 39196
 
 AIUpdateHUD: ; 38387
 	call UpdateEnemyMonInParty
-	farcall UpdateEnemyHUD
+	farcall Predef_UpdateEnemyHUD
 	ld a, $1
 	ld [hBGMapMode], a
 	ld hl, wEnemyItemState
@@ -664,7 +664,7 @@ EnemyPotionFinish: ; 38436
 	xor a
 	ld [wWhichHPBar], a
 	call AIUsedItemSound
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	jp AIUpdateHUD
 
 

--- a/engine/battle/ai/move.asm
+++ b/engine/battle/ai/move.asm
@@ -92,7 +92,7 @@ AIChooseMove: ; 440ce
 
 	push bc
 	ld d, BANK(TrainerClassAttributes)
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld d, c
 	pop bc
 

--- a/engine/battle/ai/move.asm
+++ b/engine/battle/ai/move.asm
@@ -92,7 +92,7 @@ AIChooseMove: ; 440ce
 
 	push bc
 	ld d, BANK(TrainerClassAttributes)
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld d, c
 	pop bc
 

--- a/engine/battle/ai/move.asm
+++ b/engine/battle/ai/move.asm
@@ -92,7 +92,7 @@ AIChooseMove: ; 440ce
 
 	push bc
 	ld d, BANK(TrainerClassAttributes)
-	predef FlagPredef
+	predef Predef_Flag
 	ld d, c
 	pop bc
 

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1488,7 +1488,7 @@ AI_Smart_Encore: ; 38c3b
 	push hl
 	ld a, [wEnemyMoveStruct + MOVE_TYPE]
 	ld hl, EnemyMonType1
-	predef CheckTypeMatchup
+	predef Predef_CheckTypeMatchup
 
 	pop hl
 	ld a, [wd265]

--- a/engine/battle/ai/switch.asm
+++ b/engine/battle/ai/switch.asm
@@ -28,7 +28,7 @@ CheckPlayerMoveTypeMatchups: ; 3484e
 	inc hl
 	call GetMoveByte
 	ld hl, EnemyMonType
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	cp 10 + 1 ; 1.0 + 0.1
 	jr nc, .super_effective
@@ -73,7 +73,7 @@ CheckPlayerMoveTypeMatchups: ; 3484e
 	ld a, [BattleMonType1]
 	ld b, a
 	ld hl, EnemyMonType1
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	cp 10 + 1 ; 1.0 + 0.1
 	jr c, .ok
@@ -82,7 +82,7 @@ CheckPlayerMoveTypeMatchups: ; 3484e
 	ld a, [BattleMonType2]
 	cp b
 	jr z, .ok2
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	cp 10 + 1 ; 1.0 + 0.1
 	jr c, .ok2
@@ -123,7 +123,7 @@ CheckPlayerMoveTypeMatchups: ; 3484e
 	inc hl
 	call GetMoveByte
 	ld hl, BattleMonType1
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 
 	ld a, [wTypeMatchup]
 	; immune
@@ -390,7 +390,7 @@ FindEnemyMonsImmuneToLastCounterMove: ; 34a2a
 	inc hl
 	call GetMoveByte
 	ld hl, BaseType
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	and a
 	jr nz, .next
@@ -481,7 +481,7 @@ FindEnemyMonsWithASuperEffectiveMove: ; 34aa7
 	inc hl
 	call GetMoveByte
 	ld hl, BattleMonType1
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 
 	; if immune or not very effective: continue
 	ld a, [wTypeMatchup]
@@ -585,7 +585,7 @@ FindEnemyMonsThatResistPlayer: ; 34b20
 .skip_move
 	ld a, [BattleMonType1]
 	ld hl, BaseType
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	cp 10 + 1
 	jr nc, .dont_choose_mon
@@ -593,7 +593,7 @@ FindEnemyMonsThatResistPlayer: ; 34b20
 
 .check_type
 	ld hl, BaseType
-	call CheckTypeMatchup
+	call Predef_CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	cp 10 + 1
 	jr nc, .dont_choose_mon

--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -67,7 +67,7 @@ _AnimateHPBar: ; d627
 	ld a, [hli]
 	ld b, a
 	pop hl
-	call ComputeHPBarPixels
+	call Predef_ComputeHPBarPixels
 	ld a, e
 	ld [wCurHPBarPixels], a
 
@@ -79,7 +79,7 @@ _AnimateHPBar: ; d627
 	ld e, a
 	ld a, [wCurHPAnimMaxHP + 1]
 	ld d, a
-	call ComputeHPBarPixels
+	call Predef_ComputeHPBarPixels
 	ld a, e
 	ld [wNewHPBarPixels], a
 
@@ -183,11 +183,11 @@ LongAnim_UpdateVariables: ; d6f5
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	; This routine is buggy. The result from ComputeHPBarPixels is stored
+	; This routine is buggy. The result from Predef_ComputeHPBarPixels is stored
 	; in e. However, the pop de opcode deletes this result before it is even
 	; used. The game then proceeds as though it never deleted that output.
 	; To fix, uncomment the line below.
-	call ComputeHPBarPixels
+	call Predef_ComputeHPBarPixels
 	; ld a, e
 	pop bc
 	pop de
@@ -227,7 +227,7 @@ LongHPBarAnim_UpdateTiles: ; d749
 	ld e, a
 	ld a, [wCurHPAnimMaxHP + 1]
 	ld d, a
-	call ComputeHPBarPixels
+	call Predef_ComputeHPBarPixels
 	ld c, e
 	ld d, HP_BAR_LENGTH
 	ld a, [wWhichHPBar]

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -1,4 +1,4 @@
-DoBattleTransition: ; 8c20f
+Predef_DoBattleTransition: ; 8c20f
 	call .InitGFX
 	ld a, [rBGP]
 	ld [wBGP], a

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -1,4 +1,4 @@
-Predef_StartBattle: ; 8c20f
+DoBattleTransition: ; 8c20f
 	call .InitGFX
 	ld a, [rBGP]
 	ld [wBGP], a
@@ -16,7 +16,7 @@ Predef_StartBattle: ; 8c20f
 	ld a, [wJumptableIndex]
 	bit 7, a
 	jr nz, .done
-	call FlashyTransitionToBattle
+	call BattleTransitionJumptable
 	call DelayFrame
 	jr .loop
 
@@ -144,7 +144,7 @@ TrainerBattlePokeballTiles: ; 8c2f4
 INCBIN "gfx/overworld/trainer_battle_pokeball_tiles.2bpp"
 
 
-FlashyTransitionToBattle: ; 8c314
+BattleTransitionJumptable: ; 8c314
 	jumptable .dw, wJumptableIndex
 ; 8c323
 

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -863,8 +863,7 @@ ENDM
 	ret
 ; 8c7c9 (23:47c9)
 
-Function8c7c9:
-; XXX
+Unreferenced_Function8c7c9:
 	ld a, $1
 	ld [hBGMapMode], a
 	call WaitBGMap

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -2760,7 +2760,7 @@ PlayerMonFaintHappinessMod: ; 3d1aa
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld hl, EnemySubStatus3
 	res SUBSTATUS_IN_LOOP, [hl]
 	xor a
@@ -3357,10 +3357,10 @@ AddBattleParticipant: ; 3d581
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
 	push bc
-	predef Predef_Flag
+	predef Predef_FlagAction
 	pop bc
 	ld hl, wBattleParticipantsIncludingFainted
-	predef_jump Predef_Flag
+	predef_jump Predef_FlagAction
 ; 3d599
 
 FindPkmnInOTPartyToSwitchIntoBattle: ; 3d599
@@ -4350,7 +4350,7 @@ PursuitSwitch: ; 3dc5b
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	call PlayerMonFaintedAnimation
 	ld hl, BattleText_PkmnFainted
 	jr .done_fainted
@@ -6631,7 +6631,7 @@ LoadEnemyMon: ; 3e8eb
 	ld c, a
 	ld b, SET_FLAG
 	ld hl, PokedexSeen
-	predef Predef_Flag
+	predef Predef_FlagAction
 
 	ld hl, EnemyMonStats
 	ld de, EnemyStats
@@ -7313,7 +7313,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld c, a
 	ld b, CHECK_FLAG
 	ld d, $0
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	and a
 	pop bc
@@ -7642,7 +7642,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld a, [CurPartyMon]
 	ld c, a
 	ld b, SET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	pop af
 	ld [CurPartyLevel], a
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8091,7 +8091,7 @@ TextJump_GoodComeBack: ; 3f352
 	db "@"
 ; 3f357
 
-UnusedFunction_TextJump_ComeBack: ; 3f357
+Unreferenced_TextJump_ComeBack: ; 3f357
 ; this function doesn't seem to be used
 	ld hl, TextJump_ComeBack
 	ret

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -160,7 +160,7 @@ WildFled_EnemyFled_LinkBattleCanceled: ; 3c0e5
 
 BattleTurn: ; 3c12f
 .loop
-	call MobileFn_3c1bf
+	call Stubbed_Function3c1bf
 	call CheckContestBattleOver
 	jp c, .quit
 
@@ -231,7 +231,8 @@ BattleTurn: ; 3c12f
 	ret
 ; 3c1bf
 
-MobileFn_3c1bf: mobile
+Stubbed_Function3c1bf:
+	ret
 	ld a, $5
 	call GetSRAMBank
 	ld hl, $a89b ; s5_a89b
@@ -2588,7 +2589,7 @@ AddBattleMoneyToAccount: ; 3d0be
 	push bc
 	ld b, h
 	ld c, l
-	farcall TrainerRankings_AddToBattlePayouts
+	farcall StubbedTrainerRankings_AddToBattlePayouts
 	pop bc
 	pop hl
 .loop
@@ -8375,7 +8376,7 @@ Unreferenced_DoBattle: ; 3f4d9
 ; 3f4dd
 
 BattleIntro: ; 3f4dd
-	farcall TrainerRankings_Battles ; mobile
+	farcall StubbedTrainerRankings_Battles ; mobile
 	call LoadTrainerOrWildMonPic
 	xor a
 	ld [TempBattleMonSpecies], a
@@ -8460,7 +8461,7 @@ BackUpBGMap2: ; 3f568
 
 InitEnemyTrainer: ; 3f594
 	ld [TrainerClass], a
-	farcall TrainerRankings_TrainerBattles
+	farcall StubbedTrainerRankings_TrainerBattles
 	xor a
 	ld [TempEnemyMonSpecies], a
 	callfar GetTrainerAttributes
@@ -8516,7 +8517,7 @@ InitEnemyTrainer: ; 3f594
 InitEnemyWildmon: ; 3f607
 	ld a, WILD_BATTLE
 	ld [wBattleMode], a
-	farcall TrainerRankings_WildBattles
+	farcall StubbedTrainerRankings_WildBattles
 	call LoadEnemyMon
 	ld hl, EnemyMonMoves
 	ld de, wWildMonMoves
@@ -8698,7 +8699,7 @@ CheckPayDay: ; 3f71d
 ; 3f759
 
 ShowLinkBattleParticipantsAfterEnd: ; 3f759
-	farcall TrainerRankings_LinkBattles
+	farcall StubbedTrainerRankings_LinkBattles
 	farcall BackupMobileEventIndex
 	ld a, [CurOTMon]
 	ld hl, OTPartyMon1Status
@@ -8728,17 +8729,17 @@ DisplayLinkBattleResult: ; 3f77c
 	cp $1
 	jr c, .victory
 	jr z, .loss
-	farcall TrainerRankings_ColosseumDraws
+	farcall StubbedTrainerRankings_ColosseumDraws
 	ld de, .Draw
 	jr .store_result
 
 .victory
-	farcall TrainerRankings_ColosseumWins
+	farcall StubbedTrainerRankings_ColosseumWins
 	ld de, .Win
 	jr .store_result
 
 .loss
-	farcall TrainerRankings_ColosseumLosses
+	farcall StubbedTrainerRankings_ColosseumLosses
 	ld de, .Lose
 	jr .store_result
 
@@ -9486,7 +9487,7 @@ BattleStartMessage: ; 3fc8b
 	cp BATTLETYPE_FISH
 	jr nz, .NotFishing
 
-	farcall TrainerRankings_HookedEncounters
+	farcall StubbedTrainerRankings_HookedEncounters
 
 	ld hl, HookedPokemonAttackedText
 	jr .PlaceBattleStartText

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1951,8 +1951,7 @@ GetMaxHP: ; 3ccac
 	ret
 ; 3ccc2
 
-GetHalfHP: ; 3ccc2
-; unreferenced
+Unreferenced_GetHalfHP: ; 3ccc2
 	ld hl, BattleMonHP
 	ld a, [hBattleTurn]
 	and a
@@ -6769,8 +6768,7 @@ CheckUnownLetter: ; 3eb75
 
 ; 3ebc7
 
-SwapBattlerLevels: ; 3ebc7
-; unreferenced
+Unreferenced_SwapBattlerLevels: ; 3ebc7
 	push bc
 	ld a, [BattleMonLevel]
 	ld b, a
@@ -7162,7 +7160,7 @@ _LoadHPBar: ; 3eda6
 	ret
 ; 3edad
 
-LoadHPExpBarGFX: ; unreferenced
+Unreferenced_LoadHPExpBarGFX:
 	ld de, EnemyHPBarBorderGFX
 	ld hl, vTiles2 tile $6c
 	lb bc, BANK(EnemyHPBarBorderGFX), 4
@@ -8104,7 +8102,7 @@ TextJump_ComeBack: ; 3f35b
 	db "@"
 ; 3f360
 
-HandleSafariAngerEatingStatus: ; unreferenced
+Unreferenced_HandleSafariAngerEatingStatus:
 	ld hl, wSafariMonEating
 	ld a, [hl]
 	and a
@@ -8371,8 +8369,7 @@ StartBattle: ; 3f4c1
 	ret
 ; 3f4d9
 
-_DoBattle: ; 3f4d9
-; unreferenced
+Unreferenced_DoBattle: ; 3f4d9
 	call DoBattle
 	ret
 ; 3f4dd

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8551,8 +8551,7 @@ InitEnemyWildmon: ; 3f607
 	ret
 ; 3f662
 
-Function3f662: ; 3f662
-; XXX
+Unreferenced_Function3f662: ; 3f662
 	ld hl, EnemyMonMoves
 	ld de, wListMoves_MoveIndicesBuffer
 	ld b, NUM_MOVES

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -47,7 +47,7 @@ DoBattle: ; 3c000
 
 .player_2
 	call LoadTileMapToTempTileMap
-	call CheckPlayerPartyForFitPkmn
+	call Predef_CheckPlayerPartyForFitPkmn
 	ld a, d
 	and a
 	jp z, LostBattle
@@ -1285,7 +1285,7 @@ HandleWrap: ; 3c874
 	xor a
 	ld [wNumHits], a
 	ld [FXAnimID + 1], a
-	predef PlayBattleAnim
+	predef Predef_PlayBattleAnim
 	call SwitchTurnCore
 
 .skip_anim
@@ -2047,7 +2047,7 @@ UpdateHPBar: ; 3cd3c
 .ok
 	push bc
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	pop bc
 	ret
 ; 3cd55
@@ -2061,7 +2061,7 @@ HandleEnemyMonFaint: ; 3cd55
 	xor a
 	ld [wWhichMonFaintedFirst], a
 	call UpdateBattleStateAndExperienceAfterEnemyFaint
-	call CheckPlayerPartyForFitPkmn
+	call Predef_CheckPlayerPartyForFitPkmn
 	ld a, d
 	and a
 	jp z, LostBattle
@@ -2069,7 +2069,7 @@ HandleEnemyMonFaint: ; 3cd55
 	ld hl, BattleMonHP
 	ld a, [hli]
 	or [hl]
-	call nz, UpdatePlayerHUD
+	call nz, Predef_UpdatePlayerHUD
 
 	ld a, $1
 	ld [hBGMapMode], a
@@ -2193,7 +2193,7 @@ UpdateBattleStateAndExperienceAfterEnemyFaint: ; 3ce01
 	call PlayerMonFaintHappinessMod
 
 .player_mon_did_not_faint
-	call CheckPlayerPartyForFitPkmn
+	call Predef_CheckPlayerPartyForFitPkmn
 	ld a, d
 	and a
 	ret z
@@ -2713,7 +2713,7 @@ HandlePlayerMonFaint: ; 3d14e
 	ld a, $1
 	ld [wWhichMonFaintedFirst], a
 	call PlayerMonFaintHappinessMod
-	call CheckPlayerPartyForFitPkmn
+	call Predef_CheckPlayerPartyForFitPkmn
 	ld a, d
 	and a
 	jp z, LostBattle
@@ -2759,7 +2759,7 @@ PlayerMonFaintHappinessMod: ; 3d1aa
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	ld hl, EnemySubStatus3
 	res SUBSTATUS_IN_LOOP, [hl]
 	xor a
@@ -3356,10 +3356,10 @@ AddBattleParticipant: ; 3d581
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
 	push bc
-	predef FlagPredef
+	predef Predef_Flag
 	pop bc
 	ld hl, wBattleParticipantsIncludingFainted
-	predef_jump FlagPredef
+	predef_jump Predef_Flag
 ; 3d599
 
 FindPkmnInOTPartyToSwitchIntoBattle: ; 3d599
@@ -3577,7 +3577,7 @@ LoadEnemyPkmnToSwitchTo: ; 3d6ca
 	and a
 	jr nz, .skip_unown
 	ld hl, EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld a, [UnownLetter]
 	ld [wFirstUnownSeen], a
 .skip_unown
@@ -3687,8 +3687,8 @@ Function_SetEnemyPkmnAndSendOutAnimation: ; 3d7c7
 	call GetBaseData
 	ld a, OTPARTYMON
 	ld [MonType], a
-	predef CopyPkmnToTempMon
-	call GetEnemyMonFrontpic
+	predef Predef_CopyPkmnToTempMon
+	call Predef_GetEnemyMonFrontpic
 
 	xor a
 	ld [wNumHits], a
@@ -3713,7 +3713,7 @@ Function_SetEnemyPkmnAndSendOutAnimation: ; 3d7c7
 	hlcoord 12, 0
 	ld d, $0
 	ld e, ANIM_MON_SLOW
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 	jr .skip_cry
 
 .cry_no_anim
@@ -3723,7 +3723,7 @@ Function_SetEnemyPkmnAndSendOutAnimation: ; 3d7c7
 	call PlayStereoCry
 
 .skip_cry
-	call UpdateEnemyHUD
+	call Predef_UpdateEnemyHUD
 	ld a, $1
 	ld [hBGMapMode], a
 	ret
@@ -3764,7 +3764,7 @@ ResetEnemyStatLevels: ; 3d867
 	ret
 ; 3d873
 
-CheckPlayerPartyForFitPkmn: ; 3d873
+Predef_CheckPlayerPartyForFitPkmn: ; 3d873
 ; Has the player any Pkmn in his Party that can fight?
 	ld a, [PartyCount]
 	ld e, a
@@ -4167,7 +4167,7 @@ SwitchPlayerMon: ; 3db32
 
 SendOutPlayerMon: ; 3db5f
 	ld hl, BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	hlcoord 1, 5
 	ld b, 7
 	ld c, 8
@@ -4175,7 +4175,7 @@ SendOutPlayerMon: ; 3db5f
 	call WaitBGMap
 	xor a
 	ld [hBGMapMode], a
-	call GetBattleMonBackpic
+	call Predef_GetBattleMonBackpic
 	xor a
 	ld [hGraphicStartTile], a
 	ld [wBattleMenuCursorBuffer], a
@@ -4215,7 +4215,7 @@ SendOutPlayerMon: ; 3db5f
 	call PlayStereoCry
 
 .statused
-	call UpdatePlayerHUD
+	call Predef_UpdatePlayerHUD
 	ld a, $1
 	ld [hBGMapMode], a
 	ret
@@ -4261,13 +4261,13 @@ BreakAttraction: ; 3dc18
 SpikesDamage: ; 3dc23
 	ld hl, PlayerScreens
 	ld de, BattleMonType
-	ld bc, UpdatePlayerHUD
+	ld bc, Predef_UpdatePlayerHUD
 	ld a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, EnemyScreens
 	ld de, EnemyMonType
-	ld bc, UpdateEnemyHUD
+	ld bc, Predef_UpdateEnemyHUD
 .ok
 
 	bit SCREENS_SPIKES, [hl]
@@ -4349,7 +4349,7 @@ PursuitSwitch: ; 3dc5b
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	call PlayerMonFaintedAnimation
 	ld hl, BattleText_PkmnFainted
 	jr .done_fainted
@@ -4498,7 +4498,7 @@ HandleHPHealingItem: ; 3dd2f
 
 .got_hp_bar_coords
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 UseOpponentItem:
 	call RefreshBattleHuds
 	callfar GetOpponentItem
@@ -4521,7 +4521,7 @@ ItemRecoveryAnim: ; 3ddc8
 	xor a
 	ld [wNumHits], a
 	ld [FXAnimID + 1], a
-	predef PlayBattleAnim
+	predef Predef_PlayBattleAnim
 	call SwitchTurnCore
 	pop bc
 	pop de
@@ -4751,7 +4751,7 @@ UpdateBattleHUDs: ; 3df2c
 	ret
 ; 3df48
 
-UpdatePlayerHUD:: ; 3df48
+Predef_UpdatePlayerHUD:: ; 3df48
 	push hl
 	push de
 	push bc
@@ -4784,7 +4784,7 @@ DrawPlayerHUD: ; 3df58
 	ld b, 1
 	xor a ; PARTYMON
 	ld [MonType], a
-	predef DrawPlayerHP
+	predef Predef_DrawPlayerHP
 
 	; Exp bar
 	push de
@@ -4797,7 +4797,7 @@ DrawPlayerHUD: ; 3df58
 	hlcoord 10, 11
 	ld a, [TempMonLevel]
 	ld b, a
-	call FillInExpBar
+	call Predef_FillInExpBar
 	pop de
 	ret
 ; 3df98
@@ -4866,7 +4866,7 @@ PrintPlayerHUD: ; 3dfbf
 
 	ld a, TEMPMON
 	ld [MonType], a
-	callfar GetGender
+	callfar Predef_GetGender
 	ld a, " "
 	jr c, .got_gender_char
 	ld a, "♂"
@@ -4880,7 +4880,7 @@ PrintPlayerHUD: ; 3dfbf
 	push af ; back up gender
 	push hl
 	ld de, BattleMonStatus
-	predef PlaceNonFaintStatus
+	predef Predef_PlaceNonFaintStatus
 	pop hl
 	pop bc
 	ret nz
@@ -4895,7 +4895,7 @@ PrintPlayerHUD: ; 3dfbf
 	jp PrintLevel
 ; 3e036
 
-UpdateEnemyHUD:: ; 3e036
+Predef_UpdateEnemyHUD:: ; 3e036
 	push hl
 	push de
 	push bc
@@ -4944,7 +4944,7 @@ DrawEnemyHUD: ; 3e043
 
 	ld a, TEMPMON
 	ld [MonType], a
-	callfar GetGender
+	callfar Predef_GetGender
 	ld a, " "
 	jr c, .got_gender
 	ld a, "♂"
@@ -4959,7 +4959,7 @@ DrawEnemyHUD: ; 3e043
 	push af
 	push hl
 	ld de, EnemyMonStatus
-	predef PlaceNonFaintStatus
+	predef Predef_PlaceNonFaintStatus
 	pop hl
 	pop bc
 	jr nz, .skip_level
@@ -5184,8 +5184,8 @@ BattleMenu_Pack: ; 3e1c7
 	call ClearPalettes
 	call DelayFrame
 	call _LoadBattleFontsHPBar
-	call GetBattleMonBackpic
-	call GetEnemyMonFrontpic
+	call Predef_GetBattleMonBackpic
+	call Predef_GetEnemyMonFrontpic
 	call ExitMenu
 	call WaitBGMap
 	call FinishBattleAnim
@@ -5217,10 +5217,10 @@ BattleMenu_Pack: ; 3e1c7
 	ld a, [BattleType]
 	cp BATTLETYPE_TUTORIAL
 	jr z, .tutorial2
-	call GetBattleMonBackpic
+	call Predef_GetBattleMonBackpic
 
 .tutorial2
-	call GetEnemyMonFrontpic
+	call Predef_GetEnemyMonFrontpic
 	ld a, $1
 	ld [wMenuCursorY], a
 	call ExitMenu
@@ -5574,7 +5574,7 @@ MoveSelectionScreen: ; 3e4bc
 .got_start_coord
 	ld a, SCREEN_WIDTH
 	ld [Buffer1], a
-	predef ListMoves
+	predef Predef_ListMoves
 
 	ld b, 5
 	ld a, [wMoveSelectionMenuType]
@@ -5907,7 +5907,7 @@ MoveInfoBox: ; 3e6c8
 	ld a, [wPlayerMoveStruct + MOVE_ANIM]
 	ld b, a
 	hlcoord 2, 10
-	predef PrintMoveType
+	predef Predef_PrintMoveType
 
 .done
 	ret
@@ -6363,7 +6363,7 @@ LoadEnemyMon: ; 3e8eb
 
 ; Get letter based on DVs
 	ld hl, EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 ; Can't use any letters that haven't been unlocked
 ; If combined with forced shiny battletype, causes an infinite loop
 	call CheckUnownLetter
@@ -6451,7 +6451,7 @@ LoadEnemyMon: ; 3e8eb
 	ld de, EnemyMonMaxHP
 	ld b, FALSE
 	ld hl, EnemyMonDVs - (MON_DVS - MON_STAT_EXP + 1) ; LinkBattleRNs + 7 ; ?
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 
 ; If we're in a trainer battle,
 ; get the rest of the parameters from the party struct
@@ -6566,7 +6566,7 @@ LoadEnemyMon: ; 3e8eb
 ; Make sure the predef knows this isn't a partymon
 	ld [wEvolutionOldSpecies], a
 ; Fill moves based on level
-	predef FillMoves
+	predef Predef_FillMoves
 
 .PP:
 ; Trainer battle?
@@ -6577,7 +6577,7 @@ LoadEnemyMon: ; 3e8eb
 ; Fill wild PP
 	ld hl, EnemyMonMoves
 	ld de, EnemyMonPP
-	predef FillPP
+	predef Predef_FillPP
 	jr .Finish
 
 .TrainerPP:
@@ -6630,7 +6630,7 @@ LoadEnemyMon: ; 3e8eb
 	ld c, a
 	ld b, SET_FLAG
 	ld hl, PokedexSeen
-	predef FlagPredef
+	predef Predef_Flag
 
 	ld hl, EnemyMonStats
 	ld de, EnemyStats
@@ -6787,7 +6787,7 @@ BattleWinSlideInEnemyTrainerFrontpic: ; 3ebd8
 	ld a, [OtherTrainerClass]
 	ld [TrainerClass], a
 	ld de, vTiles2
-	callfar GetTrainerPic
+	callfar Predef_GetTrainerPic
 	hlcoord 19, 0
 	ld c, 0
 
@@ -7264,7 +7264,7 @@ Call_PlayBattleAnim: ; 3ee17
 	ld a, d
 	ld [FXAnimID + 1], a
 	call WaitBGMap
-	predef_jump PlayBattleAnim
+	predef_jump Predef_PlayBattleAnim
 ; 3ee27
 
 FinishBattleAnim: ; 3ee27
@@ -7312,7 +7312,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld c, a
 	ld b, CHECK_FLAG
 	ld d, $0
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	and a
 	pop bc
@@ -7490,7 +7490,7 @@ GiveExperiencePoints: ; 3ee3b
 .not_max_exp
 	xor a ; PARTYMON
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	callfar CalcLevel
 	pop bc
 	ld hl, MON_LEVEL
@@ -7527,7 +7527,7 @@ GiveExperiencePoints: ; 3ee3b
 	add hl, bc
 	push bc
 	ld b, TRUE
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop bc
 	pop de
 	ld hl, MON_MAXHP + 1
@@ -7580,7 +7580,7 @@ GiveExperiencePoints: ; 3ee3b
 	call ApplyStatLevelMultiplierOnAllStats
 	callfar ApplyStatusEffectOnPlayerStats
 	callfar BadgeStatBoosts
-	callfar UpdatePlayerHUD
+	callfar Predef_UpdatePlayerHUD
 	call EmptyBattleTextBox
 	call LoadTileMapToTempTileMap
 	ld a, $1
@@ -7603,14 +7603,14 @@ GiveExperiencePoints: ; 3ee3b
 .skip_animation2
 	xor a ; PARTYMON
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	hlcoord 9, 0
 	ld b, $a
 	ld c, $9
 	call TextBox
 	hlcoord 11, 1
 	ld bc, 4
-	predef PrintTempMonStats
+	predef Predef_PrintTempMonStats
 	ld c, $1e
 	call DelayFrames
 	call WaitPressAorB_BlinkCursor
@@ -7630,7 +7630,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld a, b
 	ld [CurPartyLevel], a
 	push bc
-	predef LearnLevelMoves
+	predef Predef_LearnLevelMoves
 	pop bc
 	ld a, b
 	cp c
@@ -7641,7 +7641,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld a, [CurPartyMon]
 	ld c, a
 	ld b, SET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	pop af
 	ld [CurPartyLevel], a
 
@@ -7763,7 +7763,7 @@ AnimateExpBar: ; 3f136
 	ld [wd002], a
 	xor a ; PARTYMON
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	ld a, [TempMonLevel]
 	ld b, a
 	ld e, a
@@ -8134,7 +8134,7 @@ Unreferenced_HandleSafariAngerEatingStatus:
 	jp StdBattleTextBox
 ; 3f390
 
-FillInExpBar: ; 3f390
+Predef_FillInExpBar: ; 3f390
 	push hl
 	call CalcExpBar
 	pop hl
@@ -8276,7 +8276,7 @@ PlaceExpBar: ; 3f41c
 	ret
 ; 3f43d
 
-GetBattleMonBackpic: ; 3f43d
+Predef_GetBattleMonBackpic: ; 3f43d
 	ld a, [PlayerSubStatus4]
 	bit SUBSTATUS_SUBSTITUTE, a
 	ld hl, BattleAnimCmd_RaiseSub
@@ -8292,9 +8292,9 @@ DropPlayerSub: ; 3f447
 	ld a, [BattleMonSpecies]
 	ld [CurPartySpecies], a
 	ld hl, BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles2 tile $31
-	predef GetMonBackpic
+	predef Predef_GetMonBackpic
 	pop af
 	ld [CurPartySpecies], a
 	ret
@@ -8312,7 +8312,7 @@ GetBattleMonBackpic_DoAnim: ; 3f46f
 	ret
 ; 3f47c
 
-GetEnemyMonFrontpic: ; 3f47c
+Predef_GetEnemyMonFrontpic: ; 3f47c
 	ld a, [EnemySubStatus4]
 	bit SUBSTATUS_SUBSTITUTE, a
 	ld hl, BattleAnimCmd_RaiseSub
@@ -8331,9 +8331,9 @@ DropEnemySub: ; 3f486
 	ld [CurPartySpecies], a
 	call GetBaseData
 	ld hl, EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles2
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	pop af
 	ld [CurPartySpecies], a
 	ret
@@ -8350,7 +8350,7 @@ GetEnemyMonFrontpic_DoAnim: ; 3f4b4
 	ret
 ; 3f4c1
 
-StartBattle: ; 3f4c1
+Predef_StartBattle: ; 3f4c1
 ; This check prevents you from entering a battle without any Pokemon.
 ; Those using walk-through-walls to bypass getting a Pokemon experience
 ; the effects of this check.
@@ -8409,7 +8409,7 @@ BattleIntro: ; 3f4dd
 	call ClearSprites
 	ld a, [wBattleMode]
 	cp WILD_BATTLE
-	call z, UpdateEnemyHUD
+	call z, Predef_UpdateEnemyHUD
 	ld a, $1
 	ld [hBGMapMode], a
 	ret
@@ -8474,14 +8474,14 @@ InitEnemyTrainer: ; 3f594
 .ok
 
 	ld de, vTiles2
-	callfar GetTrainerPic
+	callfar Predef_GetTrainerPic
 	xor a
 	ld [hGraphicStartTile], a
 	dec a
 	ld [wEnemyItemState], a
 	hlcoord 12, 0
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld a, -1
 	ld [CurOTMon], a
 	ld a, TRAINER_BATTLE
@@ -8527,7 +8527,7 @@ InitEnemyWildmon: ; 3f607
 	ld bc, NUM_MOVES
 	call CopyBytes
 	ld hl, EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld a, [CurPartySpecies]
 	cp UNOWN
 	jr nz, .skip_unown
@@ -8538,13 +8538,13 @@ InitEnemyWildmon: ; 3f607
 	ld [wFirstUnownSeen], a
 .skip_unown
 	ld de, vTiles2
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	xor a
 	ld [TrainerClass], a
 	ld [hGraphicStartTile], a
 	hlcoord 12, 0
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 ; 3f662
 
@@ -8623,7 +8623,7 @@ ExitBattle: ; 3f69e
 	call CheckPayDay
 	xor a
 	ld [wForceEvolution], a
-	predef EvolveAfterBattle
+	predef Predef_EvolveAfterBattle
 	farcall GivePokerusAndConvertBerries
 	ret
 ; 3f6d0
@@ -9297,7 +9297,7 @@ InitBattleDisplay: ; 3fb6c
 	ld [hGraphicStartTile], a
 	hlcoord 2, 6
 	lb bc, 6, 6
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	xor a
 	ld [hWY], a
 	ld [rWY], a
@@ -9370,7 +9370,7 @@ GetTrainerBackpic: ; 3fbff
 .Decompress:
 	ld de, vTiles2 tile $31
 	ld c, $31
-	predef DecompressPredef
+	predef Predef_Decompress
 	ret
 ; 3fc30
 
@@ -9392,7 +9392,7 @@ CopyBackpic: ; 3fc30
 	ld [hGraphicStartTile], a
 	hlcoord 2, 6
 	lb bc, 6, 6
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 ; 3fc5b
 
@@ -9472,7 +9472,7 @@ BattleStartMessage: ; 3fc8b
 	hlcoord 12, 0
 	ld d, $0
 	ld e, ANIM_MON_NORMAL
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 	jr .skip_cry ; cry is played during the animation
 
 .cry_no_anim

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -2760,7 +2760,7 @@ PlayerMonFaintHappinessMod: ; 3d1aa
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld hl, EnemySubStatus3
 	res SUBSTATUS_IN_LOOP, [hl]
 	xor a
@@ -3357,10 +3357,10 @@ AddBattleParticipant: ; 3d581
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
 	push bc
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	pop bc
 	ld hl, wBattleParticipantsIncludingFainted
-	predef_jump Predef_FlagAction
+	predef_jump Predef_SmallFarFlagAction
 ; 3d599
 
 FindPkmnInOTPartyToSwitchIntoBattle: ; 3d599
@@ -4350,7 +4350,7 @@ PursuitSwitch: ; 3dc5b
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, RESET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	call PlayerMonFaintedAnimation
 	ld hl, BattleText_PkmnFainted
 	jr .done_fainted
@@ -6631,7 +6631,7 @@ LoadEnemyMon: ; 3e8eb
 	ld c, a
 	ld b, SET_FLAG
 	ld hl, PokedexSeen
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 
 	ld hl, EnemyMonStats
 	ld de, EnemyStats
@@ -7313,7 +7313,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld c, a
 	ld b, CHECK_FLAG
 	ld d, $0
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	and a
 	pop bc
@@ -7642,7 +7642,7 @@ GiveExperiencePoints: ; 3ee3b
 	ld a, [CurPartyMon]
 	ld c, a
 	ld b, SET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	pop af
 	ld [CurPartyLevel], a
 

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -8078,7 +8078,7 @@ BattleCommand_LeechSeed: ; 36f9d
 
 BattleCommand_Splash: ; 36fe1
 	call AnimateCurrentMove
-	farcall TrainerRankings_Splash
+	farcall StubbedTrainerRankings_Splash
 	jp PrintNothingHappened
 
 ; 36fed
@@ -8605,7 +8605,7 @@ CheckSubstituteOpp: ; 37378
 
 
 BattleCommand_Selfdestruct: ; 37380
-	farcall TrainerRankings_Selfdestruct
+	farcall StubbedTrainerRankings_Selfdestruct
 	ld a, BATTLEANIM_PLAYER_DAMAGE
 	ld [wNumHits], a
 	ld c, 3

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -182,7 +182,7 @@ CheckPlayerTurn:
 	call StdBattleTextBox
 	call CantMove
 	call UpdateBattleMonInParty
-	ld hl, UpdatePlayerHUD
+	ld hl, Predef_UpdatePlayerHUD
 	call CallBattleCore
 	ld a, $1
 	ld [hBGMapMode], a
@@ -433,7 +433,7 @@ CheckEnemyTurn: ; 3421f
 	call StdBattleTextBox
 	call CantMove
 	call UpdateEnemyMonInParty
-	ld hl, UpdateEnemyHUD
+	ld hl, Predef_UpdateEnemyHUD
 	call CallBattleCore
 	ld a, $1
 	ld [hBGMapMode], a
@@ -670,7 +670,7 @@ HitConfusion: ; 343a5
 	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
 	call z, PlayFXAnimID
 
-	ld hl, UpdatePlayerHUD
+	ld hl, Predef_UpdatePlayerHUD
 	call CallBattleCore
 	ld a, $1
 	ld [hBGMapMode], a
@@ -1539,12 +1539,12 @@ BattleCheckTypeMatchup: ; 347c8
 	ld hl, EnemyMonType1
 	ld a, [hBattleTurn]
 	and a
-	jr z, CheckTypeMatchup
+	jr z, Predef_CheckTypeMatchup
 	ld hl, BattleMonType1
-CheckTypeMatchup: ; 347d3
+Predef_CheckTypeMatchup: ; 347d3
 ; There is an incorrect assumption about this function made in the AI related code: when
-; the AI calls CheckTypeMatchup (not BattleCheckTypeMatchup), it assumes that placing the
-; offensive type in a will make this function do the right thing. Since a is overwritten,
+; the AI calls Predef_CheckTypeMatchup (not BattleCheckTypeMatchup), it assumes that placing
+; the offensive type in a will make this function do the right thing. Since a is overwritten,
 ; this assumption is incorrect. A simple fix would be to load the move type for the
 ; current move into a in BattleCheckTypeMatchup, before falling through, which is
 ; consistent with how the rest of the code assumes this code works like.
@@ -2636,7 +2636,7 @@ BattleCommand_CheckDestinyBond: ; 351c0
 	ld [Buffer6], a
 	ld h, b
 	ld l, c
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	call RefreshBattleHuds
 
 	call BattleCommand_SwitchTurn
@@ -4049,7 +4049,7 @@ BattleCommand_PainSplit: ; 35926
 	ld a, $1
 	ld [wWhichHPBar], a
 	hlcoord 10, 9
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	ld hl, EnemyMonHP
 	ld a, [hli]
 	ld [Buffer4], a
@@ -4064,7 +4064,7 @@ BattleCommand_PainSplit: ; 35926
 	ld [wWhichHPBar], a
 	call ResetDamage
 	hlcoord 2, 2
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	farcall _UpdateBattleHUDs
 
 	ld hl, SharedPainText
@@ -4206,7 +4206,7 @@ BattleCommand_Conversion2: ; 359e6
 
 	ld a, [hl]
 	ld [wNamedObjectIndexBuffer], a
-	predef GetTypeName
+	predef Predef_GetTypeName
 	ld hl, TransformedTypeText
 	jp StdBattleTextBox
 
@@ -4744,7 +4744,7 @@ PlayFXAnimID: ; 35d08
 	ld c, 3
 	call DelayFrames
 
-	callfar PlayBattleAnim
+	callfar Predef_PlayBattleAnim
 
 	ret
 
@@ -4806,7 +4806,7 @@ EnemyHurtItself: ; 35d1c
 	hlcoord 2, 2
 	xor a
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 .did_no_damage
 	jp RefreshBattleHuds
 
@@ -4866,7 +4866,7 @@ PlayerHurtItself: ; 35d7e
 	hlcoord 10, 9
 	ld a, $1
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 .did_no_damage
 	jp RefreshBattleHuds
 
@@ -5334,7 +5334,7 @@ SapHealth: ; 36011
 	xor a
 .hp_bar
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	call RefreshBattleHuds
 	jp UpdateBattleMonInParty
 
@@ -6296,11 +6296,11 @@ BattleCommand_Curl: ; 365a7
 
 
 BattleCommand_RaiseSubNoAnim: ; 365af
-	ld hl, GetBattleMonBackpic
+	ld hl, Predef_GetBattleMonBackpic
 	ld a, [hBattleTurn]
 	and a
 	jr z, .PlayerTurn
-	ld hl, GetEnemyMonFrontpic
+	ld hl, Predef_GetEnemyMonFrontpic
 .PlayerTurn:
 	xor a
 	ld [hBGMapMode], a
@@ -7581,7 +7581,7 @@ BattleCommand_Recoil: ; 36cb2
 	xor a
 .animate_hp_bar
 	ld [wWhichHPBar], a
-	predef AnimateHPBar
+	predef Predef_AnimateHPBar
 	call RefreshBattleHuds
 	ld hl, RecoilText
 	jp StdBattleTextBox
@@ -8282,7 +8282,7 @@ BattleCommand_Conversion: ; 3707f
 	inc de
 	ld [de], a
 	ld [wNamedObjectIndexBuffer], a
-	farcall GetTypeName
+	farcall Predef_GetTypeName
 	call AnimateCurrentMove
 	ld hl, TransformedTypeText
 	jp StdBattleTextBox
@@ -9911,7 +9911,7 @@ PlayUserBattleAnim: ; 37e47
 	push hl
 	push de
 	push bc
-	callfar PlayBattleAnim
+	callfar Predef_PlayBattleAnim
 	pop bc
 	pop de
 	pop hl
@@ -9933,7 +9933,7 @@ PlayOpponentBattleAnim: ; 37e54
 	push bc
 	call BattleCommand_SwitchTurn
 
-	callfar PlayBattleAnim
+	callfar Predef_PlayBattleAnim
 
 	call BattleCommand_SwitchTurn
 	pop bc

--- a/engine/battle/effect_commands/attract.asm
+++ b/engine/battle/effect_commands/attract.asm
@@ -35,7 +35,7 @@ CheckOppositeGender: ; 377f5
 	xor a
 	ld [MonType], a
 
-	farcall GetGender
+	farcall Predef_GetGender
 	jr c, .genderless_samegender
 
 	ld b, 1
@@ -58,7 +58,7 @@ CheckOppositeGender: ; 377f5
 	ld [TempMonDVs + 1], a
 	ld a, 3
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	pop bc
 	jr c, .genderless_samegender
 

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -33,7 +33,7 @@ AppearUser: ; fbd77 (3e:7d77)
 	ld a, $31
 .okay
 	ld [hGraphicStartTile], a
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 FinishAppearDisappearUser: ; fbd91 (3e:7d91)
 	ld a, $1
 	ld [hBGMapMode], a

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -103,7 +103,7 @@ TrainerType1: ; 397eb
 	ld a, OTPARTYMON
 	ld [MonType], a
 	push hl
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	pop hl
 	jr .loop
 ; 39806
@@ -124,7 +124,7 @@ TrainerType2: ; 39806
 	ld [MonType], a
 
 	push hl
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	ld a, [OTPartyCount]
 	dec a
 	ld hl, OTPartyMon1Moves
@@ -200,7 +200,7 @@ TrainerType3: ; 39871
 	ld a, OTPARTYMON
 	ld [MonType], a
 	push hl
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	ld a, [OTPartyCount]
 	dec a
 	ld hl, OTPartyMon1Item
@@ -231,7 +231,7 @@ TrainerType4: ; 3989d
 	ld [MonType], a
 
 	push hl
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	ld a, [OTPartyCount]
 	dec a
 	ld hl, OTPartyMon1Item

--- a/engine/battle/returntobattle_useball.asm
+++ b/engine/battle/returntobattle_useball.asm
@@ -4,13 +4,13 @@ _ReturnToBattle_UseBall: ; 2715c
 	ld a, [BattleType]
 	cp BATTLETYPE_TUTORIAL
 	jr z, .gettutorialbackpic
-	farcall GetBattleMonBackpic
+	farcall Predef_GetBattleMonBackpic
 	jr .continue
 
 .gettutorialbackpic
 	farcall GetTrainerBackpic
 .continue
-	farcall GetEnemyMonFrontpic
+	farcall Predef_GetEnemyMonFrontpic
 	farcall _LoadBattleFontsHPBar
 	call GetMemSGBLayout
 	call CloseWindow

--- a/engine/battle/start_battle.asm
+++ b/engine/battle/start_battle.asm
@@ -33,7 +33,7 @@ FindFirstAliveMonAndStartBattle: ; 2ee2f
 	add hl, de
 	ld a, [hl]
 	ld [BattleMonLevel], a
-	predef DoBattleTransition
+	predef Predef_DoBattleTransition
 	farcall _LoadBattleFontsHPBar
 	ld a, 1
 	ld [hBGMapMode], a

--- a/engine/battle/start_battle.asm
+++ b/engine/battle/start_battle.asm
@@ -33,7 +33,7 @@ FindFirstAliveMonAndStartBattle: ; 2ee2f
 	add hl, de
 	ld a, [hl]
 	ld [BattleMonLevel], a
-	predef Predef_StartBattle
+	predef DoBattleTransition
 	farcall _LoadBattleFontsHPBar
 	ld a, 1
 	ld [hBGMapMode], a

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -1,6 +1,6 @@
 ; Battle animation command interpreter.
 
-PlayBattleAnim: ; cc0d6
+Predef_PlayBattleAnim: ; cc0d6
 
 	ld a, [rSVBK]
 	push af
@@ -167,7 +167,7 @@ BattleAnimRestoreHuds: ; cc1bb
 	ld [rSVBK], a
 
 	ld hl, UpdateBattleHuds
-	ld a, BANK(UpdatePlayerHUD)
+	ld a, BANK(Predef_UpdatePlayerHUD)
 	rst FarCall ; Why not "call UpdateBattleHuds"?
 
 	pop af
@@ -929,18 +929,18 @@ BattleAnimCmd_Transform: ; cc5dc (33:45dc)
 	ld a, [TempBattleMonSpecies] ; TempBattleMonSpecies
 	ld [CurPartySpecies], a ; CurPartySpecies
 	ld hl, BattleMonDVs ; BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles0 tile $00
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	jr .done
 
 .player
 	ld a, [TempEnemyMonSpecies] ; TempEnemyMonSpecies
 	ld [CurPartySpecies], a ; CurPartySpecies
 	ld hl, EnemyMonDVs ; EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles0 tile $00
-	predef GetMonBackpic
+	predef Predef_GetMonBackpic
 
 .done
 	pop af
@@ -1156,16 +1156,16 @@ BattleAnimCmd_BeatUp: ; cc776 (33:4776)
 	jr z, .player
 
 	ld hl, BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles2 tile $00
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	jr .done
 
 .player
 	ld hl, EnemyMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld de, vTiles2 tile $31
-	predef GetMonBackpic
+	predef Predef_GetMonBackpic
 
 .done
 	pop af

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -232,8 +232,7 @@ ClearActorHud: ; cc207
 	ret
 ; cc220
 
-Functioncc220: ; cc220
-; Appears to be unused.
+Unreferenced_Functioncc220: ; cc220
 	xor a
 	ld [hBGMapMode], a
 	ld a, LOW(vBGMap0 tile $28)

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -246,7 +246,6 @@ BillsPCDepositMenuDataHeader: ; 0xe253d (38:653d)
 ; 0xe2564 (38:6564)
 
 Unreferenced_BillsPCClearThreeBoxes: ; e2564
-; unreferenced
 	hlcoord 0, 0
 	ld b,  4
 	ld c,  8
@@ -1586,7 +1585,7 @@ endr
 	db -1
 ; e2ed5
 
-BillsPC_UnusedFillBox: ; e2ed5
+Unreferenced_BillsPC_FillBox: ; e2ed5
 .row
 	push bc
 	push hl

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -1099,10 +1099,10 @@ PCMonInfo: ; e2ac6 (38:6ac6)
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	call GetBaseData
 	ld de, vTiles2 tile $00
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	xor a
 	ld [wBillsPC_MonHasMail], a
 	ld a, [CurPartySpecies]
@@ -1119,7 +1119,7 @@ PCMonInfo: ; e2ac6 (38:6ac6)
 
 	ld a, $3
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	jr c, .skip_gender
 	ld a, "♂"
 	jr nz, .printgender
@@ -1702,7 +1702,7 @@ BillsPC_StatsScreen: ; e2f7e (38:6f7e)
 	call BillsPC_CopyMon
 	ld a, $3
 	ld [MonType], a
-	predef StatsScreenInit
+	predef Predef_StatsScreenInit
 	call BillsPC_InitGFX
 	call MaxVolume
 	ret
@@ -1730,7 +1730,7 @@ StatsScreenDPad: ; e2f95 (38:6f95)
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	call GetBaseData
 	call BillsPC_CopyMon
 .pressed_a_b_right_left
@@ -1823,7 +1823,7 @@ DepositPokemon: ; e307c (38:707c)
 	call GetNick
 	ld a, PC_DEPOSIT
 	ld [wPokemonWithdrawDepositParameter], a
-	predef SentGetPkmnIntoFromBox
+	predef Predef_SendGetPkmnIntoFromBox
 	jr c, .asm_boxisfull
 	xor a
 	ld [wPokemonWithdrawDepositParameter], a
@@ -1878,7 +1878,7 @@ TryWithdrawPokemon: ; e30fa (38:70fa)
 	call CloseSRAM
 	xor a
 	ld [wPokemonWithdrawDepositParameter], a
-	predef SentGetPkmnIntoFromBox
+	predef Predef_SendGetPkmnIntoFromBox
 	jr c, .PartyFull
 	ld a, PC_DEPOSIT
 	ld [wPokemonWithdrawDepositParameter], a

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -245,7 +245,7 @@ BillsPCDepositMenuDataHeader: ; 0xe253d (38:653d)
 	db "CANCEL@"
 ; 0xe2564 (38:6564)
 
-BillsPC_ClearThreeBoxes: ; e2564
+Unreferenced_BillsPCClearThreeBoxes: ; e2564
 ; unreferenced
 	hlcoord 0, 0
 	ld b,  4

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -2559,7 +2559,7 @@ BillsPC_ChangeBoxSubmenu: ; e36f9 (38:76f9)
 	ret
 ; e3778 (38:7778)
 
-	hlcoord 11, 7 ; XXX
+	hlcoord 11, 7 ; unused
 
 .MenuDataHeader: ; 0xe377b
 	db $40 ; flags

--- a/engine/billspctop.asm
+++ b/engine/billspctop.asm
@@ -143,7 +143,7 @@ BillsPC_DepositMenu: ; e4fe (3:64fe)
 	and a
 	ret
 
-Functione512: ; unused
+Unreferenced_Functione512:
 	ld a, [PartyCount]
 	and a
 	jr z, .no_pkmn
@@ -212,7 +212,7 @@ BillsPC_WithdrawMenu: ; e559 (3:6559)
 	and a
 	ret
 
-Functione56d: ; unused
+Unreferenced_Functione56d:
 	ld a, [PartyCount]
 	cp PARTY_LENGTH
 	jr nc, .asm_e576

--- a/engine/billspctop.asm
+++ b/engine/billspctop.asm
@@ -268,7 +268,7 @@ CopyBoxmonToTempMon: ; e5bb
 	call CloseSRAM
 	ret
 
-Functione5d9: ; unreferenced
+Unreferenced_Functione5d9:
 	ld a, [wCurBox]
 	cp b
 	jr z, .same_box

--- a/engine/breeding.asm
+++ b/engine/breeding.asm
@@ -10,7 +10,7 @@ CheckBreedmonCompatibility: ; 16e1d
 	ld [TempMonDVs + 1], a
 	ld a, TEMPMON
 	ld [MonType], a
-	predef GetGender
+	predef Predef_GetGender
 	jr c, .genderless
 	ld b, $1
 	jr nz, .breedmon2
@@ -26,7 +26,7 @@ CheckBreedmonCompatibility: ; 16e1d
 	ld [TempMonDVs + 1], a
 	ld a, $3
 	ld [MonType], a
-	predef GetGender
+	predef Predef_GetGender
 	pop bc
 	jr c, .genderless
 	ld a, $1
@@ -289,7 +289,7 @@ HatchEggs: ; 16f70 (5:6f70)
 	ld bc, MON_STAT_EXP - 1
 	add hl, bc
 	ld b, $0
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop bc
 	ld hl, MON_MAXHP
 	add hl, bc
@@ -514,7 +514,7 @@ GLOBAL EggMoves
 	cp b
 	jr nz, .loop5
 	ld [wPutativeTMHMMove], a
-	predef CanLearnTMHMMove
+	predef Predef_CanLearnTMHMMove
 	ld a, c
 	and a
 	jr z, .done
@@ -559,7 +559,7 @@ LoadEggMove: ; 17169
 	ld [hl], b
 	ld hl, wEggMonMoves
 	ld de, wEggMonPP
-	predef FillPP
+	predef Predef_FillPP
 	pop bc
 	pop de
 	ret
@@ -590,7 +590,7 @@ GetHeritableMoves: ; 17197
 	ld [TempMonDVs + 1], a
 	ld a, TEMPMON
 	ld [MonType], a
-	predef GetGender
+	predef Predef_GetGender
 	jr c, .inherit_mon2_moves
 	jr nz, .inherit_mon2_moves
 	jr .inherit_mon1_moves
@@ -606,7 +606,7 @@ GetHeritableMoves: ; 17197
 	ld [TempMonDVs + 1], a
 	ld a, TEMPMON
 	ld [MonType], a
-	predef GetGender
+	predef Predef_GetGender
 	jr c, .inherit_mon1_moves
 	jr nz, .inherit_mon1_moves
 
@@ -647,9 +647,9 @@ GetEggFrontpic: ; 17224 (5:7224)
 	ld [CurSpecies], a
 	call GetBaseData
 	ld hl, BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop de
-	predef_jump GetMonFrontpic
+	predef_jump Predef_GetMonFrontpic
 
 GetHatchlingFrontpic: ; 1723c (5:723c)
 	push de
@@ -657,9 +657,9 @@ GetHatchlingFrontpic: ; 1723c (5:723c)
 	ld [CurSpecies], a
 	call GetBaseData
 	ld hl, BattleMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop de
-	predef_jump GetAnimatedFrontpicPredef
+	predef_jump Predef_GetAnimatedFrontpic
 
 Hatch_UpdateFrontpicBGMapCenter: ; 17254 (5:7254)
 	push af
@@ -677,7 +677,7 @@ Hatch_UpdateFrontpicBGMapCenter: ; 17254 (5:7254)
 	ld a, c
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	pop af
 	call Hatch_LoadFrontpicPal
 	call SetPalettes
@@ -779,7 +779,7 @@ EggHatch_AnimationSequence: ; 1728f (5:728f)
 	hlcoord 6, 3
 	ld d, $0
 	ld e, ANIM_MON_HATCH
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 	pop af
 	ld [CurSpecies], a
 	ret

--- a/engine/breeding.asm
+++ b/engine/breeding.asm
@@ -232,7 +232,7 @@ HatchEggs: ; 16f70 (5:6f70)
 	push de
 
 	farcall SetEggMonCaughtData
-	farcall TrainerRankings_EggsHatched
+	farcall StubbedTrainerRankings_EggsHatched
 	ld a, [CurPartyMon]
 	ld hl, PartyMon1Species
 	ld bc, PARTYMON_STRUCT_LENGTH

--- a/engine/breeding.asm
+++ b/engine/breeding.asm
@@ -981,8 +981,7 @@ DayCareMonCompatibilityText: ; 1746c
 	db "@"
 ; 0x174b5
 
-DayCareMonPrintEmptyString: ; 174b5
-; unreferenced
+Unreferenced_DayCareMonPrintEmptyString: ; 174b5
 	ld hl, .string
 	ret
 ; 174b9

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -2,6 +2,13 @@ CARDFLIP_LIGHT_OFF EQU $ef
 CARDFLIP_LIGHT_ON  EQU $f5
 CARDFLIP_DECK_SIZE EQU 4 * 6
 
+; two labels below called from inside ./dummy_game.asm
+Unknown_e00ed: ; e00ed (38:40ed)
+; Graphics for an unused Game Corner
+; game were meant to be here.
+Ret_e00ed: ; e00ed (38:40ed)
+	ret
+
 _CardFlip: ; e00ee (38:40ee)
 	ld hl, Options
 	set 4, [hl]

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -6,7 +6,7 @@ CARDFLIP_DECK_SIZE EQU 4 * 6
 Unknown_e00ed: ; e00ed (38:40ed)
 ; Graphics for an unused Game Corner
 ; game were meant to be here.
-Ret_e00ed: ; e00ed (38:40ed)
+ret_e00ed: ; e00ed (38:40ed)
 	ret
 
 _CardFlip: ; e00ee (38:40ee)

--- a/engine/caught_data.asm
+++ b/engine/caught_data.asm
@@ -1,4 +1,4 @@
-CheckPartyFullAfterContest: ; 4d9e5
+Special_CheckPartyFullAfterContest: ; 4d9e5
 	ld a, [wContestMon]
 	and a
 	jp z, .DidntCatchAnything

--- a/engine/cgb_layouts.asm
+++ b/engine/cgb_layouts.asm
@@ -6,7 +6,7 @@ CheckCGB: ; 8d55
 	ret
 ; 8d59
 
-Predef_LoadSGBLayoutCGB: ; 8d59
+LoadSGBLayoutCGB: ; 8d59
 	ld a, b
 	cp SCGB_RAM
 	jr nz, .not_ram

--- a/engine/clock_reset.asm
+++ b/engine/clock_reset.asm
@@ -220,6 +220,7 @@ RestartClock: ; 20021 (8:4021)
 	ret
 ; 20160 (8:4160)
 
+; unused
 .unreferenced ; 20160
 	ld a, [Buffer3]
 	ld b, a

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -43,7 +43,7 @@ CheckShininess:
 	and a
 	ret
 
-Unreferenced_CheckContestMon:
+UnusedPredef_CheckContestMon:
 ; Check a mon's DVs at hl in the bug catching contest.
 ; Return carry if its DVs are good enough to place in the contest.
 

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -43,8 +43,7 @@ CheckShininess:
 	and a
 	ret
 
-; unreferenced
-CheckContestMon:
+Unreferenced_CheckContestMon:
 ; Check a mon's DVs at hl in the bug catching contest.
 ; Return carry if its DVs are good enough to place in the contest.
 
@@ -135,8 +134,7 @@ SGB_ApplyPartyMenuHPPals: ; 8ade
 	ld [hl], e
 	ret
 
-Function8b07:
-; Unreferenced
+Unreferenced_Function8b07:
 	call CheckCGB
 	ret z
 ; CGB only
@@ -169,8 +167,7 @@ Function8b07:
 	RGB 08, 16, 28
 	RGB 00, 00, 00
 
-Function8b3f:
-; Unreferenced
+Unreferenced_Function8b3f:
 	call CheckCGB
 	ret nz
 	ld a, [hSGB]

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -854,7 +854,7 @@ PushSGBPals:
 	jr nz, .loop
 	ret
 
-InitSGBBorder:
+Predef_InitSGBBorder:
 	call CheckCGB
 	ret nz
 ; SGB/DMG only

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -737,7 +737,8 @@ GetMonPalettePointer_:
 	call GetMonPalettePointer
 	ret
 
-Function9779: mobile
+Unreferenced_Function9779:
+	ret
 	call CheckCGB
 	ret z
 	ld hl, BattleObjectPals

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -78,8 +78,7 @@ CheckContestMon:
 	and a
 	ret
 
-Function8aa4:
-; XXX
+Unreferenced_Function8aa4:
 	push de
 	push bc
 	ld hl, PalPacket_9ce6
@@ -180,8 +179,7 @@ Function8b3f:
 	ld hl, BlkPacket_9a86
 	jp PushSGBPals_
 
-Function8b4d:
-; XXX
+Unreferenced_Function8b4d:
 	call CheckCGB
 	jr nz, .cgb
 	ld a, [hSGB]
@@ -196,8 +194,7 @@ Function8b4d:
 	call GetPredefPal
 	jp LoadHLPaletteIntoDE
 
-Function8b67:
-; XXX
+Unreferenced_Function8b67:
 	call CheckCGB
 	jr nz, .cgb
 	ld a, [hSGB]
@@ -212,8 +209,7 @@ Function8b67:
 	call GetPredefPal
 	jp LoadHLPaletteIntoDE
 
-Function8b81:
-; XXX
+Unreferenced_Function8b81:
 	call CheckCGB
 	jr nz, .cgb
 	ld a, [hSGB]
@@ -281,8 +277,7 @@ got_palette_pointer_8bd7
 	call LoadPalette_White_Col1_Col2_Black
 	ret
 
-Function8bec:
-; XXX
+Unreferenced_Function8bec:
 	ld a, [hCGB]
 	and a
 	jr nz, .cgb
@@ -455,8 +450,7 @@ INCLUDE "data/palettes/mail.pal"
 
 INCLUDE "engine/cgb_layouts.asm"
 
-Function95f0:
-; XXX
+Unreferenced_Function95f0:
 	ld hl, .Palette
 	ld de, wBGPals1
 	ld bc, 1 palettes
@@ -768,8 +762,7 @@ Function9779: mobile
 BattleObjectPals:
 INCLUDE "data/palettes/battle_objects.pal"
 
-Function97cc:
-; XXX
+Unreferenced_Function97cc:
 	call CheckCGB
 	ret z
 	ld a, $90
@@ -979,8 +972,7 @@ _InitSGBBorderPals:
 	dw PalPacket_9dd6
 	dw PalPacket_9de6
 
-Function9911:
-; XXX
+Unreferenced_Function9911:
 	di
 	xor a
 	ld [rJOYP], a

--- a/engine/crystal_colors.asm
+++ b/engine/crystal_colors.asm
@@ -322,5 +322,5 @@ InitMG_Mobile_LinkTradePalMap: ; 49856
 	ret
 ; 4985a
 
-Unknown_4985a: ; unreferenced
+; unused
 INCLUDE "data/palettes/unknown/4985a.asm"

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -315,12 +315,12 @@ Function81adb: ; 81adb
 	hlcoord 12, 3
 	call _PrepMonFrontpic
 	ld de, vTiles2 tile $31
-	predef GetMonBackpic
+	predef Predef_GetMonBackpic
 	ld a, $31
 	ld [hGraphicStartTile], a
 	hlcoord 2, 4
 	lb bc, 6, 6
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld a, [wd003]
 	and a
 	jr z, .asm_81b66
@@ -346,13 +346,13 @@ Function81adb: ; 81adb
 	hlcoord 4, 1
 	call PlaceString
 	ld de, vTiles2
-	callfar GetTrainerPic
+	callfar Predef_GetTrainerPic
 	xor a
 	ld [TempEnemyMonSpecies], a
 	ld [hGraphicStartTile], a
 	hlcoord 2, 3
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 
 .asm_81ba9
 	ld a, $1
@@ -739,7 +739,7 @@ Function81df4: ; 81df4
 	ld a, [wd004]
 	inc a
 	ld [wd265], a
-	predef GetTMHMMove
+	predef Predef_GetTMHMMove
 	ld a, [wd265]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
@@ -748,7 +748,7 @@ Function81df4: ; 81df4
 	ld a, [wd004]
 	call Function81e55
 	ld [CurItem], a
-	predef CanLearnTMHMMove
+	predef Predef_CanLearnTMHMMove
 	ld a, c
 	and a
 	ld de, String_81e46

--- a/engine/decorations.asm
+++ b/engine/decorations.asm
@@ -1197,7 +1197,7 @@ DecorationDesc_GiantOrnament: ; 26fdd
 	db "@"
 ; 0x26feb
 
-ToggleMaptileDecorations: ; 26feb
+Special_ToggleMaptileDecorations: ; 26feb
 	lb de, 0, 4
 	ld a, [Bed]
 	call SetDecorationTile
@@ -1251,7 +1251,7 @@ SetDecorationTile: ; 27037
 	ret
 ; 27043
 
-ToggleDecorationsVisibility: ; 27043
+Special_ToggleDecorationsVisibility: ; 27043
 	ld de, EVENT_KRISS_HOUSE_2F_CONSOLE
 	ld hl, VariableSprites + SPRITE_CONSOLE - SPRITE_VARS
 	ld a, [Console]

--- a/engine/dma_transfer.asm
+++ b/engine/dma_transfer.asm
@@ -112,7 +112,7 @@ Mobile_ReloadMapPart: ; 104099
 	ret
 ; 1040d4
 
-; XXX
+; unused
 	ld hl, .unreferenced_1040da
 	jp CallInSafeGFXMode
 
@@ -136,7 +136,7 @@ Mobile_ReloadMapPart: ; 104099
 	ret
 ; 1040fb
 
-; XXX
+; unused
 	ld hl, .unreferenced_104101
 	jp CallInSafeGFXMode
 

--- a/engine/dummy_game.asm
+++ b/engine/dummy_game.asm
@@ -77,7 +77,7 @@ _DummyGame: ; e1e5b (38:5e5b)
 	ret
 
 .ResetBoard:
-	call ret_e00ed
+	call Ret_e00ed
 	jr nc, .proceed
 	ld hl, wJumptableIndex
 	set 7, [hl]
@@ -232,7 +232,7 @@ endr
 	ld hl, wJumptableIndex
 	inc [hl]
 .AskPlayAgain:
-	call ret_e00ed
+	call Ret_e00ed
 	jr nc, .restart
 	ld hl, wJumptableIndex
 	set 7, [hl]

--- a/engine/dummy_game.asm
+++ b/engine/dummy_game.asm
@@ -77,7 +77,7 @@ _DummyGame: ; e1e5b (38:5e5b)
 	ret
 
 .ResetBoard:
-	call Ret_e00ed
+	call ret_e00ed
 	jr nc, .proceed
 	ld hl, wJumptableIndex
 	set 7, [hl]
@@ -232,7 +232,7 @@ endr
 	ld hl, wJumptableIndex
 	inc [hl]
 .AskPlayAgain:
-	call Ret_e00ed
+	call ret_e00ed
 	jr nc, .restart
 	ld hl, wJumptableIndex
 	set 7, [hl]

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -1060,7 +1060,7 @@ Invalid_0x96c2d: ; 96c2d
 	end
 ; 96c2e
 
-; unreferenced
+; unused
 	end
 ; 96c2f
 

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -994,6 +994,7 @@ CountStep: ; 96b79
 	ret
 ; 96bd3
 
+; unused
 .unreferenced ; 96bd3
 	ld a, 7
 	scf

--- a/engine/events/buena.asm
+++ b/engine/events/buena.asm
@@ -1,4 +1,4 @@
-SpecialBuenasPassword: ; 8af6b
+Special_BuenasPassword: ; 8af6b
 	xor a
 	ld [wWhichIndexSet], a
 	ld hl, .MenuDataHeader
@@ -64,7 +64,7 @@ SpecialBuenasPassword: ; 8af6b
 	ret
 ; 8afd4
 
-SpecialBuenaPrize: ; 8afd4
+Special_BuenaPrize: ; 8afd4
 	xor a
 	ld [wMenuScrollPosition], a
 	ld a, $1

--- a/engine/events/buena_menu.asm
+++ b/engine/events/buena_menu.asm
@@ -1,4 +1,4 @@
-AskRememberPassword: ; 4ae12
+Special_AskRememberPassword: ; 4ae12
 	call .DoMenu
 	ld a, $0
 	jr c, .okay

--- a/engine/events/bug_contest/contest_2.asm
+++ b/engine/events/bug_contest/contest_2.asm
@@ -87,7 +87,7 @@ BugCatchingContestantEventFlagTable: ; 139fe
 	dw EVENT_BUG_CATCHING_CONTESTANT_10A
 ; 13a12
 
-ContestDropOffMons: ; 13a12
+Special_ContestDropOffMons: ; 13a12
 	ld hl, PartyMon1HP
 	ld a, [hli]
 	or [hl]
@@ -112,7 +112,7 @@ ContestDropOffMons: ; 13a12
 	ret
 ; 13a31
 
-ContestReturnMons: ; 13a31
+Special_ContestReturnMons: ; 13a31
 ; Restore the species of the second mon.
 	ld hl, PartySpecies + 1
 	ld a, [wBugContestSecondPartySpecies]

--- a/engine/events/bug_contest/display_stats.asm
+++ b/engine/events/bug_contest/display_stats.asm
@@ -101,7 +101,7 @@ DisplayAlreadyCaughtText: ; cc0c7
 	text_jump UnknownText_0x1c10dd
 	db "@"
 
-Predef2F:
-Predef38:
-Predef39: ; cc0d5
+DummyPredef2F:
+DummyPredef38:
+DummyPredef39: ; cc0d5
 	ret

--- a/engine/events/bug_contest/judging.asm
+++ b/engine/events/bug_contest/judging.asm
@@ -1,6 +1,6 @@
 _Special_BugContestJudging: ; 1369d
 	call ContestScore
-	farcall TrainerRankings_BugContestScore
+	farcall StubbedTrainerRankings_BugContestScore
 	call BugContest_JudgeContestants
 	ld a, [wBugContestThirdPlaceWinnerID]
 	call LoadContestantName

--- a/engine/events/bug_contest/judging.asm
+++ b/engine/events/bug_contest/judging.asm
@@ -1,4 +1,4 @@
-_BugContestJudging: ; 1369d
+_Special_BugContestJudging: ; 1369d
 	call ContestScore
 	farcall TrainerRankings_BugContestScore
 	call BugContest_JudgeContestants

--- a/engine/events/catch_tutorial.asm
+++ b/engine/events/catch_tutorial.asm
@@ -41,7 +41,7 @@ CatchTutorial:: ; 4e554
 	ld hl, .AutoInput
 	ld a, BANK(.AutoInput)
 	call StartAutoInput
-	callfar StartBattle
+	callfar Predef_StartBattle
 	call StopAutoInput
 	pop af
 

--- a/engine/events/celebi.asm
+++ b/engine/events/celebi.asm
@@ -361,7 +361,7 @@ CelebiEvent_SetBattleType: ; 49bf3
 
 ; 49bf9
 
-CheckCaughtCelebi: ; 49bf9
+Special_CheckCaughtCelebi: ; 49bf9
 	ld a, [wBattleResult]
 	bit 6, a
 	jr z, .false

--- a/engine/events/crystal_unown.asm
+++ b/engine/events/crystal_unown.asm
@@ -1,4 +1,4 @@
-SpecialHoOhChamber: ; 0x8addb
+Special_HoOhChamber: ; 0x8addb
 	ld hl, PartySpecies
 	ld a, [hl]
 	cp HO_OH ; is Ho-oh the first Pokémon in the party?
@@ -11,7 +11,7 @@ SpecialHoOhChamber: ; 0x8addb
 	ret
 ; 0x8adef
 
-SpecialOmanyteChamber: ; 8adef
+Special_OmanyteChamber: ; 8adef
 	call GetSecondaryMapHeaderPointer
 	ld de, EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER
 	ld b, CHECK_FLAG

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -565,7 +565,7 @@ DayCare_GiveEgg: ; 169ac
 	pop hl
 	push bc
 	ld b, $0
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop bc
 	ld hl, MON_HP
 	add hl, bc
@@ -639,7 +639,7 @@ DayCare_InitBreeding: ; 16a3b
 	cp DITTO
 	ld a, $0
 	jr z, .LoadWhichBreedmonIsTheMother
-	farcall GetGender
+	farcall Predef_GetGender
 	ld a, $0
 	jr z, .LoadWhichBreedmonIsTheMother
 	inc a
@@ -684,7 +684,7 @@ DayCare_InitBreeding: ; 16a3b
 	ld de, wEggMonMoves
 	xor a
 	ld [Buffer1], a
-	predef FillMoves
+	predef Predef_FillMoves
 	farcall InitEggMoves
 	ld hl, wEggMonID
 	ld a, [PlayerID]
@@ -726,7 +726,7 @@ DayCare_InitBreeding: ; 16a3b
 	ld a, TEMPMON
 	ld [MonType], a
 	push hl
-	farcall GetGender
+	farcall Predef_GetGender
 	pop hl
 	ld de, wBreedMon1DVs
 	ld bc, wBreedMon2DVs
@@ -770,7 +770,7 @@ DayCare_InitBreeding: ; 16a3b
 	call CopyBytes
 	ld hl, wEggMonMoves
 	ld de, wEggMonPP
-	predef FillPP
+	predef Predef_FillPP
 	ld hl, wMonOrItemNameBuffer
 	ld de, StringBuffer1
 	ld bc, NAME_LENGTH

--- a/engine/events/dratini.asm
+++ b/engine/events/dratini.asm
@@ -1,4 +1,4 @@
-SpecialDratini: ; 0x8b170
+Special_Dratini: ; 0x8b170
 ; if ScriptVar is 0 or 1, change the moveset of the last Dratini in the party.
 ;  0: give it a special moveset with Extremespeed.
 ;  1: give it the normal moveset of a level 15 Dratini.

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -7,7 +7,7 @@ PlayWhirlpoolSound: ; 8c7d4
 ; 8c7e1
 
 BlindingFlash: ; 8c7e1
-	farcall FadeOutPalettes
+	farcall Special_FadeOutPalettes
 	ld hl, wStatusFlags
 	set 2, [hl] ; Flash
 	farcall ReplaceTimeOfDayPals
@@ -15,7 +15,7 @@ BlindingFlash: ; 8c7e1
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
 	farcall LoadOW_BGPal7
-	farcall FadeInPalettes
+	farcall Special_FadeInPalettes
 	ret
 ; 8c80a
 

--- a/engine/events/fruit_trees.asm
+++ b/engine/events/fruit_trees.asm
@@ -58,7 +58,7 @@ CheckFruitTree: ; 44055
 ; 4405f
 
 PickedFruitTree: ; 4405f
-	farcall TrainerRankings_FruitPicked
+	farcall StubbedTrainerRankings_FruitPicked
 	ld b, 1
 	jp GetFruitTreeFlag
 ; 4406a

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -42,7 +42,7 @@ RedCredits:: ; 86455
 	ld [MusicFadeID + 1], a
 	ld a, 10
 	ld [MusicFade], a
-	farcall FadeOutPalettes
+	farcall Special_FadeOutPalettes
 	xor a
 	ld [VramState], a
 	ld [hMapAnims], a
@@ -65,7 +65,7 @@ HallOfFame_FadeOutMusic: ; 8648e
 	ld [MusicFadeID + 1], a
 	ld a, 10
 	ld [MusicFade], a
-	farcall FadeOutPalettes
+	farcall Special_FadeOutPalettes
 	xor a
 	ld [VramState], a
 	ld [hMapAnims], a

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -130,7 +130,7 @@ AnimateHallOfFame: ; 864c3
 	call WaitBGMap
 	decoord 6, 5
 	ld c, $6
-	predef HOF_AnimateFrontpic
+	predef HOF_Predef_AnimateFrontpic
 	ld c, 60
 	call DelayFrames
 	and a
@@ -244,18 +244,18 @@ AnimateHOFMonEntrance: ; 865b5
 	ld a, [hli]
 	ld [TempMonDVs + 1], a
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, " "
 	call ByteFill
 	ld de, vTiles2 tile $31
-	predef GetMonBackpic
+	predef Predef_GetMonBackpic
 	ld a, $31
 	ld [hGraphicStartTile], a
 	hlcoord 6, 6
 	lb bc, 6, 6
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld a, $d0
 	ld [hSCY], a
 	ld a, $90
@@ -403,7 +403,7 @@ _HallOfFamePC: ; 86650
 	call SetPalettes
 	decoord 6, 5
 	ld c, $6
-	predef HOF_AnimateFrontpic
+	predef HOF_Predef_AnimateFrontpic
 	and a
 	ret
 
@@ -478,7 +478,7 @@ DisplayHOFMon: ; 86748
 	ld [CurPartySpecies], a
 	ld [wd265], a
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	xor a
 	ld [wBoxAlignment], a
 	hlcoord 6, 5
@@ -499,7 +499,7 @@ DisplayHOFMon: ; 86748
 	call PlaceString
 	ld a, TEMPMON
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	ld a, " "
 	jr c, .got_gender
 	ld a, "♂"
@@ -546,7 +546,7 @@ HOF_AnimatePlayerPic: ; 86810
 	ld [hGraphicStartTile], a
 	hlcoord 6, 6
 	lb bc, 6, 6
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld a, $d0
 	ld [hSCY], a
 	ld a, $90
@@ -570,7 +570,7 @@ HOF_AnimatePlayerPic: ; 86810
 	ld [hGraphicStartTile], a
 	hlcoord 12, 5
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld a, $c0
 	ld [hSCX], a
 	call WaitBGMap

--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -1,4 +1,4 @@
-GetFirstPokemonHappiness: ; 718d
+Special_GetFirstPokemonHappiness: ; 718d
 	ld hl, PartyMon1Happiness
 	ld bc, PARTYMON_STRUCT_LENGTH
 	ld de, PartySpecies
@@ -17,7 +17,7 @@ GetFirstPokemonHappiness: ; 718d
 	call GetPokemonName
 	jp CopyPokemonName_Buffer1_Buffer3
 
-CheckFirstMonIsEgg: ; 71ac
+Special_CheckFirstMonIsEgg: ; 71ac
 	ld a, [PartySpecies]
 	ld [wd265], a
 	cp EGG

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -1,4 +1,4 @@
-HealMachineAnim: ; 12324
+Special_HealMachineAnim: ; 12324
 	; If you have no Pokemon, don't change the buffer.  This can lead to some glitchy effects if you have no Pokemon.
 	ld a, [PartyCount]
 	and a

--- a/engine/events/itemfinder.asm
+++ b/engine/events/itemfinder.asm
@@ -30,7 +30,7 @@ ItemFinder: ; 12580
 
 .Script_FoundSomething: ; 0x125ad
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	callasm .ItemfinderSound
 	writetext .Text_FoundSomething
 	closetext
@@ -39,7 +39,7 @@ ItemFinder: ; 12580
 
 .Script_FoundNothing: ; 0x125ba
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writetext .Text_FoundNothing
 	closetext
 	end

--- a/engine/events/itemfinder.asm
+++ b/engine/events/itemfinder.asm
@@ -30,7 +30,7 @@ ItemFinder: ; 12580
 
 .Script_FoundSomething: ; 0x125ad
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	callasm .ItemfinderSound
 	writetext .Text_FoundSomething
 	closetext
@@ -39,7 +39,7 @@ ItemFinder: ; 12580
 
 .Script_FoundNothing: ; 0x125ba
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writetext .Text_FoundNothing
 	closetext
 	end

--- a/engine/events/kurt.asm
+++ b/engine/events/kurt.asm
@@ -163,7 +163,7 @@ Kurt_SelectQuantity: ; 880c2
 	db 09, 06 ; start coords
 	db 12, 19 ; end coords
 
-	db 0, 0, -1, 0 ; XXX
+	db 0, 0, -1, 0 ; unused
 
 .PlaceApricornName: ; 88116
 	call MenuBoxCoord2Tile

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -103,7 +103,7 @@ Special_CheckForLuckyNumberWinners: ; 4d87a
 	ld a, [ScriptVar]
 	and a
 	ret z ; found nothing
-	farcall TrainerRankings_LuckyNumberShow
+	farcall StubbedTrainerRankings_LuckyNumberShow
 	ld a, [wFoundMatchingIDInParty]
 	and a
 	push af

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -28,7 +28,7 @@ Special_CheckMagikarpLength: ; fbb32
 	ld c, l
 	call CalcMagikarpLength
 	call PrintMagikarpLength
-	farcall TrainerRankings_MagikarpLength
+	farcall StubbedTrainerRankings_MagikarpLength
 	ld hl, .MeasureItText
 	call PrintText
 

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -442,7 +442,7 @@ MagnetTrain_Jumptable_FirstRunThrough: ; 8ceae
 	ld [wEnvironment], a
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	ld a, [rBGP]
 	ld [wBGP], a
 	ld a, [rOBP0]

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -442,7 +442,7 @@ MagnetTrain_Jumptable_FirstRunThrough: ; 8ceae
 	ld [wEnvironment], a
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	ld a, [rBGP]
 	ld [wBGP], a
 	ld a, [rOBP0]

--- a/engine/events/misc_scripts.asm
+++ b/engine/events/misc_scripts.asm
@@ -2,7 +2,7 @@ Script_AbortBugContest: ; 0x122c1
 	checkflag ENGINE_BUG_CONTEST_TIMER
 	iffalse .finish
 	setflag ENGINE_DAILY_BUG_CONTEST
-	special ContestReturnMons
+	special Special_ContestReturnMons
 .finish
 	end
 

--- a/engine/events/mom_phone.asm
+++ b/engine/events/mom_phone.asm
@@ -257,7 +257,7 @@ _MomText_ItsInRoom: ; 0xfd1ca
 
 	db 0 ; unused
 
-Predef3A: ; fd1d0
+DummyPredef3A: ; fd1d0
 	ret
 ; fd1d1
 

--- a/engine/events/mom_phone.asm
+++ b/engine/events/mom_phone.asm
@@ -217,7 +217,7 @@ endr
 
 INCLUDE "data/items/mom_phone.asm"
 
-	db 0, 0, 0 ; XXX
+	db 0, 0, 0 ; unused
 
 _MomText_HiHowAreYou: ; 0xfd1b1
 	; Hi,  ! How are you?
@@ -255,10 +255,10 @@ _MomText_ItsInRoom: ; 0xfd1ca
 	db "@"
 ; 0xfd1cf
 
-	db 0 ; XXX
+	db 0 ; unused
 
 Predef3A: ; fd1d0
 	ret
 ; fd1d1
 
-	ret ; XXX
+	ret ; unused

--- a/engine/events/move_deleter.asm
+++ b/engine/events/move_deleter.asm
@@ -1,4 +1,4 @@
-MoveDeletion:
+Special_MoveDeletion:
 	ld hl, .IntroText
 	call PrintText
 	call YesNoBox

--- a/engine/events/move_tutor.asm
+++ b/engine/events/move_tutor.asm
@@ -54,7 +54,7 @@ CheckCanLearnMoveTutorMove: ; 492b9
 	ld hl, .MenuDataHeader
 	call LoadMenuDataHeader
 
-	predef CanLearnTMHMMove
+	predef Predef_CanLearnTMHMMove
 
 	push bc
 	ld a, [CurPartyMon]
@@ -78,7 +78,7 @@ CheckCanLearnMoveTutorMove: ; 492b9
 	callfar KnowsMove
 	jr c, .didnt_learn
 
-	predef LearnMove
+	predef Predef_LearnMove
 	ld a, b
 	and a
 	jr z, .didnt_learn

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -986,7 +986,7 @@ StrengthFunction: ; cce5
 	jr c, .Failed
 	jr .UseStrength
 
-.AlreadyUsing: ; unreferenced
+.Unreferenced_AlreadyUsing:
 	ld hl, .JumpText
 	call MenuTextBoxBackup
 	ld a, $80

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -208,7 +208,7 @@ CheckMapForSomethingToCut: ; c7ce
 
 Script_CutFromMenu: ; c7fe
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 Script_Cut: ; 0xc802
 	callasm GetPartyNick
@@ -318,7 +318,7 @@ UseFlash: ; c8e0
 
 Script_UseFlash: ; 0xc8e6
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writetext UnknownText_0xc8f3
 	callasm BlindingFlash
 	closetext
@@ -407,7 +407,7 @@ SurfFunction: ; c909
 	ret
 
 SurfFromMenuScript: ; c983
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 UsedSurfScript: ; c986
 	writetext UsedSurfText ; "used SURF!"
@@ -620,10 +620,10 @@ FlyFunction: ; ca3b
 .FlyScript: ; 0xcaa3
 	reloadmappart
 	callasm HideSprites
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	callasm FlyFromAnim
 	farscall Script_AbortBugContest
-	special WarpToSpawnPoint
+	special Special_WarpToSpawnPoint
 	callasm DelayLoadingNewSprites
 	writecode VAR_MOVEMENT, PLAYER_NORMAL
 	newloadmap MAPSETUP_FLY
@@ -680,7 +680,7 @@ CheckMapCanWaterfall: ; cb07
 
 Script_WaterfallFromMenu: ; 0xcb1c
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 Script_UsedWaterfall: ; 0xcb20
 	callasm GetPartyNick
@@ -856,13 +856,13 @@ dig_incave
 
 .UsedEscapeRopeScript: ; 0xcc2b
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writetext .Text_UsedEscapeRope
 	jump .UsedDigOrEscapeRopeScript
 
 .UsedDigScript: ; 0xcc35
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writetext .Text_UsedDig
 
 .UsedDigOrEscapeRopeScript: ; 0xcc3c
@@ -871,7 +871,7 @@ dig_incave
 	playsound SFX_WARP_TO
 	applymovement PLAYER, .DigOut
 	farscall Script_AbortBugContest
-	special WarpToSpawnPoint
+	special Special_WarpToSpawnPoint
 	writecode VAR_MOVEMENT, PLAYER_NORMAL
 	newloadmap MAPSETUP_DOOR
 	playsound SFX_WARP_FROM
@@ -950,7 +950,7 @@ TeleportFunction: ; cc61
 
 .TeleportScript: ; 0xccbb
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writetext .Text_ReturnToLastMonCenter
 	pause 60
 	reloadmappart
@@ -958,7 +958,7 @@ TeleportFunction: ; cc61
 	playsound SFX_WARP_TO
 	applymovement PLAYER, .TeleportFrom
 	farscall Script_AbortBugContest
-	special WarpToSpawnPoint
+	special Special_WarpToSpawnPoint
 	writecode VAR_MOVEMENT, PLAYER_NORMAL
 	newloadmap MAPSETUP_TELEPORT
 	playsound SFX_WARP_FROM
@@ -1021,7 +1021,7 @@ SetStrengthFlag: ; cd12
 
 Script_StrengthFromMenu: ; 0xcd29
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 Script_UsedStrength: ; 0xcd2d
 	callasm SetStrengthFlag
@@ -1183,7 +1183,7 @@ TryWhirlpoolMenu: ; cdde
 
 Script_WhirlpoolFromMenu: ; 0xce0b
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 Script_UsedWhirlpool: ; 0xce0f
 	callasm GetPartyNick
@@ -1284,7 +1284,7 @@ UnknownText_0xcea2: ; 0xcea2
 
 HeadbuttFromMenuScript: ; 0xcea7
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 HeadbuttScript: ; 0xceab
 	callasm GetPartyNick
@@ -1382,7 +1382,7 @@ GetFacingObject: ; cf0d
 
 RockSmashFromMenuScript: ; 0xcf2e
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 
 RockSmashScript: ; cf32
 	callasm GetPartyNick
@@ -1611,7 +1611,7 @@ Fishing_CheckFacingUp: ; d06c
 Script_FishCastRod: ; 0xd07c
 	reloadmappart
 	loadvar hBGMapMode, $0
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	loademote EMOTE_ROD
 	callasm LoadFishingGFX
 	loademote EMOTE_SHOCK
@@ -1735,7 +1735,7 @@ BikeFunction: ; d0b3
 
 Script_GetOnBike: ; 0xd13e
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writecode VAR_MOVEMENT, PLAYER_BIKE
 	writetext GotOnTheBikeText
 	waitbutton
@@ -1755,7 +1755,7 @@ Script_GetOnBike_Register: ; 0xd14e
 
 Script_GetOffBike: ; 0xd158
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	writecode VAR_MOVEMENT, PLAYER_NORMAL
 	writetext GotOffTheBikeText
 	waitbutton

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -1749,7 +1749,7 @@ Script_GetOnBike_Register: ; 0xd14e
 	special ReplaceKrisSprite
 	end
 
-; XXX
+; unused
 	nop
 	ret
 

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -427,7 +427,7 @@ UsedSurfScript: ; c986
 	end
 
 .empty_fn ; c9a2
-	farcall TrainerRankings_Surf
+	farcall StubbedTrainerRankings_Surf
 	ret
 
 UsedSurfText: ; c9a9
@@ -700,7 +700,7 @@ Script_UsedWaterfall: ; 0xcb20
 	ld a, [PlayerStandingTile]
 	call CheckWaterfallTile
 	ret z
-	farcall TrainerRankings_Waterfall
+	farcall StubbedTrainerRankings_Waterfall
 	ld a, $1
 	ld [ScriptVar], a
 	ret

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -208,7 +208,7 @@ CheckMapForSomethingToCut: ; c7ce
 
 Script_CutFromMenu: ; c7fe
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 Script_Cut: ; 0xc802
 	callasm GetPartyNick
@@ -318,7 +318,7 @@ UseFlash: ; c8e0
 
 Script_UseFlash: ; 0xc8e6
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writetext UnknownText_0xc8f3
 	callasm BlindingFlash
 	closetext
@@ -407,7 +407,7 @@ SurfFunction: ; c909
 	ret
 
 SurfFromMenuScript: ; c983
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 UsedSurfScript: ; c986
 	writetext UsedSurfText ; "used SURF!"
@@ -620,7 +620,7 @@ FlyFunction: ; ca3b
 .FlyScript: ; 0xcaa3
 	reloadmappart
 	callasm HideSprites
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	callasm FlyFromAnim
 	farscall Script_AbortBugContest
 	special Special_WarpToSpawnPoint
@@ -680,7 +680,7 @@ CheckMapCanWaterfall: ; cb07
 
 Script_WaterfallFromMenu: ; 0xcb1c
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 Script_UsedWaterfall: ; 0xcb20
 	callasm GetPartyNick
@@ -856,13 +856,13 @@ dig_incave
 
 .UsedEscapeRopeScript: ; 0xcc2b
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writetext .Text_UsedEscapeRope
 	jump .UsedDigOrEscapeRopeScript
 
 .UsedDigScript: ; 0xcc35
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writetext .Text_UsedDig
 
 .UsedDigOrEscapeRopeScript: ; 0xcc3c
@@ -950,7 +950,7 @@ TeleportFunction: ; cc61
 
 .TeleportScript: ; 0xccbb
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writetext .Text_ReturnToLastMonCenter
 	pause 60
 	reloadmappart
@@ -1021,7 +1021,7 @@ SetStrengthFlag: ; cd12
 
 Script_StrengthFromMenu: ; 0xcd29
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 Script_UsedStrength: ; 0xcd2d
 	callasm SetStrengthFlag
@@ -1183,7 +1183,7 @@ TryWhirlpoolMenu: ; cdde
 
 Script_WhirlpoolFromMenu: ; 0xce0b
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 Script_UsedWhirlpool: ; 0xce0f
 	callasm GetPartyNick
@@ -1284,7 +1284,7 @@ UnknownText_0xcea2: ; 0xcea2
 
 HeadbuttFromMenuScript: ; 0xcea7
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 HeadbuttScript: ; 0xceab
 	callasm GetPartyNick
@@ -1382,7 +1382,7 @@ GetFacingObject: ; cf0d
 
 RockSmashFromMenuScript: ; 0xcf2e
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 
 RockSmashScript: ; cf32
 	callasm GetPartyNick
@@ -1611,7 +1611,7 @@ Fishing_CheckFacingUp: ; d06c
 Script_FishCastRod: ; 0xd07c
 	reloadmappart
 	loadvar hBGMapMode, $0
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	loademote EMOTE_ROD
 	callasm LoadFishingGFX
 	loademote EMOTE_SHOCK
@@ -1735,7 +1735,7 @@ BikeFunction: ; d0b3
 
 Script_GetOnBike: ; 0xd13e
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writecode VAR_MOVEMENT, PLAYER_BIKE
 	writetext GotOnTheBikeText
 	waitbutton
@@ -1755,7 +1755,7 @@ Script_GetOnBike_Register: ; 0xd14e
 
 Script_GetOffBike: ; 0xd158
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	writecode VAR_MOVEMENT, PLAYER_NORMAL
 	writetext GotOffTheBikeText
 	waitbutton

--- a/engine/events/poisonstep.asm
+++ b/engine/events/poisonstep.asm
@@ -104,7 +104,7 @@ DoPoisonStep:: ; 505da
 	ld de, SFX_POISON
 	call PlaySFX
 	ld b, $2
-	predef LoadPoisonBGPals
+	predef Predef_LoadPoisonBGPals
 	call DelayFrame
 	ret
 ; 50669
@@ -145,7 +145,7 @@ DoPoisonStep:: ; 505da
 	ld a, [PartyCount]
 	cp [hl]
 	jr nz, .party_loop
-	predef CheckPlayerPartyForFitPkmn
+	predef Predef_CheckPlayerPartyForFitPkmn
 	ld a, d
 	ld [ScriptVar], a
 	ret

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -1,4 +1,4 @@
-LoadPoisonBGPals: ; cbcdd
+Predef_LoadPoisonBGPals: ; cbcdd
 	call .LoadPals
 	ld a, [hCGB]
 	and a
@@ -20,7 +20,7 @@ LoadPoisonBGPals: ; cbcdd
 	call DmgToCgbBGPals
 	ld c, 4
 	call DelayFrames
-	farcall _Special_UpdateTimePals
+	farcall _UpdateTimePals
 	ret
 
 .cgb
@@ -44,5 +44,5 @@ LoadPoisonBGPals: ; cbcdd
 	ld [hCGBPalUpdate], a
 	ld c, 4
 	call DelayFrames
-	farcall _Special_UpdateTimePals
+	farcall _UpdateTimePals
 	ret

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -20,7 +20,7 @@ LoadPoisonBGPals: ; cbcdd
 	call DmgToCgbBGPals
 	ld c, 4
 	call DelayFrames
-	farcall _UpdateTimePals
+	farcall _Special_UpdateTimePals
 	ret
 
 .cgb
@@ -44,5 +44,5 @@ LoadPoisonBGPals: ; cbcdd
 	ld [hCGBPalUpdate], a
 	ld c, 4
 	call DelayFrames
-	farcall _UpdateTimePals
+	farcall _Special_UpdateTimePals
 	ret

--- a/engine/events/poke_seer.asm
+++ b/engine/events/poke_seer.asm
@@ -15,7 +15,7 @@
 	const SEERACTION_CANT_TELL_2
 	const SEERACTION_LEVEL_ONLY
 
-SpecialPokeSeer: ; 4f0bc
+Special_PokeSeer: ; 4f0bc
 	ld a, SEER_INTRO
 	call PrintSeerText
 	call JoyWaitAorB

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -216,7 +216,7 @@ Function15715: ; 15715
 	ld hl, KrissPCMenuData
 	call LoadMenuDataHeader
 .asm_15722
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	call DoNthMenu
 	jr c, .asm_15731
 	call MenuJumptable
@@ -354,7 +354,7 @@ KrisWithdrawItemMenu: ; 0x157d1
 	ld [CurItemQuantity], a
 	ld hl, PCItems
 	call TossItem
-	predef PartyMonItemName
+	predef Predef_PartyMonItemName
 	ld hl, .WithdrewText
 	call MenuTextBox
 	xor a
@@ -518,7 +518,7 @@ KrisDepositItemMenu: ; 0x1588b
 	ld [CurItemQuantity], a
 	ld hl, NumItems
 	call TossItem
-	predef PartyMonItemName
+	predef Predef_PartyMonItemName
 	ld hl, .DepositText
 	call PrintText
 	ret

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -1,4 +1,4 @@
-PokemonCenterPC: ; 1559a
+Special_PokemonCenterPC: ; 1559a
 	call PC_CheckPartyForPokemon
 	ret c
 	call PC_PlayBootSound
@@ -216,7 +216,7 @@ Function15715: ; 15715
 	ld hl, KrissPCMenuData
 	call LoadMenuDataHeader
 .asm_15722
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	call DoNthMenu
 	jr c, .asm_15731
 	call MenuJumptable

--- a/engine/events/pokepic.asm
+++ b/engine/events/pokepic.asm
@@ -12,7 +12,7 @@ Pokepic:: ; 244e3
 	ld [CurSpecies], a
 	call GetBaseData
 	ld de, vTiles1
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	ld a, [wMenuBorderTopCoord]
 	inc a
 	ld b, a
@@ -23,7 +23,7 @@ Pokepic:: ; 244e3
 	ld a, $80
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	call WaitBGMap
 	ret
 

--- a/engine/events/print_photo.asm
+++ b/engine/events/print_photo.asm
@@ -1,4 +1,4 @@
-PhotoStudio: ; 16dc7
+Special_PhotoStudio: ; 16dc7
 	ld hl, .Text_AskWhichMon
 	call PrintText
 	farcall SelectMonFromParty

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -140,13 +140,13 @@ UnownPrinter: ; 16be4
 	xor a
 	ld [wBoxAlignment], a
 	ld de, vTiles2
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	call .Load2bppToSRAM
 	hlcoord 1, 6
 	xor a
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ld de, vTiles2 tile $31
 	farcall RotateUnownFrontpic
 	ret
@@ -228,6 +228,6 @@ PlaceUnownPrinterFrontpic: ; 16dac
 	ld a, $31
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 ; 16dc7

--- a/engine/events/prof_oaks_pc.asm
+++ b/engine/events/prof_oaks_pc.asm
@@ -3,7 +3,7 @@ ProfOaksPC: ; 0x265d3
 	call MenuTextBox
 	call YesNoBox
 	jr c, .shutdown
-	call ProfOaksPCBoot ; player chose "yes"?
+	call Special_ProfOaksPCBoot ; player chose "yes"?
 .shutdown
 	ld hl, OakPCText4
 	call PrintText
@@ -11,7 +11,7 @@ ProfOaksPC: ; 0x265d3
 	call ExitMenu
 	ret
 
-ProfOaksPCBoot ; 0x265ee
+Special_ProfOaksPCBoot ; 0x265ee
 	ld hl, OakPCText2
 	call PrintText
 	call Rate

--- a/engine/events/sacred_ash.asm
+++ b/engine/events/sacred_ash.asm
@@ -52,12 +52,12 @@ SacredAshScript: ; 0x50821
 	special HealParty
 	reloadmappart
 	playsound SFX_WARP_TO
-	special FadeOutPalettes
-	special FadeInPalettes
-	special FadeOutPalettes
-	special FadeInPalettes
-	special FadeOutPalettes
-	special FadeInPalettes
+	special Special_FadeOutPalettes
+	special Special_FadeInPalettes
+	special Special_FadeOutPalettes
+	special Special_FadeInPalettes
+	special Special_FadeOutPalettes
+	special Special_FadeInPalettes
 	waitsfx
 	writetext UnknownText_0x50845
 	playsound SFX_CAUGHT_MON

--- a/engine/events/special.asm
+++ b/engine/events/special.asm
@@ -230,6 +230,5 @@ CopyPokemonName_Buffer1_Buffer3: ; 746e
 	ld bc, PKMN_NAME_LENGTH
 	jp CopyBytes
 
-Predef1: ; 747a
-; not used
+DummyPredef1: ; 747a
 	ret

--- a/engine/events/special.asm
+++ b/engine/events/special.asm
@@ -1,4 +1,4 @@
-SpecialGiveShuckle: ; 7305
+Special_GiveShuckle: ; 7305
 
 ; Adding to the party.
 	xor a
@@ -70,7 +70,7 @@ SpecialShuckleOT:
 SpecialShuckleNick:
 	db "SHUCKIE@"
 
-SpecialReturnShuckle: ; 737e
+Special_ReturnShuckle: ; 737e
 	farcall SelectMonFromParty
 	jr c, .refused
 

--- a/engine/events/special.asm
+++ b/engine/events/special.asm
@@ -10,7 +10,7 @@ Special_GiveShuckle: ; 7305
 	ld a, 15
 	ld [CurPartyLevel], a
 
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	jr nc, .NotGiven
 
 ; Caught data.

--- a/engine/events/squirtbottle.asm
+++ b/engine/events/squirtbottle.asm
@@ -7,7 +7,7 @@ _Squirtbottle: ; 50730
 
 .SquirtbottleScript:
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	callasm .CheckCanUseSquirtbottle
 	iffalse .NothingHappenedScript
 	farjump WateredWeirdTreeScript

--- a/engine/events/squirtbottle.asm
+++ b/engine/events/squirtbottle.asm
@@ -7,7 +7,7 @@ _Squirtbottle: ; 50730
 
 .SquirtbottleScript:
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	callasm .CheckCanUseSquirtbottle
 	iffalse .NothingHappenedScript
 	farjump WateredWeirdTreeScript

--- a/engine/events/std_scripts.asm
+++ b/engine/events/std_scripts.asm
@@ -113,7 +113,7 @@ PokecenterNurseScript:
 	special HealParty
 	playmusic MUSIC_NONE
 	writebyte 0 ; Machine is at a Pokemon Center
-	special HealMachineAnim
+	special Special_HealMachineAnim
 	pause 30
 	special RestartMapMusic
 	spriteface LAST_TALKED, DOWN
@@ -123,7 +123,7 @@ PokecenterNurseScript:
 	iftrue .no
 	checkflag ENGINE_POKERUS ; nurse already talked about pokerus
 	iftrue .no
-	special SpecialCheckPokerus
+	special Special_CheckPokerus
 	iftrue .pokerus
 .no
 
@@ -203,7 +203,7 @@ HomepageScript:
 Radio1Script:
 	opentext
 	writebyte MAPRADIO_POKEMON_CHANNEL
-	special MapRadio
+	special Special_MapRadio
 	closetext
 	end
 
@@ -211,7 +211,7 @@ Radio2Script:
 ; Lucky Channel
 	opentext
 	writebyte MAPRADIO_LUCKY_CHANNEL
-	special MapRadio
+	special Special_MapRadio
 	closetext
 	end
 
@@ -220,7 +220,7 @@ TrashCanScript: ; 0xbc1a5
 
 PCScript:
 	opentext
-	special PokemonCenterPC
+	special Special_PokemonCenterPC
 	closetext
 	end
 
@@ -319,7 +319,7 @@ BugContestResultsScript:
 	opentext
 	farwritetext ContestResults_ReadyToJudgeText
 	waitbutton
-	special BugContestJudging
+	special Special_BugContestJudging
 	RAM2MEM $0
 	if_equal 1, BugContestResults_FirstPlace
 	if_equal 2, BugContestResults_SecondPlace
@@ -345,9 +345,9 @@ BugContestResults_FinishUp
 	iffalse BugContestResults_DidNotLeaveMons
 	farwritetext ContestResults_ReturnPartyText
 	waitbutton
-	special ContestReturnMons
+	special Special_ContestReturnMons
 BugContestResults_DidNotLeaveMons
-	special CheckPartyFullAfterContest
+	special Special_CheckPartyFullAfterContest
 	if_equal $0, BugContestResults_CleanUp
 	if_equal $2, BugContestResults_CleanUp
 	farwritetext ContestResults_PartyFullText
@@ -620,7 +620,7 @@ InitializeEventsScript:
 	return
 
 AskNumber1MScript:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	checkcode VAR_CALLERID
 	if_equal PHONE_SCHOOLBOY_JACK, .Jack
 	if_equal PHONE_SAILOR_HUEY, .Huey
@@ -705,7 +705,7 @@ AskNumber1MScript:
 	end
 
 AskNumber2MScript:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	checkcode VAR_CALLERID
 	if_equal PHONE_SCHOOLBOY_JACK, .Jack
 	if_equal PHONE_SAILOR_HUEY, .Huey
@@ -1886,7 +1886,7 @@ CoinVendor_IntroScript: ; 0xbcde0
 HappinessCheckScript:
 	faceplayer
 	opentext
-	special GetFirstPokemonHappiness
+	special Special_GetFirstPokemonHappiness
 	if_less_than 50, .Unhappy
 	if_less_than 150, .KindaHappy
 	farwritetext HappinessText3

--- a/engine/events/std_scripts.asm
+++ b/engine/events/std_scripts.asm
@@ -107,7 +107,7 @@ PokecenterNurseScript:
 
 	farwritetext NurseTakePokemonText
 	pause 20
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	spriteface LAST_TALKED, LEFT
 	pause 10
 	special HealParty

--- a/engine/events/std_scripts.asm
+++ b/engine/events/std_scripts.asm
@@ -107,7 +107,7 @@ PokecenterNurseScript:
 
 	farwritetext NurseTakePokemonText
 	pause 20
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	spriteface LAST_TALKED, LEFT
 	pause 10
 	special HealParty

--- a/engine/events/sweet_scent.asm
+++ b/engine/events/sweet_scent.asm
@@ -8,7 +8,7 @@ SweetScentFromMenu: ; 506bc
 
 .SweetScent: ; 0x506c8
 	reloadmappart
-	special UpdateTimePals
+	special Special_UpdateTimePals
 	callasm GetPartyNick
 	writetext UnknownText_0x50726
 	waitbutton

--- a/engine/events/sweet_scent.asm
+++ b/engine/events/sweet_scent.asm
@@ -8,7 +8,7 @@ SweetScentFromMenu: ; 506bc
 
 .SweetScent: ; 0x506c8
 	reloadmappart
-	special Special_UpdateTimePals
+	special UpdateTimePals
 	callasm GetPartyNick
 	writetext UnknownText_0x50726
 	waitbutton

--- a/engine/events/whiteout.asm
+++ b/engine/events/whiteout.asm
@@ -49,7 +49,7 @@ BattleBGMap: ; 1250a
 ; 12513
 
 HalveMoney: ; 12513
-	farcall TrainerRankings_WhiteOuts
+	farcall StubbedTrainerRankings_WhiteOuts
 
 ; Halve the player's money.
 	ld hl, Money

--- a/engine/events/whiteout.asm
+++ b/engine/events/whiteout.asm
@@ -10,7 +10,7 @@ Script_OverworldWhiteout:: ; 0x124c8
 Script_Whiteout: ; 0x124ce
 	writetext .WhitedOutText
 	waitbutton
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	pause 40
 	special HealParty
 	checkflag ENGINE_BUG_CONTEST_TIMER
@@ -18,7 +18,7 @@ Script_Whiteout: ; 0x124ce
 	callasm HalveMoney
 	callasm GetWhiteoutSpawn
 	farscall Script_AbortBugContest
-	special WarpToSpawnPoint
+	special Special_WarpToSpawnPoint
 	newloadmap MAPSETUP_WARP
 	end_all
 

--- a/engine/events_2.asm
+++ b/engine/events_2.asm
@@ -1,7 +1,7 @@
 ; More overworld event handling.
 
 
-WarpToSpawnPoint:: ; 97c28
+Special_WarpToSpawnPoint:: ; 97c28
 	ld hl, wStatusFlags2
 	res 1, [hl] ; safari zone?
 	res 2, [hl] ; bug contest

--- a/engine/events_2.asm
+++ b/engine/events_2.asm
@@ -361,7 +361,7 @@ HandleCmdQueue:: ; 97e08
 	ret
 ; 97e25
 
-GetNthCmdQueueEntry: ; 97e25 unreferenced
+Unreferenced_GetNthCmdQueueEntry: ; 97e25
 	ld hl, wCmdQueue
 	ld bc, CMDQUEUE_ENTRY_SIZE
 	call AddNTimes

--- a/engine/events_3.asm
+++ b/engine/events_3.asm
@@ -360,7 +360,7 @@ CheckForHiddenItems: ; b8172
 
 
 TreeMonEncounter: ; b81ea
-	farcall TrainerRankings_TreeEncounters
+	farcall StubbedTrainerRankings_TreeEncounters
 
 	xor a
 	ld [TempWildMonSpecies], a

--- a/engine/evolution_animation.asm
+++ b/engine/evolution_animation.asm
@@ -122,7 +122,7 @@ EvolutionAnimation: ; 4e5e1
 	hlcoord 7, 2
 	ld d, $0
 	ld e, ANIM_MON_EVOLVE
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 
 	pop af
 	ld [CurPartySpecies], a
@@ -168,7 +168,7 @@ EvolutionAnimation: ; 4e5e1
 	ld a, $1
 	ld [wBoxAlignment], a
 	ld de, vTiles2
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	xor a
 	ld [wBoxAlignment], a
 	ret

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -621,7 +621,7 @@ ShiftMoves: ; 4256e
 EvoFlagAction: ; 42577
 	push de
 	ld d, $0
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	pop de
 	ret
 ; 42581

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -6,7 +6,7 @@ EvolvePokemon: ; 421d8
 	ld c, a
 	ld b, SET_FLAG
 	call EvoFlagAction
-EvolveAfterBattle: ; 421e6
+Predef_EvolveAfterBattle: ; 421e6
 	xor a
 	ld [wMonTriedToEvolve], a
 	dec a
@@ -55,7 +55,7 @@ EvolveAfterBattle_MasterLoop
 	push hl
 	xor a
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	pop hl
 
 .loop
@@ -265,7 +265,7 @@ EvolveAfterBattle_MasterLoop
 	ld hl, TempMonExp + 2
 	ld de, TempMonMaxHP
 	ld b, $1
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 
 	ld a, [CurPartyMon]
 	ld hl, PartyMons
@@ -301,7 +301,7 @@ EvolveAfterBattle_MasterLoop
 	ld [wd265], a
 	xor a
 	ld [MonType], a
-	call LearnLevelMoves
+	call Predef_LearnLevelMoves
 	ld a, [wd265]
 	dec a
 	call SetSeenAndCaughtMon
@@ -311,7 +311,7 @@ EvolveAfterBattle_MasterLoop
 	jr nz, .skip_unown
 
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	callfar UpdateUnownDex
 
 .skip_unown
@@ -429,7 +429,7 @@ Text_WhatEvolving: ; 0x42482
 ; 0x42487
 
 
-LearnLevelMoves: ; 42487
+Predef_LearnLevelMoves: ; 42487
 	ld a, [wd265]
 	ld [CurPartySpecies], a
 	dec a
@@ -484,7 +484,7 @@ LearnLevelMoves: ; 42487
 	ld [wd265], a
 	call GetMoveName
 	call CopyName1
-	predef LearnMove
+	predef Predef_LearnMove
 	pop hl
 	jr .find_move
 
@@ -495,7 +495,7 @@ LearnLevelMoves: ; 42487
 ; 424e1
 
 
-FillMoves: ; 424e1
+Predef_FillMoves: ; 424e1
 ; Fill in moves at de for CurPartySpecies at CurPartyLevel
 
 	push hl
@@ -621,7 +621,7 @@ ShiftMoves: ; 4256e
 EvoFlagAction: ; 42577
 	push de
 	ld d, $0
-	predef FlagPredef
+	predef Predef_Flag
 	pop de
 	ret
 ; 42581

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -333,7 +333,7 @@ EvolveAfterBattle_MasterLoop
 	inc hl
 	jp .loop
 
-; XXX
+; unused
 	pop hl
 .ReturnToMap:
 	pop de

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -247,7 +247,7 @@ EvolveAfterBattle_MasterLoop
 	push hl
 	ld hl, Text_EvolvedIntoPKMN
 	call PrintTextBoxText
-	farcall TrainerRankings_MonsEvolved
+	farcall StubbedTrainerRankings_MonsEvolved
 
 	ld de, MUSIC_NONE
 	call PlayMusic

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -621,7 +621,7 @@ ShiftMoves: ; 4256e
 EvoFlagAction: ; 42577
 	push de
 	ld d, $0
-	predef Predef_Flag
+	predef Predef_FlagAction
 	pop de
 	ret
 ; 42581

--- a/engine/health.asm
+++ b/engine/health.asm
@@ -52,7 +52,7 @@ HealPartyMon: ; c677
 	farcall RestoreAllPP
 	ret
 
-ComputeHPBarPixels: ; c699
+Predef_ComputeHPBarPixels: ; c699
 ; e = bc * (6 * 8) / de
 	ld a, b
 	or c
@@ -103,7 +103,7 @@ ComputeHPBarPixels: ; c699
 	ld e, 0
 	ret
 
-AnimateHPBar: ; c6e0
+Predef_AnimateHPBar: ; c6e0
 	call WaitBGMap
 	call _AnimateHPBar
 	call WaitBGMap

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -943,24 +943,24 @@ Intro_WipeInFrontpic: ; 6182
 
 Intro_PrepTrainerPic: ; 619c
 	ld de, vTiles2
-	farcall GetTrainerPic
+	farcall Predef_GetTrainerPic
 	xor a
 	ld [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 ; 61b4
 
 ShrinkFrame: ; 61b4
 	ld de, vTiles2
 	ld c, $31
-	predef DecompressPredef
+	predef Predef_Decompress
 	xor a
 	ld [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 ; 61cd
 
@@ -1048,7 +1048,7 @@ StartTitleScreen: ; 6219
 	ld [hWY], a
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	ld a, [wIntroSceneFrameCounter]
 	cp $5
 	jr c, .ok

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -1048,7 +1048,7 @@ StartTitleScreen: ; 6219
 	ld [hWY], a
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	ld a, [wIntroSceneFrameCounter]
 	cp $5
 	jr c, .ok

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -10,7 +10,7 @@ _MainMenu: ; 5ae8
 	jp StartTitleScreen
 ; 5b04
 
-; unreferenced
+; unused
 	ret
 ; 5b05
 
@@ -827,7 +827,7 @@ NamePlayer: ; 0x6074
 	db "KRIS@@@@@@@"
 ; 60e9
 
-Function60e9: ; Unreferenced
+Unreferenced_Function60e9:
 	call LoadMenuDataHeader
 	call VerticalMenu
 	ld a, [wMenuCursorY]
@@ -1094,7 +1094,7 @@ RunTitleScreen: ; 627b
 	ret
 ; 6292
 
-Function6292: ; 6292 ; unreferenced
+Unreferenced_Function6292: ; 6292
 	ld a, [hVBlankCounter]
 	and $7
 	ret nz
@@ -1125,7 +1125,7 @@ TitleScreenScene: ; 62a3
 	dw TitleScreenEnd
 ; 62b7
 
-.NextScene: ; Unreferenced
+.Unreferenced_NextScene:
 	ld hl, wJumptableIndex
 	inc [hl]
 	ret
@@ -1329,7 +1329,7 @@ ResetClock: ; 6392
 	jp Init
 ; 639b
 
-Function639b: ; unreferenced
+Unreferenced_Function639b:
 	; If bit 0 or 1 of [wTitleScreenTimer] is set, we don't need to be here.
 	ld a, [wTitleScreenTimer]
 	and $3

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -415,7 +415,7 @@ ParkBall: ; e8a2
 	ld [hBattleTurn], a
 	ld [Buffer2], a
 	ld [wNumHits], a
-	predef PlayBattleAnim
+	predef Predef_PlayBattleAnim
 
 	ld a, [wWildMon]
 	and a
@@ -547,7 +547,7 @@ ParkBall: ; e8a2
 
 	ld a, [EnemyMonSpecies]
 	ld [wd265], a
-	predef NewPokedexEntry
+	predef Predef_NewPokedexEntry
 
 .skip_pokedex
 	ld a, [BattleType]
@@ -567,7 +567,7 @@ ParkBall: ; e8a2
 	ld [MonType], a
 	call ClearSprites
 
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 
 	farcall SetCaughtData
 
@@ -623,7 +623,7 @@ ParkBall: ; e8a2
 .SendToPC:
 	call ClearSprites
 
-	predef SentPkmnIntoBox
+	predef Predef_SendPkmnIntoBox
 
 	farcall SetBoxMonCaughtData
 
@@ -985,7 +985,7 @@ LoveBallMultiplier:
 	ld [MonType], a
 	ld a, [CurBattleMon]
 	ld [CurPartyMon], a
-	farcall GetGender
+	farcall Predef_GetGender
 	jr c, .done1 ; no effect on genderless
 
 	ld d, 0 ; male
@@ -999,7 +999,7 @@ LoveBallMultiplier:
 	ld [CurPartySpecies], a
 	ld a, WILDMON
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	jr c, .done2 ; no effect on genderless
 
 	ld d, 0 ; male
@@ -1289,7 +1289,7 @@ UpdateStatsAfterItem: ; ee8c
 	ld a, MON_STAT_EXP - 1
 	call GetPartyParamLocation
 	ld b, $1
-	predef_jump CalcPkmnStats
+	predef_jump Predef_CalcPkmnStats
 ; ee9f
 
 RareCandy_StatBooster_ExitMenu: ; ee9f
@@ -1428,7 +1428,7 @@ RareCandy: ; ef14
 
 	xor a ; PARTYMON
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 
 	hlcoord 9, 0
 	ld b, 10
@@ -1437,7 +1437,7 @@ RareCandy: ; ef14
 
 	hlcoord 11, 1
 	ld bc, $0004
-	predef PrintTempMonStats
+	predef Predef_PrintTempMonStats
 
 	call WaitPressAorB_BlinkCursor
 
@@ -1445,7 +1445,7 @@ RareCandy: ; ef14
 	ld [MonType], a
 	ld a, [CurPartySpecies]
 	ld [wd265], a
-	predef LearnLevelMoves
+	predef Predef_LearnLevelMoves
 
 	xor a
 	ld [wForceEvolution], a
@@ -1668,7 +1668,7 @@ RevivePokemon: ; f0d6
 	ld d, 0
 	ld hl, wBattleParticipantsIncludingFainted
 	ld b, CHECK_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	and a
 	jr z, .skip_to_revive
@@ -1677,7 +1677,7 @@ RevivePokemon: ; f0d6
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 
 .skip_to_revive
 	xor a
@@ -1844,7 +1844,7 @@ HealHP_SFX_GFX: ; f1db (3:71db)
 	call AddNTimes
 	ld a, $2
 	ld [wWhichHPBar], a
-	predef_jump AnimateHPBar
+	predef_jump Predef_AnimateHPBar
 
 UseItem_SelectMon: ; f1f9 (3:71f9)
 	call .SelectMon
@@ -2957,7 +2957,7 @@ UseBallInTrainerBattle: ; f7a0
 	ld [wBattleAnimParam], a
 	ld [hBattleTurn], a
 	ld [wNumHits], a
-	predef PlayBattleAnim
+	predef Predef_PlayBattleAnim
 	ld hl, BlockedTheBallText
 	call PrintText
 	ld hl, DontBeAThiefText
@@ -3104,7 +3104,7 @@ ApplyPPUp: ; f84c
 	call GetPartyParamLocation
 	push hl
 	ld de, Buffer1
-	predef FillPP
+	predef Predef_FillPP
 	pop hl
 	ld bc, MON_PP - MON_MOVES
 	add hl, bc

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -517,7 +517,7 @@ ParkBall: ; e8a2
 	cp BATTLETYPE_TUTORIAL
 	jp z, .FinishTutorial
 
-	farcall TrainerRankings_WildMonsCaught
+	farcall StubbedTrainerRankings_WildMonsCaught
 
 	ld hl, Text_GotchaMonWasCaught
 	call PrintText

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -1668,7 +1668,7 @@ RevivePokemon: ; f0d6
 	ld d, 0
 	ld hl, wBattleParticipantsIncludingFainted
 	ld b, CHECK_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	and a
 	jr z, .skip_to_revive
@@ -1677,7 +1677,7 @@ RevivePokemon: ; f0d6
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 
 .skip_to_revive
 	xor a

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -1668,7 +1668,7 @@ RevivePokemon: ; f0d6
 	ld d, 0
 	ld hl, wBattleParticipantsIncludingFainted
 	ld b, CHECK_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	and a
 	jr z, .skip_to_revive
@@ -1677,7 +1677,7 @@ RevivePokemon: ; f0d6
 	ld c, a
 	ld hl, wBattleParticipantsNotFainted
 	ld b, SET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 
 .skip_to_revive
 	xor a

--- a/engine/learn.asm
+++ b/engine/learn.asm
@@ -1,4 +1,4 @@
-LearnMove: ; 6508
+Predef_LearnMove: ; 6508
 	call LoadTileMapToTempTileMap
 	ld a, [CurPartyMon]
 	ld hl, PartyMonNicknames
@@ -144,7 +144,7 @@ ForgetMove: ; 65d3
 	hlcoord 5 + 2, 2 + 2
 	ld a, SCREEN_WIDTH * 2
 	ld [Buffer1], a
-	predef ListMoves
+	predef Predef_ListMoves
 	; wMenuData3
 	ld a, $4
 	ld [w2DMenuCursorInitY], a

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -150,7 +150,7 @@ TimeCapsule: ; 2805d
 	ld [wd265], a
 	push hl
 	push de
-	callfar ConvertMon_1to2
+	callfar Predef_ConvertMon_1to2
 	pop de
 	pop hl
 	ld a, [wd265]
@@ -449,7 +449,7 @@ Gen2ToGen2LinkComms: ; 28177
 	pop af
 	ld [rIF], a
 
-	predef StartBattle
+	predef Predef_StartBattle
 
 	ld a, [rIF]
 	ld h, a
@@ -786,7 +786,7 @@ Link_PrepPartyData_Gen1: ; 28499
 	add hl, bc
 	ld c, STAT_SATK
 	ld b, TRUE
-	predef CalcPkmnStatC
+	predef Predef_CalcPkmnStatC
 
 	pop bc
 	pop de
@@ -993,7 +993,7 @@ Function2868a: ; 2868a
 	push bc
 	push de
 	ld [wd265], a
-	callfar ConvertMon_1to2
+	callfar Predef_ConvertMon_1to2
 	pop de
 	pop bc
 	ld a, [wd265]
@@ -1072,7 +1072,7 @@ Function2868a: ; 2868a
 	add hl, bc
 	ld c, STAT_SATK
 	ld b, TRUE
-	predef CalcPkmnStatC
+	predef Predef_CalcPkmnStatC
 	pop bc
 	pop hl
 	ld a, [hQuotient + 1]
@@ -1085,7 +1085,7 @@ Function2868a: ; 2868a
 	add hl, bc
 	ld c, STAT_SDEF
 	ld b, TRUE
-	predef CalcPkmnStatC
+	predef Predef_CalcPkmnStatC
 	pop bc
 	pop hl
 	ld a, [hQuotient + 1]
@@ -1362,7 +1362,7 @@ Function28926: ; 28926
 	hlcoord 0, 15
 	ld b, 1
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 2, 16
 	ld de, .String_Stats_Trade
 	call PlaceString
@@ -1471,7 +1471,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	farcall Link_WaitBGMap
 	ld hl, .Text_CantTradeLastMon
 	bccoord 1, 14
@@ -1493,7 +1493,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	farcall Link_WaitBGMap
 	ld hl, .Text_Abnormal
 	bccoord 1, 14
@@ -1503,7 +1503,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1648,7 +1648,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, $4
 	ld c, $12
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	farcall Link_WaitBGMap
 	ld a, [wd002]
 	ld hl, PartySpecies
@@ -1677,7 +1677,7 @@ LinkTrade: ; 28b87
 	hlcoord 10, 7
 	ld b, 3
 	ld c, 7
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	ld de, String28eab
 	hlcoord 12, 8
 	call PlaceString
@@ -1717,7 +1717,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1734,7 +1734,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1891,11 +1891,11 @@ LinkTrade: ; 28b87
 	ld a, [hLinkPlayerNumber]
 	cp $1
 	jr z, .player_2
-	predef TradeAnimation
+	predef Predef_TradeAnimation
 	jr .done_animation
 
 .player_2
-	predef TradeAnimationPlayer2
+	predef Predef_TradeAnimationPlayer2
 
 .done_animation
 	pop af
@@ -1913,7 +1913,7 @@ LinkTrade: ; 28b87
 	ld de, TempMonSpecies
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call CopyBytes
-	predef AddTempmonToParty
+	predef Predef_AddTempmonToParty
 	ld a, [PartyCount]
 	dec a
 	ld [CurPartyMon], a
@@ -1964,7 +1964,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 1, 14
 	ld de, String28ebd
 	call PlaceString
@@ -2001,7 +2001,7 @@ String_TooBadTheTradeWasCanceled: ; 28ece
 	next "was canceled!@"
 
 
-LinkTextboxPredef: ; 28eef
+Predef_LinkTextbox: ; 28eef
 	ld d, h
 	ld e, l
 	farcall LinkTextbox
@@ -2023,11 +2023,11 @@ Unreferenced_Function28f09: ; 28f09
 	hlcoord 0, 0
 	ld b, 6
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	hlcoord 0, 8
 	ld b, 6
 	ld c, 18
-	call LinkTextboxPredef
+	call Predef_LinkTextbox
 	farcall PlaceTradePartnerNamesAndParty
 	ret
 ; 28f24
@@ -2584,7 +2584,7 @@ Unreferenced_Function29fe4:
 	call GetSRAMBank
 	ld d, $0
 	ld b, CHECK_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	call CloseSRAM
 	ld a, c
 	and a

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -1957,7 +1957,7 @@ LinkTrade: ; 28b87
 
 .save
 	farcall SaveAfterLinkTrade
-	farcall TrainerRankings_Trades
+	farcall StubbedTrainerRankings_Trades
 	farcall BackupMobileEventIndex
 	ld c, 40
 	call DelayFrames

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -1597,8 +1597,7 @@ Function28b22: ; 28b22
 	ret
 ; 28b42
 
-Function28b42: ; 28b42
-; unreferenced
+Unreferenced_Function28b42: ; 28b42
 	hlcoord 0, 16
 	ld a, "┘"
 	ld bc, 2 * SCREEN_WIDTH
@@ -2020,8 +2019,7 @@ SetTradeRoomBGPals: ; 28eff
 	ret
 ; 28f09
 
-Function28f09: ; 28f09
-; unreferenced
+Unreferenced_Function28f09: ; 28f09
 	hlcoord 0, 0
 	ld b, 6
 	ld c, 18
@@ -2577,12 +2575,11 @@ Special_CableClubCheckWhichChris: ; 29f47
 	ret
 ; 29f54
 
-UnusedGen1LinkCommsBorderGFX: ; 29f54
-; unreferenced
+Unreferenced_Gen1LinkCommsBorderGFX: ; 29f54
 INCBIN "gfx/trade/unused_gen_1_border_tiles.2bpp"
 ; 29fe4
 
-Function29fe4: ; unreferenced
+Unreferenced_Function29fe4:
 	ld a, BANK(sPartyMail)
 	call GetSRAMBank
 	ld d, $0

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -2143,7 +2143,7 @@ Special_EnterTimeCapsule: ; 29c7b
 	ret
 ; 29c92
 
-WaitForOtherPlayerToExit: ; 29c92
+Special_WaitForOtherPlayerToExit: ; 29c92
 	ld c, 3
 	call DelayFrames
 	ld a, -1

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -2584,7 +2584,7 @@ Unreferenced_Function29fe4:
 	call GetSRAMBank
 	ld d, $0
 	ld b, CHECK_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	call CloseSRAM
 	ld a, c
 	and a

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -1362,7 +1362,7 @@ Function28926: ; 28926
 	hlcoord 0, 15
 	ld b, 1
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 2, 16
 	ld de, .String_Stats_Trade
 	call PlaceString
@@ -1471,7 +1471,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	farcall Link_WaitBGMap
 	ld hl, .Text_CantTradeLastMon
 	bccoord 1, 14
@@ -1493,7 +1493,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	farcall Link_WaitBGMap
 	ld hl, .Text_Abnormal
 	bccoord 1, 14
@@ -1503,7 +1503,7 @@ Function28926: ; 28926
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1649,7 +1649,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, $4
 	ld c, $12
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	farcall Link_WaitBGMap
 	ld a, [wd002]
 	ld hl, PartySpecies
@@ -1678,7 +1678,7 @@ LinkTrade: ; 28b87
 	hlcoord 10, 7
 	ld b, 3
 	ld c, 7
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	ld de, String28eab
 	hlcoord 12, 8
 	call PlaceString
@@ -1718,7 +1718,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1735,7 +1735,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 1, 14
 	ld de, String_TooBadTheTradeWasCanceled
 	call PlaceString
@@ -1965,7 +1965,7 @@ LinkTrade: ; 28b87
 	hlcoord 0, 12
 	ld b, 4
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 1, 14
 	ld de, String28ebd
 	call PlaceString
@@ -2002,7 +2002,7 @@ String_TooBadTheTradeWasCanceled: ; 28ece
 	next "was canceled!@"
 
 
-Predef_LinkTextbox: ; 28eef
+LinkTextboxPredef: ; 28eef
 	ld d, h
 	ld e, l
 	farcall LinkTextbox
@@ -2025,11 +2025,11 @@ Function28f09: ; 28f09
 	hlcoord 0, 0
 	ld b, 6
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	hlcoord 0, 8
 	ld b, 6
 	ld c, 18
-	call Predef_LinkTextbox
+	call LinkTextboxPredef
 	farcall PlaceTradePartnerNamesAndParty
 	ret
 ; 28f24

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -2584,7 +2584,7 @@ Unreferenced_Function29fe4:
 	call GetSRAMBank
 	ld d, $0
 	ld b, CHECK_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	call CloseSRAM
 	ld a, c
 	and a

--- a/engine/link_2.asm
+++ b/engine/link_2.asm
@@ -3,7 +3,7 @@ LinkMonStatsScreen: ; 4d319
 	dec a
 	ld [CurPartyMon], a
 	call LowVolume
-	predef StatsScreenInit
+	predef Predef_StatsScreenInit
 	ld a, [CurPartyMon]
 	inc a
 	ld [wMenuCursorY], a

--- a/engine/link_trade.asm
+++ b/engine/link_trade.asm
@@ -181,7 +181,7 @@ Function16d6e1: ; 16d6e1
 	hlcoord 4, 10
 	ld b, 1
 	ld c, 10
-	predef Predef_LinkTextbox
+	predef LinkTextboxPredef
 	hlcoord 5, 11
 	ld de, .Waiting
 	call PlaceString

--- a/engine/link_trade.asm
+++ b/engine/link_trade.asm
@@ -181,7 +181,7 @@ Function16d6e1: ; 16d6e1
 	hlcoord 4, 10
 	ld b, 1
 	ld c, 10
-	predef LinkTextboxPredef
+	predef Predef_LinkTextbox
 	hlcoord 5, 11
 	ld de, .Waiting
 	call PlaceString

--- a/engine/mail_2.asm
+++ b/engine/mail_2.asm
@@ -725,8 +725,7 @@ MailGFX_PlaceMessage: ; b9803
 	jp PlaceString
 ; b984e
 
-Functionb984e: ; b984e
-; XXX
+Unreferenced_Functionb984e: ; b984e
 .loop
 	ld a, [hl]
 	xor $ff

--- a/engine/main_menu.asm
+++ b/engine/main_menu.asm
@@ -279,7 +279,7 @@ MainMenu_PrintCurrentTimeAndDay: ; 49e09
 	ret
 
 .min
-; unreferenced
+; unused
 	db "min.@"
 ; 49e75
 

--- a/engine/map_objects.asm
+++ b/engine/map_objects.asm
@@ -418,8 +418,7 @@ UpdatePlayerStep: ; 4738
 	ret
 ; 4759
 
-Function4759: ; 4759
-; unreferenced
+Unreferenced_Function4759: ; 4759
 	push bc
 	ld e, a
 	ld d, 0

--- a/engine/map_objects.asm
+++ b/engine/map_objects.asm
@@ -1570,7 +1570,7 @@ StepType05: ; 4e0c
 	ld [hl], a
 	call IncrementObjectStructField1c
 StepType04: ; 4e21
-	call MobileFn_4fb2
+	call Stubbed_Function4fb2
 	ld hl, OBJECT_DIRECTION_WALKING
 	add hl, bc
 	ld [hl], STANDING
@@ -1578,7 +1578,7 @@ StepType04: ; 4e21
 ; 4e2b
 
 NPCStep: ; 4e2b
-	call MobileFn_4fb2
+	call Stubbed_Function4fb2
 	call AddStepVector
 	ld hl, OBJECT_STEP_DURATION
 	add hl, bc
@@ -1841,7 +1841,8 @@ SkyfallTop: ; 4f83
 	ret
 ; 4fb2
 
-MobileFn_4fb2: mobile
+Stubbed_Function4fb2:
+	ret
 	ld hl, OBJECT_1D
 	add hl, bc
 	inc [hl]

--- a/engine/map_setup.asm
+++ b/engine/map_setup.asm
@@ -79,7 +79,7 @@ MapSetupCommands: ; 15440
 	dba LoadGraphics ; 0e
 	dba LoadTileset ; 0f
 	dba LoadMapTimeOfDay ; 10
-	dba LoadMapPalettes ; 11
+	dba Special_LoadMapPalettes ; 11
 	dba LoadWildMonData ; 12
 	dba RefreshMapSprites ; 13
 	dba HandleNewMap ; 14

--- a/engine/map_setup.asm
+++ b/engine/map_setup.asm
@@ -91,8 +91,8 @@ MapSetupCommands: ; 15440
 	dba LoadMapAttributes ; 1a
 	dba LoadMapAttributes_SkipPeople ; 1b
 	dba ClearBGPalettes ; 1c
-	dba FadeOutPalettes ; 1d
-	dba FadeInPalettes ; 1e
+	dba Special_FadeOutPalettes ; 1d
+	dba Special_FadeInPalettes ; 1e
 	dba GetCoordOfUpperLeftCorner ; 1f
 	dba RestoreFacingAfterWarp ; 20
 	dba SpawnInFacingDown ; 21
@@ -233,7 +233,7 @@ FadeOldMapMusic: ; 15567
 ; 1556d
 
 RetainOldPalettes: ; 1556d
-	farcall _UpdateTimePals
+	farcall _Special_UpdateTimePals
 	ret
 
 RotatePalettesRightMapAndMusic: ; 15574

--- a/engine/map_setup.asm
+++ b/engine/map_setup.asm
@@ -137,7 +137,7 @@ LoadObjectsRunCallback_02: ; 154d7
 	ret
 ; 154ea (5:54ea)
 
-; unreferenced
+; unused
 	ret
 ; 154eb
 

--- a/engine/map_setup.asm
+++ b/engine/map_setup.asm
@@ -233,7 +233,7 @@ FadeOldMapMusic: ; 15567
 ; 1556d
 
 RetainOldPalettes: ; 1556d
-	farcall _Special_UpdateTimePals
+	farcall _UpdateTimePals
 	ret
 
 RotatePalettesRightMapAndMusic: ; 15574

--- a/engine/mart.asm
+++ b/engine/mart.asm
@@ -443,7 +443,7 @@ GetMartDialogGroup: ; 15ca3
 
 
 BuyMenuLoop: ; 15cef
-	farcall PlaceMoneyTopRight
+	farcall Special_PlaceMoneyTopRight
 	call UpdateSprites
 	ld hl, MenuDataHeader_Buy
 	call CopyMenuDataHeader

--- a/engine/mart.asm
+++ b/engine/mart.asm
@@ -892,7 +892,7 @@ Text_Mart_ICanPayThisMuch: ; 0x15f78
 	db "@"
 ; 0x15f7d
 
-DummyString ; 15f7d
+.UnusedString15f7d: ; 15f7d
 	db "!ダミー!@"
 
 Text_Mart_HowMayIHelpYou: ; 0x15f83

--- a/engine/mart.asm
+++ b/engine/mart.asm
@@ -797,7 +797,7 @@ SellMenu: ; 15eb3
 	ret
 ; 15ed3
 
-.NothingToSell: ; unreferenced
+.Unreferenced_NothingToSell:
 	ld hl, .NothingToSellText
 	call MenuTextBoxBackup
 	and a

--- a/engine/mart.asm
+++ b/engine/mart.asm
@@ -525,7 +525,7 @@ StandardMartAskPurchaseQuantity:
 ; 15d97
 
 MartConfirmPurchase: ; 15d97
-	predef PartyMonItemName
+	predef Predef_PartyMonItemName
 	ld a, MARTTEXT_COSTS_THIS_MUCH
 	call LoadBuyMenuText
 	call YesNoBox
@@ -864,7 +864,7 @@ SellMenu: ; 15eb3
 	ld a, [wMartItemID]
 	ld hl, NumItems
 	call TossItem
-	predef PartyMonItemName
+	predef Predef_PartyMonItemName
 	hlcoord 1, 14
 	lb bc, 3, 18
 	call ClearBox

--- a/engine/menu.asm
+++ b/engine/menu.asm
@@ -291,8 +291,7 @@ MobileMenuJoypad: ; 241ba
 ; 241d5
 
 
-Function241d5: ; 241d5
-; Unreferenced
+Unreferenced_Function241d5: ; 241d5
 	call Place2DMenuCursor
 .loop
 	call Move2DMenuCursor
@@ -725,8 +724,7 @@ _ExitMenu:: ; 243e8
 	ret
 ; 24423
 
-Function24423: ; 24423
-; Unreferenced
+Unreferenced_Function24423: ; 24423
 	ld a, [VramState]
 	bit 0, a
 	ret z

--- a/engine/menu_2.asm
+++ b/engine/menu_2.asm
@@ -27,7 +27,7 @@ PlaceMenuItemQuantity: ; 0x24ac3
 .done
 	ret
 
-PlaceMoneyTopRight: ; 24ae8
+Special_PlaceMoneyTopRight: ; 24ae8
 	ld hl, MenuDataHeader_0x24b15
 	call CopyMenuDataHeader
 	jr PlaceMoneyDataHeader

--- a/engine/menu_2.asm
+++ b/engine/menu_2.asm
@@ -112,8 +112,8 @@ CoinString: ; 24b89
 ShowMoney_TerminatorString: ; 24b8e
 	db "@"
 
-Function24b8f: ; 24b8f
-; unreferenced, related to safari?
+Unreferenced_Function24b8f: ; 24b8f
+; related to safari?
 	ld hl, Options
 	ld a, [hl]
 	push af

--- a/engine/mon_icons.asm
+++ b/engine/mon_icons.asm
@@ -281,8 +281,7 @@ FlyFunction_GetMonIcon: ; 8e9bc (23:69bc)
 	ret
 ; 8e9cc (23:69cc)
 
-GetMonIcon2: ; 8e9cc
-; unreferenced
+Unreferenced_GetMonIcon2: ; 8e9cc
 	push de
 	ld a, [wd265]
 	call ReadMonMenuIcon

--- a/engine/mon_stats.asm
+++ b/engine/mon_stats.asm
@@ -1,8 +1,8 @@
-DrawPlayerHP: ; 50b0a
+Predef_DrawPlayerHP: ; 50b0a
 	ld a, $1
 	jr DrawHP
 
-DrawEnemyHP: ; 50b0e
+Predef_DrawEnemyHP: ; 50b0e
 	ld a, $2
 
 DrawHP: ; 50b10
@@ -43,7 +43,7 @@ DrawHP: ; 50b10
 	ld c, e
 
 .not_boxmon
-	predef ComputeHPBarPixels
+	predef Predef_ComputeHPBarPixels
 	ld a, 6
 	ld d, a
 	ld c, a
@@ -82,7 +82,7 @@ DrawHP: ; 50b10
 	pop de
 	ret
 
-PrintTempMonStats: ; 50b7b
+Predef_PrintTempMonStats: ; 50b7b
 ; Print TempMon's stats at hl, with spacing bc.
 	push bc
 	push hl
@@ -121,7 +121,7 @@ PrintTempMonStats: ; 50b7b
 	next "SPEED"
 	next "@"
 
-GetGender: ; 50bdd
+Predef_GetGender: ; 50bdd
 ; Return the gender of a given monster (CurPartyMon/CurOTMon/CurWildMon).
 ; When calling this function, a should be set to an appropriate MonType value.
 
@@ -235,7 +235,7 @@ GetGender: ; 50bdd
 	scf
 	ret
 
-ListMovePP: ; 50c50
+Predef_ListMovePP: ; 50c50
 	ld a, [wNumMoves]
 	inc a
 	ld c, a
@@ -343,7 +343,7 @@ UnusedPredef22:
 	call GetNick
 	pop hl
 	call PlaceString
-	call CopyPkmnToTempMon
+	call Predef_CopyPkmnToTempMon
 	pop hl
 	ld a, [CurPartySpecies]
 	cp EGG
@@ -352,7 +352,7 @@ UnusedPredef22:
 	ld bc, -12
 	add hl, bc
 	ld b, $0
-	call DrawEnemyHP
+	call Predef_DrawEnemyHP
 	pop hl
 	ld bc, 5
 	add hl, bc
@@ -363,7 +363,7 @@ UnusedPredef22:
 .egg
 	ret
 
-PlaceStatusString: ; 50d0a
+Predef_PlaceStatusString: ; 50d0a
 	push de
 	inc de
 	inc de
@@ -373,7 +373,7 @@ PlaceStatusString: ; 50d0a
 	ld a, [de]
 	or b
 	pop de
-	jr nz, PlaceNonFaintStatus
+	jr nz, Predef_PlaceNonFaintStatus
 	push de
 	ld de, FntString
 	call CopyStatusString
@@ -396,7 +396,7 @@ CopyStatusString: ; 50d25
 	ld [hl], a
 	ret
 
-PlaceNonFaintStatus: ; 50d2e
+Predef_PlaceNonFaintStatus: ; 50d2e
 	push de
 	ld a, [de]
 	ld de, PsnString
@@ -430,7 +430,7 @@ BrnString: db "BRN@"
 FrzString: db "FRZ@"
 ParString: db "PAR@"
 
-ListMoves: ; 50d6f
+Predef_ListMoves: ; 50d6f
 ; List moves at hl, spaced every [Buffer1] tiles.
 	ld de, wListMoves_MoveIndicesBuffer
 	ld b, $0

--- a/engine/mon_stats.asm
+++ b/engine/mon_stats.asm
@@ -335,7 +335,7 @@ Unreferenced_Function50cd0: ; 50cd0
 	jr nz, .loop
 	ret
 
-Predef22: ; unreferenced predef
+UnreferencedPredef22:
 	push hl
 	push hl
 	ld hl, PartyMonNicknames

--- a/engine/mon_stats.asm
+++ b/engine/mon_stats.asm
@@ -324,8 +324,7 @@ ListMovePP: ; 50c50
 	jr nz, .load_loop
 	ret
 
-Function50cd0: ; 50cd0
-; XXX
+Unreferenced_Function50cd0: ; 50cd0
 .loop
 	ld [hl], $32
 	inc hl

--- a/engine/mon_stats.asm
+++ b/engine/mon_stats.asm
@@ -335,7 +335,7 @@ Unreferenced_Function50cd0: ; 50cd0
 	jr nz, .loop
 	ret
 
-UnreferencedPredef22:
+UnusedPredef22:
 	push hl
 	push hl
 	ld hl, PartyMonNicknames

--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -1119,7 +1119,7 @@ Predef_GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexCaught
 	ld b, RESET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 
 .skip_caught_flag
 ; If we haven't seen this Pokemon before receiving
@@ -1135,7 +1135,7 @@ Predef_GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexSeen
 	ld b, RESET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 
 .skip_seen_flag
 	pop af

--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -1,4 +1,4 @@
-TryAddMonToParty: ; d88c
+Predef_TryAddMonToParty: ; d88c
 ; Check if to copy wild Pkmn or generate new Pkmn
 	; Whose is it?
 	ld de, PartyCount
@@ -120,7 +120,7 @@ GeneratePartyMonStats: ; d906
 	endr
 	ld [hl], a
 	ld [Buffer1], a
-	predef FillMoves
+	predef Predef_FillMoves
 
 .next
 	pop de
@@ -195,7 +195,7 @@ endr
 	push de
 	inc hl
 	inc hl
-	call FillPP
+	call Predef_FillPP
 	pop de
 	pop hl
 rept 4
@@ -224,7 +224,7 @@ endr
 	ld a, $1
 	ld c, a
 	ld b, FALSE
-	call CalcPkmnStatC
+	call Predef_CalcPkmnStatC
 	ld a, [hProduct + 2]
 	ld [de], a
 	inc de
@@ -297,7 +297,7 @@ endr
 	ld bc, MON_STAT_EXP - 1
 	add hl, bc
 	ld b, $0 ; if b = 1, then stat calculation takes stat exp into account.
-	call CalcPkmnStats
+	call Predef_CalcPkmnStats
 
 .next3
 	ld a, [MonType]
@@ -311,7 +311,7 @@ endr
 	dec a
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	callfar UpdateUnownDex
 
 .done
@@ -319,7 +319,7 @@ endr
 	ret
 ; da6d
 
-FillPP: ; da6d
+Predef_FillPP: ; da6d
 	push bc
 	ld b, NUM_MOVES
 .loop
@@ -350,7 +350,7 @@ FillPP: ; da6d
 	ret
 ; da96
 
-AddTempmonToParty: ; da96
+Predef_AddTempmonToParty: ; da96
 	ld hl, PartyCount
 	ld a, [hl]
 	cp PARTY_LENGTH
@@ -422,7 +422,7 @@ AddTempmonToParty: ; da96
 	dec a
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	callfar UpdateUnownDex
 	ld a, [wFirstUnownSeen]
 	and a
@@ -434,7 +434,7 @@ AddTempmonToParty: ; da96
 	and a
 	ret
 
-SentGetPkmnIntoFromBox: ; db3f
+Predef_SendGetPkmnIntoFromBox: ; db3f
 ; Sents/Gets Pkmn into/from Box depending on Parameter
 ; wPokemonWithdrawDepositParameter == 0: get Pkmn into Party
 ; wPokemonWithdrawDepositParameter == 1: sent Pkmn into Box
@@ -597,7 +597,7 @@ SentGetPkmnIntoFromBox: ; db3f
 	srl a
 	add $2
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	callfar CalcLevel
 	ld a, d
 	ld [CurPartyLevel], a
@@ -617,7 +617,7 @@ SentGetPkmnIntoFromBox: ; db3f
 
 	push bc
 	ld b, $1
-	call CalcPkmnStats
+	call Predef_CalcPkmnStats
 	pop bc
 
 	ld a, [wPokemonWithdrawDepositParameter]
@@ -830,7 +830,7 @@ Functiondd64: ; dd64
 	add hl, bc
 	push bc
 	ld b, $1
-	call CalcPkmnStats
+	call Predef_CalcPkmnStats
 	ld hl, PartyMon1Moves
 	ld a, [PartyCount]
 	dec a
@@ -840,7 +840,7 @@ Functiondd64: ; dd64
 	ld e, l
 	ld a, $1
 	ld [Buffer1], a
-	predef FillMoves
+	predef Predef_FillMoves
 	ld a, [PartyCount]
 	dec a
 	ld [CurPartyMon], a
@@ -904,8 +904,8 @@ DepositBreedmon: ; de44
 	ld bc, BOXMON_STRUCT_LENGTH
 	jp CopyBytes
 
-SentPkmnIntoBox: ; de6e
-; Sents the Pkmn into one of Bills Boxes
+Predef_SendPkmnIntoBox: ; de6e
+; Sends the Pkmn into one of Bills Boxes
 ; the data comes mainly from 'EnemyMon:'
 	ld a, BANK(sBoxCount)
 	call GetSRAMBank
@@ -1010,7 +1010,7 @@ SentPkmnIntoBox: ; de6e
 	cp UNOWN
 	jr nz, .not_unown
 	ld hl, sBoxMon1DVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	callfar UpdateUnownDex
 
 .not_unown
@@ -1086,7 +1086,7 @@ ShiftBoxMon: ; df47
 	ret
 ; df8c
 
-GiveEgg:: ; df8c
+Predef_GiveEgg:: ; df8c
 	ld a, [CurPartySpecies]
 	push af
 	callfar GetPreEvolution
@@ -1094,7 +1094,7 @@ GiveEgg:: ; df8c
 	ld a, [CurPartySpecies]
 	dec a
 
-; TryAddMonToParty sets Seen and Caught flags
+; Predef_TryAddMonToParty sets Seen and Caught flags
 ; when it is successful.  This routine will make
 ; sure that we aren't newly setting flags.
 	push af
@@ -1104,11 +1104,11 @@ GiveEgg:: ; df8c
 	call CheckSeenMon
 	push bc
 
-	call TryAddMonToParty
+	call Predef_TryAddMonToParty
 
 ; If we haven't caught this Pokemon before receiving
 ; the Egg, reset the flag that was just set by
-; TryAddMonToParty.
+; Predef_TryAddMonToParty.
 	pop bc
 	ld a, c
 	and a
@@ -1119,12 +1119,12 @@ GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexCaught
 	ld b, RESET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 
 .skip_caught_flag
 ; If we haven't seen this Pokemon before receiving
 ; the Egg, reset the flag that was just set by
-; TryAddMonToParty.
+; Predef_TryAddMonToParty.
 	pop bc
 	ld a, c
 	and a
@@ -1135,7 +1135,7 @@ GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexSeen
 	ld b, RESET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 
 .skip_seen_flag
 	pop af
@@ -1360,7 +1360,7 @@ ComputeNPCTrademonStats: ; e134
 	ld a, MON_STAT_EXP - 1
 	call GetPartyParamLocation
 	ld b, $1
-	call CalcPkmnStats
+	call Predef_CalcPkmnStats
 	pop de
 	ld a, MON_HP
 	call GetPartyParamLocation
@@ -1372,7 +1372,7 @@ ComputeNPCTrademonStats: ; e134
 	ret
 ; e167
 
-CalcPkmnStats: ; e167
+Predef_CalcPkmnStats: ; e167
 ; Calculates all 6 Stats of a Pkmn
 ; b: Take into account stat EXP if TRUE
 ; 'c' counts from 1-6 and points with 'BaseStats' to the base value
@@ -1382,7 +1382,7 @@ CalcPkmnStats: ; e167
 	ld c, $0
 .loop
 	inc c
-	call CalcPkmnStatC
+	call Predef_CalcPkmnStatC
 	ld a, [hMultiplicand + 1]
 	ld [de], a
 	inc de
@@ -1395,7 +1395,7 @@ CalcPkmnStats: ; e167
 	ret
 ; e17b
 
-CalcPkmnStatC: ; e17b
+Predef_CalcPkmnStatC: ; e17b
 ; 'c' is 1-6 and points to the BaseStat
 ; 1: HP
 ; 2: Attack
@@ -1596,7 +1596,7 @@ GivePoke:: ; e277
 	push bc
 	xor a ; PARTYMON
 	ld [MonType], a
-	call TryAddMonToParty
+	call Predef_TryAddMonToParty
 	jr nc, .failed
 	ld hl, PartyMonNicknames
 	ld a, [PartyCount]
@@ -1626,7 +1626,7 @@ GivePoke:: ; e277
 	ld a, [CurPartySpecies]
 	ld [TempEnemyMonSpecies], a
 	callfar LoadEnemyMon
-	call SentPkmnIntoBox
+	call Predef_SendPkmnIntoBox
 	jp nc, .FailedToGiveMon
 	ld a, BOXMON
 	ld [MonType], a

--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -1795,7 +1795,7 @@ InitNickname: ; e3de
 	pop hl
 	ld de, StringBuffer1
 	call InitName
-	ld a, $4 ; XXX could this be in bank 4 in pokered?
+	ld a, $4 ; ExitAllMenus is in bank 0, XXX could this be in bank 4 in pokered?
 	ld hl, ExitAllMenus
 	rst FarCall
 	ret

--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -1119,7 +1119,7 @@ Predef_GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexCaught
 	ld b, RESET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 
 .skip_caught_flag
 ; If we haven't seen this Pokemon before receiving
@@ -1135,7 +1135,7 @@ Predef_GiveEgg:: ; df8c
 	ld d, $0
 	ld hl, PokedexSeen
 	ld b, RESET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 
 .skip_seen_flag
 	pop af

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1369,7 +1369,7 @@ InitMysteryGiftLayout: ; 105153 (41:5153)
 	jr .gfx_loop
 ; 105232 (41:5232)
 
-.Load6GFX: ; unreferenced
+.Unreferenced_Load6GFX:
 	ld b,  6
 	jr .gfx_loop
 

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1117,7 +1117,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef_id FlagPredef
+	predef_id Predef_Flag
 	push hl
 	push bc
 	call Predef
@@ -1129,7 +1129,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ret nz
 	call GetMysteryGiftBank
 	ld b, SET_FLAG
-	predef FlagPredef
+	predef Predef_Flag
 	call CloseSRAM
 	xor a
 	ret
@@ -1142,7 +1142,7 @@ MysteryGift_CopyReceivedDecosToPC: ; 105091 (41:5091)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	and a
 	pop bc

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1117,7 +1117,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef_id Predef_FlagAction
+	predef_id Predef_SmallFarFlagAction
 	push hl
 	push bc
 	call Predef
@@ -1129,7 +1129,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ret nz
 	call GetMysteryGiftBank
 	ld b, SET_FLAG
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	call CloseSRAM
 	xor a
 	ret
@@ -1142,7 +1142,7 @@ MysteryGift_CopyReceivedDecosToPC: ; 105091 (41:5091)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	and a
 	pop bc

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1117,7 +1117,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef_id Predef_Flag
+	predef_id Predef_FlagAction
 	push hl
 	push bc
 	call Predef
@@ -1129,7 +1129,7 @@ MysteryGift_CheckAndSetDecorationAlreadyReceived: ; 105069 (41:5069)
 	ret nz
 	call GetMysteryGiftBank
 	ld b, SET_FLAG
-	predef Predef_Flag
+	predef Predef_FlagAction
 	call CloseSRAM
 	xor a
 	ret
@@ -1142,7 +1142,7 @@ MysteryGift_CopyReceivedDecosToPC: ; 105091 (41:5091)
 	ld d, $0
 	ld b, CHECK_FLAG
 	ld hl, sMysteryGiftDecorationsReceived
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	and a
 	pop bc

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -63,7 +63,7 @@ DoMysteryGift: ; 1048ba (41:48ba)
 	jr z, .skip_append_save
 	call .SaveMysteryGiftTrainerName
 	farcall RestoreMobileEventIndex
-	farcall TrainerRankings_MysteryGift
+	farcall StubbedTrainerRankings_MysteryGift
 	farcall BackupMobileEventIndex
 .skip_append_save
 	ld a, [wMysteryGiftPartnerSentDeco]

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -103,7 +103,7 @@ NamingScreen: ; 116c1
 	inc de
 	hlcoord 5, 4
 	call PlaceString
-	farcall GetGender
+	farcall Predef_GetGender
 	jr c, .genderless
 	ld a, "♂"
 	jr nz, .place_gender

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -765,7 +765,7 @@ NamingScreen_AdvanceCursor_CheckEndOfString: ; 11b27
 
 ; 11b56
 
-Dakutens: ; Dummied out
+Dakutens: ; unused
 	db "かが", "きぎ", "くぐ", "けげ", "こご"
 	db "さざ", "しじ", "すず", "せぜ", "そぞ"
 	db "ただ", "ちぢ", "つづ", "てで", "とど"
@@ -776,7 +776,7 @@ Dakutens: ; Dummied out
 	db "ハバ", "ヒビ", "フブ", "へべ", "ホボ"
 	db $ff
 
-Handakutens: ; Dummied out
+Handakutens: ; unused
 	db "はぱ", "ひぴ", "ふぷ", "へぺ", "ほぽ"
 	db "ハパ", "ヒピ", "フプ", "へぺ", "ホポ"
 	db $ff
@@ -1051,7 +1051,7 @@ INCBIN "gfx/icon/mail2.2bpp"
 
 ; 11f7a (4:5f7a)
 
-.Dummy: ; dummied out
+.UnusedString11f7a:
 	db "メールを かいてね@"
 
 ; 11f84

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -739,7 +739,7 @@ NamingScreen_AdvanceCursor_CheckEndOfString: ; 11b27
 
 ; 11b39 (4:5b39)
 
-; XXX
+; unused
 	ld a, [wNamingScreenCurrNameLength]
 	and a
 	ret z
@@ -1434,7 +1434,7 @@ MailComposition_TryAddLastCharacter: ; 121ac (4:61ac)
 
 ; 121b2 (4:61b2)
 
-; XXX
+; unused
 	ld a, [wNamingScreenCurrNameLength]
 	and a
 	ret z

--- a/engine/npc_movement.asm
+++ b/engine/npc_movement.asm
@@ -279,7 +279,7 @@ WillObjectBumpIntoSomeoneElse: ; 7009
 	jr IsNPCAtCoord
 ; 7015
 
-Function7015: ; unreferenced
+Unreferenced_Function7015:
 	ld a, [hMapObjectIndexBuffer]
 	call GetObjectStruct
 	call .CheckWillBeFacingNPC
@@ -482,7 +482,7 @@ IsObjectMovingOffEdgeOfScreen: ; 70ed
 	ret
 ; 7113
 
-Function7113: ; unreferenced
+Unreferenced_Function7113:
 	ld a, [PlayerStandingMapX]
 	ld d, a
 	ld a, [PlayerStandingMapY]

--- a/engine/npctrade.asm
+++ b/engine/npctrade.asm
@@ -67,7 +67,7 @@ NPCTrade:: ; fcba8
 	push af
 	ld a, [wcf64]
 	push af
-	predef TradeAnimation
+	predef Predef_TradeAnimation
 	pop af
 	ld [wcf64], a
 	pop af
@@ -88,12 +88,12 @@ CheckTradeGender: ; fcc23
 	cp 1
 	jr z, .check_male
 
-	farcall GetGender
+	farcall Predef_GetGender
 	jr nz, .not_matching
 	jr .matching
 
 .check_male
-	farcall GetGender
+	farcall Predef_GetGender
 	jr z, .not_matching
 
 .matching
@@ -109,7 +109,7 @@ TradeFlagAction: ; fcc4a
 	ld hl, wTradeFlags
 	ld a, [wJumptableIndex]
 	ld c, a
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	and a
 	ret
@@ -196,7 +196,7 @@ DoNPCTrade: ; fcc63
 	ld [MonType], a
 	ld [wPokemonWithdrawDepositParameter], a
 	callfar RemoveMonFromPartyOrBox
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 
 	ld e, TRADE_DIALOG
 	call GetTradeAttribute

--- a/engine/npctrade.asm
+++ b/engine/npctrade.asm
@@ -332,8 +332,7 @@ CopyTradeName: ; fcdf4
 	ret
 ; fcdfb
 
-Functionfcdfb: ; fcdfb
-; unreferenced
+Unreferenced_Functionfcdfb: ; fcdfb
 	ld bc, 4
 	call CopyBytes
 	ld a, "@"
@@ -341,8 +340,7 @@ Functionfcdfb: ; fcdfb
 	ret
 ; fce05
 
-Functionfce05: ; fce05
-; unreferenced
+Unreferenced_Functionfce05: ; fce05
 	ld bc, 3
 	call CopyBytes
 	ld a, "@"

--- a/engine/npctrade.asm
+++ b/engine/npctrade.asm
@@ -109,7 +109,7 @@ TradeFlagAction: ; fcc4a
 	ld hl, wTradeFlags
 	ld a, [wJumptableIndex]
 	ld c, a
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	and a
 	ret

--- a/engine/npctrade.asm
+++ b/engine/npctrade.asm
@@ -109,7 +109,7 @@ TradeFlagAction: ; fcc4a
 	ld hl, wTradeFlags
 	ld a, [wJumptableIndex]
 	ld c, a
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	and a
 	ret

--- a/engine/overworld.asm
+++ b/engine/overworld.asm
@@ -23,7 +23,7 @@ Function14146: ; mobile
 	push af
 	res 7, [hl]
 	set 6, [hl]
-	call Special_MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_LoadUsedSpritesGFX
 	pop af
 	ld [wSpriteFlags], a
 	ret
@@ -35,7 +35,7 @@ Function14157: ; mobile
 	push af
 	set 7, [hl]
 	res 6, [hl]
-	call Special_MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_LoadUsedSpritesGFX
 	pop af
 	ld [wSpriteFlags], a
 	ret
@@ -43,7 +43,7 @@ Function14157: ; mobile
 
 Special_RefreshSprites:: ; 14168
 	call .Refresh
-	call Special_MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_LoadUsedSpritesGFX
 	ret
 ; 1416f
 
@@ -164,7 +164,7 @@ AddOutdoorSprites: ; 141ee
 ; 14209
 
 
-Special_MapCallbackSprites_LoadUsedSpritesGFX: ; 14209
+Special_LoadUsedSpritesGFX: ; 14209
 	ld a, MAPCALLBACK_SPRITES
 	call RunMapCallback
 	call GetUsedSprites

--- a/engine/overworld.asm
+++ b/engine/overworld.asm
@@ -41,7 +41,7 @@ Function14157: ; mobile
 	ret
 ; 14168
 
-RefreshSprites:: ; 14168
+Special_RefreshSprites:: ; 14168
 	call .Refresh
 	call Special_MapCallbackSprites_LoadUsedSpritesGFX
 	ret

--- a/engine/overworld.asm
+++ b/engine/overworld.asm
@@ -23,7 +23,7 @@ Function14146: ; mobile
 	push af
 	res 7, [hl]
 	set 6, [hl]
-	call MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_MapCallbackSprites_LoadUsedSpritesGFX
 	pop af
 	ld [wSpriteFlags], a
 	ret
@@ -35,7 +35,7 @@ Function14157: ; mobile
 	push af
 	set 7, [hl]
 	res 6, [hl]
-	call MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_MapCallbackSprites_LoadUsedSpritesGFX
 	pop af
 	ld [wSpriteFlags], a
 	ret
@@ -43,7 +43,7 @@ Function14157: ; mobile
 
 RefreshSprites:: ; 14168
 	call .Refresh
-	call MapCallbackSprites_LoadUsedSpritesGFX
+	call Special_MapCallbackSprites_LoadUsedSpritesGFX
 	ret
 ; 1416f
 
@@ -164,7 +164,7 @@ AddOutdoorSprites: ; 141ee
 ; 14209
 
 
-MapCallbackSprites_LoadUsedSpritesGFX: ; 14209
+Special_MapCallbackSprites_LoadUsedSpritesGFX: ; 14209
 	ld a, MAPCALLBACK_SPRITES
 	call RunMapCallback
 	call GetUsedSprites

--- a/engine/pack.asm
+++ b/engine/pack.asm
@@ -534,8 +534,7 @@ TossMenu: ; 10364
 	ret
 ; 1039d
 
-ResetPocketCursorPositions: ; 1039d
-; unreferenced
+Unreferenced_ResetPocketCursorPositions: ; 1039d
 	ld a, [wCurrPocket]
 	and a
 	jr z, .items
@@ -1511,8 +1510,7 @@ Pack_GetItemName: ; 10a1d
 	ret
 ; 10a2a
 
-Pack_ClearTilemap: ; 10a2a
-; unreferenced
+Unreferenced_Pack_ClearTilemap: ; 10a2a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, " "

--- a/engine/party_menu.asm
+++ b/engine/party_menu.asm
@@ -188,7 +188,7 @@ PlacePartymonHPBar: ; 50117
 	ld d, a
 	ld a, [hli]
 	ld e, a
-	predef ComputeHPBarPixels
+	predef Predef_ComputeHPBarPixels
 	ret
 ; 50138
 
@@ -297,7 +297,7 @@ PlacePartyMonStatus: ; 501b2
 	ld e, l
 	ld d, h
 	pop hl
-	call PlaceStatusString
+	call Predef_PlaceStatusString
 
 .next
 	pop hl
@@ -329,7 +329,7 @@ PlacePartyMonTMHMCompatibility: ; 501e0
 	add hl, de
 	ld a, [hl]
 	ld [CurPartySpecies], a
-	predef CanLearnTMHMMove
+	predef Predef_CanLearnTMHMMove
 	pop hl
 	call .PlaceAbleNotAble
 	call PlaceString
@@ -468,7 +468,7 @@ PlacePartyMonGender: ; 502b1
 	ld [CurPartyMon], a
 	xor a
 	ld [MonType], a
-	call GetGender
+	call Predef_GetGender
 	ld de, .unknown
 	jr c, .got_gender
 	ld de, .male

--- a/engine/party_menu.asm
+++ b/engine/party_menu.asm
@@ -817,24 +817,32 @@ PartyMenuStrings: ; 0x504d2
 
 ChooseAMonString: ; 0x504e4
 	db "Choose a #MON.@"
+
 UseOnWhichPKMNString: ; 0x504f3
 	db "Use on which <PK><MN>?@"
+
 WhichPKMNString: ; 0x50504
 	db "Which <PK><MN>?@"
+
 TeachWhichPKMNString: ; 0x5050e
 	db "Teach which <PK><MN>?@"
+
 MoveToWhereString: ; 0x5051e
 	db "Move to where?@"
-ChooseAFemalePKMNString: ; 0x5052d  ; UNUSED
+
+ChooseAFemalePKMNString: ; 0x5052d
+; unused
 	db "Choose a ♀<PK><MN>.@"
-ChooseAMalePKMNString: ; 0x5053b    ; UNUSED
+
+ChooseAMalePKMNString: ; 0x5053b
+; unused
 	db "Choose a ♂<PK><MN>.@"
+
 ToWhichPKMNString: ; 0x50549
 	db "To which <PK><MN>?@"
 
 YouHaveNoPKMNString: ; 0x50556
 	db "You have no <PK><MN>!@"
-
 
 PrintPartyMenuActionText: ; 50566
 	ld a, [CurPartyMon]

--- a/engine/phone/generic_calls.asm
+++ b/engine/phone/generic_calls.asm
@@ -1240,7 +1240,7 @@ PhoneScript_Generic_Female:
 	end
 
 PhoneScript_MonFlavorText:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farscall PhoneScript_Random2
 	if_equal $0, .TooEnergetic
 	farwritetext UnknownText_0x1b518b

--- a/engine/phone/phone.asm
+++ b/engine/phone/phone.asm
@@ -471,7 +471,7 @@ UnknownScript_0x90261: ; 0x90261
 RingTwice_StartCall: ; 9026f
 	call .Ring
 	call .Ring
-	farcall TrainerRankings_PhoneCalls
+	farcall StubbedTrainerRankings_PhoneCalls
 	ret
 ; 9027c
 
@@ -500,7 +500,7 @@ PhoneCall:: ; 9029a
 	ld [PhoneCaller + 1], a
 	call Phone_FirstOfTwoRings
 	call Phone_FirstOfTwoRings
-	farcall TrainerRankings_PhoneCalls
+	farcall StubbedTrainerRankings_PhoneCalls
 	ret
 ; 902b3
 

--- a/engine/phone/phone_callers.asm
+++ b/engine/phone/phone_callers.asm
@@ -1,5 +1,5 @@
 Phone_GenericCall_Male:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farscall PhoneScript_Random2
 	if_equal 0, .Bragging
 	farscall PhoneScript_Generic_Male
@@ -9,7 +9,7 @@ Phone_GenericCall_Male:
 	farjump Phone_BraggingCall_Male
 
 Phone_GenericCall_Female:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farscall PhoneScript_Random2
 	if_equal 0, .Bragging
 	farscall PhoneScript_Generic_Female
@@ -27,7 +27,7 @@ Phone_BraggingCall_Female:
 	farjump Phone_FoundAMon_Female
 
 Phone_FoundAMon_Male:
-	special RandomPhoneWildMon
+	special Special_RandomPhoneWildMon
 	farscall PhoneScript_Random2
 	if_equal 0, .GotAway
 	farscall Phone_WhoDefeatedMon_Male
@@ -37,7 +37,7 @@ Phone_FoundAMon_Male:
 	farjump Phone_GotAwayCall_Male
 
 Phone_FoundAMon_Female:
-	special RandomPhoneWildMon
+	special Special_RandomPhoneWildMon
 	farscall PhoneScript_Random2
 	if_equal 0, .GotAway
 	farscall Phone_WhoDefeatedMon_Female
@@ -851,7 +851,7 @@ Phone_CheckIfUnseenRare_Female:
 	farjump PhoneScript_HangupText_Female
 
 PhoneScriptRareWildMon:
-	special RandomUnseenWildMon
+	special Special_RandomUnseenWildMon
 	end
 
 PhoneScript_BugCatchingContest:

--- a/engine/phone/phone_scripts.asm
+++ b/engine/phone/phone_scripts.asm
@@ -392,7 +392,7 @@ HueyPhoneScript1:
 	iftrue HueyWednesdayNight
 
 .NotWednesday:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farjump UnknownScript_0xa0908
 
 .WantsBattle:
@@ -629,7 +629,7 @@ JoeyPhoneScript1:
 	iftrue JoeyMondayAfternoon
 
 .NotMonday:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farjump UnknownScript_0xa0930
 
 .WantsBattle:
@@ -851,7 +851,7 @@ LizPhoneScript1:
 	iftrue LizThursdayAfternoon
 
 .NotThursday:
-	special RandomPhoneMon
+	special Special_RandomPhoneMon
 	farjump UnknownScript_0xa0948
 
 .WantsBattle:

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -1110,9 +1110,10 @@ PokeAnim_GetSpeciesOrUnown: ; d065c
 	ret
 ; d0669
 
-Predef48: ; d0669 Predef 48
+UnreferencedPredef48: ; d0669 Predef 48
 	ld a, $1
 	ld [wBoxAlignment], a
+
 HOF_AnimateFrontpic: ; d066e Predef 49
 	call AnimateMon_CheckIfPokemon
 	jr c, .fail

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -1,54 +1,54 @@
 ; Pic animation arrangement.
 
-AnimateMon_Slow_Normal: ; d0000
+UnusedPredef_AnimateMon_Slow_Normal: ; d0000
 	hlcoord 12, 0
 	ld a, [wBattleMode]
 	cp WILD_BATTLE
 	jr z, .wild
 	ld e, ANIM_MON_SLOW
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 
 .wild
 	ld e, ANIM_MON_NORMAL
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d001a
 
 AnimateMon_Menu: ; d001a
 	ld e, ANIM_MON_MENU
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d0022
 
 AnimateMon_Trade: ; d0022
 	ld e, ANIM_MON_TRADE
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d002a
 
 AnimateMon_Evolve: ; d002a
 	ld e, ANIM_MON_EVOLVE
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d0032
 
 AnimateMon_Hatch: ; d0032
 	ld e, ANIM_MON_HATCH
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d003a
 
 AnimateMon_Unused: ; d003a
 	ld e, ANIM_MON_UNUSED
 	ld d, $0
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	ret
 ; d0042
 
@@ -86,10 +86,10 @@ PokeAnims: ; d0042
 .Egg2:   pokeanim Idle, Play
 
 
-AnimateFrontpic: ; d008e
+Predef_AnimateFrontpic: ; d008e
 	call AnimateMon_CheckIfPokemon
 	ret c
-	call LoadMonAnimation
+	call Predef_LoadMonAnimation
 .loop
 	call SetUpPokeAnim
 	push af
@@ -99,7 +99,7 @@ AnimateFrontpic: ; d008e
 	ret
 ; d00a3
 
-LoadMonAnimation: ; d00a3
+Predef_LoadMonAnimation: ; d00a3
 	push hl
 	ld c, e
 	ld b, 0
@@ -1114,7 +1114,7 @@ UnusedPredef48: ; d0669 Predef 48
 	ld a, $1
 	ld [wBoxAlignment], a
 
-HOF_AnimateFrontpic: ; d066e Predef 49
+HOF_Predef_AnimateFrontpic: ; d066e Predef 49
 	call AnimateMon_CheckIfPokemon
 	jr c, .fail
 	ld h, d
@@ -1122,12 +1122,12 @@ HOF_AnimateFrontpic: ; d066e Predef 49
 	push bc
 	push hl
 	ld de, vTiles2
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	pop hl
 	pop bc
 	ld d, 0
 	ld e, c
-	call AnimateFrontpic
+	call Predef_AnimateFrontpic
 	xor a
 	ld [wBoxAlignment], a
 	ret

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -695,7 +695,7 @@ PokeAnim_ConvertAndApplyBitmask: ; d036b
 	ret
 ; d03f4
 
-; XXX
+; unused
 	db 6, 5, 4
 
 .GetTilemap: ; d03f7

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -1110,7 +1110,7 @@ PokeAnim_GetSpeciesOrUnown: ; d065c
 	ret
 ; d0669
 
-UnreferencedPredef48: ; d0669 Predef 48
+UnusedPredef48: ; d0669 Predef 48
 	ld a, $1
 	ld [wBoxAlignment], a
 

--- a/engine/player_gfx.asm
+++ b/engine/player_gfx.asm
@@ -30,7 +30,7 @@ MovePlayerPic: ; 88266
 	xor a
 	ld [hBGMapMode], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	xor a
 	ld [hBGMapThird], a
 	call WaitBGMap
@@ -141,7 +141,7 @@ GetChrisBackpic: ; 88830
 	ld b, BANK(ChrisBackpic)
 	ld de, vTiles2 tile $31
 	ld c, 7 * 7
-	predef DecompressPredef
+	predef Predef_Decompress
 	ret
 
 HOF_LoadTrainerFrontpic: ; 88840
@@ -203,7 +203,7 @@ DrawIntroPlayerPic: ; 88874
 	ld [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 
 ChrisPic: ; 888a9

--- a/engine/player_gfx.asm
+++ b/engine/player_gfx.asm
@@ -1,5 +1,4 @@
-Function88248: ; 88248
-; XXX
+Unreferenced_Function88248: ; 88248
 	ld c, CAL
 	ld a, [wPlayerGender]
 	bit 0, a

--- a/engine/player_movement.asm
+++ b/engine/player_movement.asm
@@ -316,7 +316,7 @@ DoPlayerMovement:: ; 80000
 	scf
 	ret
 
-; unused?
+; unused
 	xor a
 	ret
 

--- a/engine/player_step.asm
+++ b/engine/player_step.asm
@@ -76,7 +76,7 @@ HandlePlayerStep: ; d4e5 (3:54e5)
 	ret
 
 .mobile ; d509 (3:5509)
-	farcall TrainerRankings_StepCount
+	farcall StubbedTrainerRankings_StepCount
 	ret
 
 .fail2 ; d510 (3:5510)

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -441,7 +441,7 @@ DexEntryScreen_MenuActionJumptable: ; 402f2
 	call Pokedex_GetSelectedMon
 	ld a, [wDexCurrentLocation]
 	ld e, a
-	predef Pokedex_GetArea
+	predef Predef_Pokedex_GetArea
 	call Pokedex_BlackOutBG
 	call DelayFrame
 	xor a
@@ -2399,7 +2399,7 @@ Pokedex_LoadSelectedMonTiles: ; 4143b
 	ld [CurPartySpecies], a
 	call GetBaseData
 	ld de, vTiles2
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	ret
 
 .QuestionMark:
@@ -2552,7 +2552,7 @@ Pokedex_LoadUnownFrontpicTiles: ; 41a58 (10:5a58)
 	ld [CurPartySpecies], a
 	call GetBaseData
 	ld de, vTiles2 tile $00
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	pop af
 	ld [UnownLetter], a
 	ret
@@ -2582,7 +2582,7 @@ _NewPokedexEntry: ; 41a7f
 	call WaitBGMap
 	call GetBaseData
 	ld de, vTiles2
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	ld a, SCGB_POKEDEX
 	call Pokedex_GetSGBLayout
 	ld a, [CurPartySpecies]

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -441,7 +441,7 @@ DexEntryScreen_MenuActionJumptable: ; 402f2
 	call Pokedex_GetSelectedMon
 	ld a, [wDexCurrentLocation]
 	ld e, a
-	predef _Area
+	predef Pokedex_GetArea
 	call Pokedex_BlackOutBG
 	call DelayFrame
 	xor a

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2440,7 +2440,7 @@ FlyMap: ; 91c90
 
 ; 91d11
 
-_Area: ; 91d11
+Pokedex_GetArea: ; 91d11
 ; e: Current landmark
 	ld a, [wTownMapPlayerIconLandmark]
 	push af

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2331,7 +2331,7 @@ HasVisitedSpawn: ; 91c50
 	ld hl, wVisitedSpawns
 	ld b, CHECK_FLAG
 	ld d, 0
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	ret
 
@@ -2440,7 +2440,7 @@ FlyMap: ; 91c90
 
 ; 91d11
 
-Pokedex_GetArea: ; 91d11
+Predef_Pokedex_GetArea: ; 91d11
 ; e: Current landmark
 	ld a, [wTownMapPlayerIconLandmark]
 	push af

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -1751,7 +1751,7 @@ LoadStation_EvolutionRadio: ; 9183e (24:583e)
 
 ; 91853 (24:5853)
 
-LoadStation_Dummy: ; 91853
+Unreferenced_LoadStation: ; 91853
 	ret
 
 RadioMusicRestartDE: ; 91854 (24:5854)

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2331,7 +2331,7 @@ HasVisitedSpawn: ; 91c50
 	ld hl, wVisitedSpawns
 	ld b, CHECK_FLAG
 	ld d, 0
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	ret
 

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2331,7 +2331,7 @@ HasVisitedSpawn: ; 91c50
 	ld hl, wVisitedSpawns
 	ld b, CHECK_FLAG
 	ld d, 0
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	ret
 

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -1309,7 +1309,7 @@ PokegearPhoneContactSubmenu: ; 91342 (24:5342)
 
 ; 9146e
 
-; XXX
+; unused
 	ld a, [hHours]
 	cp 12
 	jr c, .am
@@ -1499,7 +1499,7 @@ UpdateRadioStation: ; 9166f (24:566f)
 
 ; 916a1 (24:56a1)
 
-; XXX
+; unused
 	ld [wPokegearRadioChannelBank], a
 	ld a, [hli]
 	ld [wPokegearRadioChannelAddr], a
@@ -2932,7 +2932,7 @@ INCBIN "gfx/pokegear/dexmap_nest_icon.2bpp"
 FlyMapLabelBorderGFX: ; 922e1
 INCBIN "gfx/pokegear/flymap_label_border.1bpp"
 
-; XXX
+Unreferenced_Function92311:
 	xor a
 	ld [wTownMapPlayerIconLandmark], a
 	call ClearBGPalettes

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -33,7 +33,7 @@ PredefPointers:: ; 856b
 	add_predef Predef_LearnMove ; $0
 	add_predef DummyPredef1
 	add_predef HealParty ; this is both a special and a predef
-	add_predef Predef_Flag
+	add_predef Predef_FlagAction
 	add_predef Predef_ComputeHPBarPixels
 	add_predef Predef_FillPP
 	add_predef Predef_TryAddMonToParty

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -64,7 +64,7 @@ PredefPointers:: ; 856b
 	add_predef CopyPkmnToTempMon
 	add_predef ListMoves ; $20
 	add_predef PlaceNonFaintStatus
-	add_predef UnreferencedPredef22
+	add_predef UnusedPredef22
 	add_predef ListMovePP
 	add_predef GetGender
 	add_predef StatsScreenInit
@@ -81,7 +81,7 @@ PredefPointers:: ; 856b
 	add_predef InitSGBBorder ; $30
 	add_predef LoadSGBLayout
 	add_predef Pokedex_GetArea
-	add_predef Unreferenced_CheckContestMon
+	add_predef UnusedPredef_CheckContestMon
 	add_predef DoBattleTransition
 	add_predef DummyPredef35
 	add_predef DummyPredef36
@@ -102,7 +102,7 @@ PredefPointers:: ; 856b
 	add_predef PlaceStatusString
 	add_predef LoadMonAnimation
 	add_predef AnimateFrontpic
-	add_predef UnreferencedPredef48 ; $48
+	add_predef UnusedPredef48 ; $48
 	add_predef HOF_AnimateFrontpic
 	dbw $ff, InexplicablyEmptyFunction ; ???
 ; 864c

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -33,7 +33,7 @@ PredefPointers:: ; 856b
 	add_predef Predef_LearnMove ; $0
 	add_predef DummyPredef1
 	add_predef HealParty ; this is both a special and a predef
-	add_predef Predef_FlagAction
+	add_predef Predef_SmallFarFlagAction
 	add_predef Predef_ComputeHPBarPixels
 	add_predef Predef_FillPP
 	add_predef Predef_TryAddMonToParty

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -81,7 +81,7 @@ PredefPointers:: ; 856b
 	add_predef InitSGBBorder ; $30
 	add_predef LoadSGBLayout
 	add_predef Pokedex_GetArea
-	add_predef CheckContestMon
+	add_predef Unreferenced_CheckContestMon
 	add_predef DoBattleTransition
 	add_predef DummyPredef35
 	add_predef DummyPredef36

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -31,7 +31,7 @@ PredefPointers:: ; 856b
 ; address, bank
 
 	add_predef LearnMove ; $0
-	add_predef Predef1
+	add_predef DummyPredef1
 	add_predef HealParty
 	add_predef FlagPredef
 	add_predef ComputeHPBarPixels
@@ -46,7 +46,7 @@ PredefPointers:: ; 856b
 	add_predef CalcPkmnStatC
 	add_predef CanLearnTMHMMove
 	add_predef GetTMHMMove
-	add_predef Predef_LinkTextbox ; $ 10
+	add_predef LinkTextboxPredef ; $ 10
 	add_predef PrintMoveDesc
 	add_predef UpdatePlayerHUD
 	add_predef PlaceGraphic
@@ -64,7 +64,7 @@ PredefPointers:: ; 856b
 	add_predef CopyPkmnToTempMon
 	add_predef ListMoves ; $20
 	add_predef PlaceNonFaintStatus
-	add_predef Predef22
+	add_predef UnreferencedPredef22
 	add_predef ListMovePP
 	add_predef GetGender
 	add_predef StatsScreenInit
@@ -77,18 +77,18 @@ PredefPointers:: ; 856b
 	add_predef PrintMonTypes
 	add_predef GetUnownLetter
 	add_predef LoadPoisonBGPals
-	add_predef Predef2F
+	add_predef DummyPredef2F
 	add_predef InitSGBBorder ; $30
-	add_predef Predef_LoadSGBLayout
-	add_predef _Area
+	add_predef LoadSGBLayout
+	add_predef Pokedex_GetArea
 	add_predef CheckContestMon
-	add_predef Predef_StartBattle
-	add_predef Predef35
-	add_predef Predef36
+	add_predef DoBattleTransition
+	add_predef DummyPredef35
+	add_predef DummyPredef36
 	add_predef PlayBattleAnim
-	add_predef Predef38 ; $38
-	add_predef Predef39
-	add_predef Predef3A
+	add_predef DummyPredef38 ; $38
+	add_predef DummyPredef39
+	add_predef DummyPredef3A
 	add_predef PartyMonItemName
 	add_predef GetMonFrontpic
 	add_predef GetMonBackpic
@@ -102,7 +102,7 @@ PredefPointers:: ; 856b
 	add_predef PlaceStatusString
 	add_predef LoadMonAnimation
 	add_predef AnimateFrontpic
-	add_predef Predef48 ; $48
+	add_predef UnreferencedPredef48 ; $48
 	add_predef HOF_AnimateFrontpic
 	dbw $ff, InexplicablyEmptyFunction ; ???
 ; 864c

--- a/engine/predef.asm
+++ b/engine/predef.asm
@@ -30,79 +30,79 @@ PredefPointers:: ; 856b
 ; $4b Predef pointers
 ; address, bank
 
-	add_predef LearnMove ; $0
+	add_predef Predef_LearnMove ; $0
 	add_predef DummyPredef1
-	add_predef HealParty
-	add_predef FlagPredef
-	add_predef ComputeHPBarPixels
-	add_predef FillPP
-	add_predef TryAddMonToParty
-	add_predef AddTempmonToParty
-	add_predef SentGetPkmnIntoFromBox
-	add_predef SentPkmnIntoBox
-	add_predef GiveEgg
-	add_predef AnimateHPBar
-	add_predef CalcPkmnStats
-	add_predef CalcPkmnStatC
-	add_predef CanLearnTMHMMove
-	add_predef GetTMHMMove
-	add_predef LinkTextboxPredef ; $ 10
-	add_predef PrintMoveDesc
-	add_predef UpdatePlayerHUD
-	add_predef PlaceGraphic
-	add_predef CheckPlayerPartyForFitPkmn
-	add_predef UpdateEnemyHUD
-	add_predef StartBattle
-	add_predef FillInExpBar
-	add_predef GetBattleMonBackpic ; $18
-	add_predef GetEnemyMonFrontpic
-	add_predef LearnLevelMoves
-	add_predef FillMoves
-	add_predef EvolveAfterBattle
-	add_predef TradeAnimationPlayer2
-	add_predef TradeAnimation
-	add_predef CopyPkmnToTempMon
-	add_predef ListMoves ; $20
-	add_predef PlaceNonFaintStatus
+	add_predef HealParty ; this is both a special and a predef
+	add_predef Predef_Flag
+	add_predef Predef_ComputeHPBarPixels
+	add_predef Predef_FillPP
+	add_predef Predef_TryAddMonToParty
+	add_predef Predef_AddTempmonToParty
+	add_predef Predef_SendGetPkmnIntoFromBox
+	add_predef Predef_SendPkmnIntoBox
+	add_predef Predef_GiveEgg
+	add_predef Predef_AnimateHPBar
+	add_predef Predef_CalcPkmnStats
+	add_predef Predef_CalcPkmnStatC
+	add_predef Predef_CanLearnTMHMMove
+	add_predef Predef_GetTMHMMove
+	add_predef Predef_LinkTextbox ; $ 10
+	add_predef Predef_PrintMoveDesc
+	add_predef Predef_UpdatePlayerHUD
+	add_predef Predef_PlaceGraphic
+	add_predef Predef_CheckPlayerPartyForFitPkmn
+	add_predef Predef_UpdateEnemyHUD
+	add_predef Predef_StartBattle
+	add_predef Predef_FillInExpBar
+	add_predef Predef_GetBattleMonBackpic ; $18
+	add_predef Predef_GetEnemyMonFrontpic
+	add_predef Predef_LearnLevelMoves
+	add_predef Predef_FillMoves
+	add_predef Predef_EvolveAfterBattle
+	add_predef Predef_TradeAnimationPlayer2
+	add_predef Predef_TradeAnimation
+	add_predef Predef_CopyPkmnToTempMon
+	add_predef Predef_ListMoves ; $20
+	add_predef Predef_PlaceNonFaintStatus
 	add_predef UnusedPredef22
-	add_predef ListMovePP
-	add_predef GetGender
-	add_predef StatsScreenInit
-	add_predef DrawPlayerHP
-	add_predef DrawEnemyHP
-	add_predef PrintTempMonStats ; $28
-	add_predef GetTypeName
-	add_predef PrintMoveType
-	add_predef PrintType
-	add_predef PrintMonTypes
-	add_predef GetUnownLetter
-	add_predef LoadPoisonBGPals
+	add_predef Predef_ListMovePP
+	add_predef Predef_GetGender
+	add_predef Predef_StatsScreenInit
+	add_predef Predef_DrawPlayerHP
+	add_predef Predef_DrawEnemyHP
+	add_predef Predef_PrintTempMonStats ; $28
+	add_predef Predef_GetTypeName
+	add_predef Predef_PrintMoveType
+	add_predef Predef_PrintType
+	add_predef Predef_PrintMonTypes
+	add_predef Predef_GetUnownLetter
+	add_predef Predef_LoadPoisonBGPals
 	add_predef DummyPredef2F
-	add_predef InitSGBBorder ; $30
-	add_predef LoadSGBLayout
-	add_predef Pokedex_GetArea
+	add_predef Predef_InitSGBBorder ; $30
+	add_predef Predef_LoadSGBLayout
+	add_predef Predef_Pokedex_GetArea
 	add_predef UnusedPredef_CheckContestMon
-	add_predef DoBattleTransition
+	add_predef Predef_DoBattleTransition
 	add_predef DummyPredef35
 	add_predef DummyPredef36
-	add_predef PlayBattleAnim
+	add_predef Predef_PlayBattleAnim
 	add_predef DummyPredef38 ; $38
 	add_predef DummyPredef39
 	add_predef DummyPredef3A
-	add_predef PartyMonItemName
-	add_predef GetMonFrontpic
-	add_predef GetMonBackpic
-	add_predef GetAnimatedFrontpicPredef
-	add_predef GetTrainerPic
-	add_predef DecompressPredef ; $40
-	add_predef CheckTypeMatchup
-	add_predef ConvertMon_1to2
-	add_predef NewPokedexEntry
-	add_predef AnimateMon_Slow_Normal
-	add_predef PlaceStatusString
-	add_predef LoadMonAnimation
-	add_predef AnimateFrontpic
+	add_predef Predef_PartyMonItemName
+	add_predef Predef_GetMonFrontpic
+	add_predef Predef_GetMonBackpic
+	add_predef Predef_GetAnimatedFrontpic
+	add_predef Predef_GetTrainerPic
+	add_predef Predef_Decompress ; $40
+	add_predef Predef_CheckTypeMatchup
+	add_predef Predef_ConvertMon_1to2
+	add_predef Predef_NewPokedexEntry
+	add_predef UnusedPredef_AnimateMon_Slow_Normal
+	add_predef Predef_PlaceStatusString
+	add_predef Predef_LoadMonAnimation
+	add_predef Predef_AnimateFrontpic
 	add_predef UnusedPredef48 ; $48
-	add_predef HOF_AnimateFrontpic
+	add_predef HOF_Predef_AnimateFrontpic
 	dbw $ff, InexplicablyEmptyFunction ; ???
 ; 864c

--- a/engine/print_party.asm
+++ b/engine/print_party.asm
@@ -157,7 +157,7 @@ PrintPartyMonPage1: ; 1dc381
 
 	xor a
 	ld [MonType], a
-	farcall CopyPkmnToTempMon
+	farcall Predef_CopyPkmnToTempMon
 	hlcoord 0, 7
 	ld b, 9
 	ld c, 18
@@ -213,7 +213,7 @@ PrintPartyMonPage1: ; 1dc381
 	call Function1dc51a
 	call Function1dc52c
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	ld hl, wBoxAlignment
 	xor a
 	ld [hl], a
@@ -241,7 +241,7 @@ PrintPartyMonPage2: ; 1dc47b
 	call LoadFontsBattleExtra
 	xor a
 	ld [MonType], a
-	farcall CopyPkmnToTempMon
+	farcall Predef_CopyPkmnToTempMon
 	hlcoord 0, 0
 	ld b, 15
 	ld c, 18
@@ -316,7 +316,7 @@ Function1dc51a: ; 1dc51a
 ; 1dc52c
 
 Function1dc52c: ; 1dc52c
-	farcall GetGender
+	farcall Predef_GetGender
 	ld a, " "
 	jr c, .got_gender
 	ld a, "♂"

--- a/engine/printer.asm
+++ b/engine/printer.asm
@@ -596,8 +596,7 @@ PlacePrinterStatusString: ; 84785
 	ret
 ; 847bd
 
-Function847bd: ; 847bd
-; XXX
+Unreferenced_Function847bd: ; 847bd
 	ld a, [wPrinterStatus]
 	and a
 	ret z

--- a/engine/printer.asm
+++ b/engine/printer.asm
@@ -860,7 +860,7 @@ Printer_GetMonGender: ; 8498a (21:498a)
 	ld [CurPartyMon], a
 	ld a, TEMPMON
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	ld a, " "
 	jr c, .got_gender
 	ld a, "♂"

--- a/engine/printnum.asm
+++ b/engine/printnum.asm
@@ -165,7 +165,7 @@ _PrintNum:: ; c4c7
 	dec e
 	jr nz, .money_leading_zero
 	inc hl
-	ld [hl], $f2 ; XXX
+	ld [hl], "<DOT>"
 
 .money_leading_zero
 	call .AdvancePointer

--- a/engine/routines/correcterrorsinplayerparty.asm
+++ b/engine/routines/correcterrorsinplayerparty.asm
@@ -90,7 +90,7 @@ Unreferenced_CorrectErrorsInPlayerParty:
 	ld hl, MON_STAT_EXP - 1
 	add hl, bc
 	ld b, $1
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop hl
 	ld bc, PARTYMON_STRUCT_LENGTH
 	add hl, bc

--- a/engine/routines/correcterrorsinplayerparty.asm
+++ b/engine/routines/correcterrorsinplayerparty.asm
@@ -1,4 +1,4 @@
-CorrectErrorsInPlayerParty: ; unreferenced
+Unreferenced_CorrectErrorsInPlayerParty:
 	ld hl, PartyCount
 	ld a, [hl]
 	and a

--- a/engine/routines/flagpredef.asm
+++ b/engine/routines/flagpredef.asm
@@ -1,4 +1,4 @@
-FlagPredef: ; 4d7c1
+Predef_Flag: ; 4d7c1
 ; Perform action b on flag c in flag array hl.
 ; If checking a flag, check flag array d:hl unless d is 0.
 

--- a/engine/routines/flagpredef.asm
+++ b/engine/routines/flagpredef.asm
@@ -1,4 +1,4 @@
-Predef_Flag: ; 4d7c1
+Predef_FlagAction: ; 4d7c1
 ; Perform action b on flag c in flag array hl.
 ; If checking a flag, check flag array d:hl unless d is 0.
 

--- a/engine/routines/flagpredef.asm
+++ b/engine/routines/flagpredef.asm
@@ -1,5 +1,5 @@
-Predef_FlagAction: ; 4d7c1
-; Perform action b on flag c in flag array hl.
+Predef_SmallFarFlagAction: ; 4d7c1
+; Perform action b on bit c in flag array hl.
 ; If checking a flag, check flag array d:hl unless d is 0.
 
 ; For longer flag arrays, see FlagAction.

--- a/engine/routines/newpokedexentry.asm
+++ b/engine/routines/newpokedexentry.asm
@@ -1,4 +1,4 @@
-NewPokedexEntry: ; fb877
+Predef_NewPokedexEntry: ; fb877
 	ld a, [hMapAnims]
 	push af
 	xor a

--- a/engine/routines/placegraphic.asm
+++ b/engine/routines/placegraphic.asm
@@ -1,4 +1,4 @@
-PlaceGraphic: ; 2ef6e
+Predef_PlaceGraphic: ; 2ef6e
 ; Fill wBoxAlignment-aligned box width b height c
 ; with iterating tile starting from hGraphicStartTile at hl.
 ; Predef $13

--- a/engine/routines/placewaitingtext.asm
+++ b/engine/routines/placewaitingtext.asm
@@ -11,7 +11,7 @@ PlaceWaitingText:: ; 4000
 	jr .proceed
 
 .notinbattle
-	predef Predef_LinkTextbox
+	predef LinkTextboxPredef
 
 .proceed
 	hlcoord 4, 11

--- a/engine/routines/placewaitingtext.asm
+++ b/engine/routines/placewaitingtext.asm
@@ -11,7 +11,7 @@ PlaceWaitingText:: ; 4000
 	jr .proceed
 
 .notinbattle
-	predef LinkTextboxPredef
+	predef Predef_LinkTextbox
 
 .proceed
 	hlcoord 4, 11

--- a/engine/routines/playslowcry.asm
+++ b/engine/routines/playslowcry.asm
@@ -1,4 +1,4 @@
-PlaySlowCry: ; fb841
+Special_PlaySlowCry: ; fb841
 	ld a, [ScriptVar]
 	call LoadCryHeader
 	jr c, .done

--- a/engine/routines/printhoursmins.asm
+++ b/engine/routines/printhoursmins.asm
@@ -1,5 +1,4 @@
-Function1dd6a9: ; 1dd6a9
-; XXX
+Unreferenced_Function1dd6a9: ; 1dd6a9
 	ld a, b
 	ld b, c
 	ld c, a

--- a/engine/routines/trademonfrontpic.asm
+++ b/engine/routines/trademonfrontpic.asm
@@ -4,13 +4,13 @@ GetTrademonFrontpic: ; 4d7fd
 	ld de, vTiles2
 	push de
 	push af
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop af
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	call GetBaseData
 	pop de
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	ret
 
 AnimateTrademonFrontpic: ; 4d81e
@@ -34,5 +34,5 @@ AnimateTrademonFrontpic: ; 4d81e
 	hlcoord 7, 2
 	ld d, $0
 	ld e, ANIM_MON_TRADE
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 	ret

--- a/engine/rtc.asm
+++ b/engine/rtc.asm
@@ -1,4 +1,4 @@
-StopRTC: ; Unreferenced???
+StopRTC: ; Unreferenced
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
 	call LatchClock

--- a/engine/rtc.asm
+++ b/engine/rtc.asm
@@ -1,4 +1,4 @@
-StopRTC: ; Unreferenced
+Unreferenced_StopRTC:
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
 	call LatchClock
@@ -58,7 +58,7 @@ TimesOfDay: ; 14044
 	db -1, MORN_F
 ; 1404e
 
-Unknown_1404e: ; unreferenced
+Unreferenced_1404e:
 	db 20, NITE_F
 	db 40, MORN_F
 	db 60, DAY_F

--- a/engine/save.asm
+++ b/engine/save.asm
@@ -415,8 +415,7 @@ EraseHallOfFame: ; 14d06
 	jp CloseSRAM
 ; 14d18
 
-Function14d18: ; 14d18
-; XXX
+Unreferenced_Function14d18: ; 14d18
 ; copy .Data to SRA4:a007
 	ld a, $4
 	call GetSRAMBank
@@ -452,8 +451,7 @@ SaveData: ; 14d68
 	ret
 ; 14d6c
 
-Function14d6c: ; 14d6c
-; XXX
+Unreferenced_Function14d6c: ; 14d6c
 	ld a, $4
 	call GetSRAMBank
 	ld a, [$a60b]
@@ -469,8 +467,7 @@ Function14d6c: ; 14d6c
 	ret
 ; 14d83
 
-Function14d83: ; 14d83
-; XXX
+Unreferenced_Function14d83: ; 14d83
 	ld a, $4
 	call GetSRAMBank
 	xor a
@@ -480,8 +477,7 @@ Function14d83: ; 14d83
 	ret
 ; 14d93
 
-Function14d93: ; 14d93
-; XXX
+Unreferenced_Function14d93: ; 14d93
 	ld a, $7
 	call GetSRAMBank
 	xor a

--- a/engine/scripting.asm
+++ b/engine/scripting.asm
@@ -2994,8 +2994,8 @@ Script_halloffame:
 
 	ld hl, wGameTimerPause
 	res 0, [hl]
-	farcall TrainerRankings_HallOfFame
-	farcall TrainerRankings_HallOfFame2
+	farcall StubbedTrainerRankings_HallOfFame
+	farcall StubbedTrainerRankings_HallOfFame2
 	farcall HallOfFame
 	ld hl, wGameTimerPause
 	set 0, [hl]

--- a/engine/scripting.asm
+++ b/engine/scripting.asm
@@ -2852,7 +2852,7 @@ Script_loadbytec2cf:
 	ld [wc2cf], a
 	ret
 
-	ld c, c ; XXX
+	ld c, c ; unused
 
 Script_closetext:
 ; script command 0x49

--- a/engine/scripting.asm
+++ b/engine/scripting.asm
@@ -1437,7 +1437,7 @@ Script_startbattle:
 ; script command 0x5f
 
 	call BufferScreen
-	predef StartBattle
+	predef Predef_StartBattle
 	ld a, [wBattleResult]
 	and $3f
 	ld [ScriptVar], a
@@ -2506,7 +2506,7 @@ Script_giveegg:
 	ld [CurPartySpecies], a
 	call GetScriptByte
 	ld [CurPartyLevel], a
-	farcall GiveEgg
+	farcall Predef_GiveEgg
 	ret nc
 	ld a, 2
 	ld [ScriptVar], a

--- a/engine/scripting.asm
+++ b/engine/scripting.asm
@@ -2806,7 +2806,8 @@ Script_warpcheck:
 	farcall EnableEvents
 	ret
 
-Script_enableevents: ; unreferenced
+Script_enableevents:
+; unused
 	farcall EnableEvents
 	ret
 
@@ -3037,7 +3038,7 @@ Script_check_save:
 	ret
 
 
-; unreferenced
+; unused
 	ld a, [.byte]
 	ld [ScriptVar], a
 	ret

--- a/engine/scrolling_menu.asm
+++ b/engine/scrolling_menu.asm
@@ -84,7 +84,7 @@ ScrollingMenuJoyAction: ; 24609
 	jr .loop
 ; 24640
 
-.unreferenced ; unreferenced
+.unreferenced ; unused
 	ld a, -1
 	and a
 	ret

--- a/engine/search.asm
+++ b/engine/search.asm
@@ -1,4 +1,4 @@
-SpecialBeastsCheck: ; 0x4a6e8
+Special_BeastsCheck: ; 0x4a6e8
 ; Check if the player owns all three legendary beasts.
 ; They must exist in either party or PC, and have the player's OT and ID.
 ; Return the result in ScriptVar.
@@ -29,7 +29,7 @@ SpecialBeastsCheck: ; 0x4a6e8
 	ret
 
 
-SpecialMonCheck: ; 0x4a711
+Special_MonCheck: ; 0x4a711
 ; Check if the player owns any monsters of the species in ScriptVar.
 ; Return the result in ScriptVar.
 

--- a/engine/sgb_layouts.asm
+++ b/engine/sgb_layouts.asm
@@ -1,7 +1,6 @@
-Predef_LoadSGBLayout: ; 864c
-; LoadSGBLayout
+LoadSGBLayout: ; 864c
 	call CheckCGB
-	jp nz, Predef_LoadSGBLayoutCGB
+	jp nz, LoadSGBLayoutCGB
 
 	ld a, b
 	cp SCGB_RAM

--- a/engine/sgb_layouts.asm
+++ b/engine/sgb_layouts.asm
@@ -1,4 +1,4 @@
-LoadSGBLayout: ; 864c
+Predef_LoadSGBLayout: ; 864c
 	call CheckCGB
 	jp nz, LoadSGBLayoutCGB
 

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -183,7 +183,7 @@ SlotsLoop: ; 927af (24:67af)
 	ld [wCurrSpriteOAMAddr], a
 	callfar DoNextFrameForFirst16Sprites
 	call .PrintCoinsAndPayout
-	call .DummyFunc
+	call .Stubbed_Function927d3
 	call DelayFrame
 	and a
 	ret
@@ -192,7 +192,7 @@ SlotsLoop: ; 927af (24:67af)
 	scf
 	ret
 
-.DummyFunc: ; 927d3 (24:67d3)
+.Stubbed_Function927d3: ; 927d3 (24:67d3)
 ; dummied out
 	ret
 	ld a, [wReel1ReelAction]

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -232,8 +232,8 @@ SlotsLoop: ; 927af (24:67af)
 
 ; 92811 (24:6811)
 
-Function92811: ; 92811
-; unreferenced - debug function?
+Unreferenced_Function92811: ; 92811
+; debug function?
 	ld a, [wSlotBias]
 	add 0
 	daa
@@ -252,8 +252,7 @@ Function92811: ; 92811
 
 ; 9282c
 
-Function9282c: ; 9282c
-; unreferenced
+Unreferenced_Function9282c: ; 9282c
 ; animate OAM tiles?
 	ld hl, wcf66
 	ld a, [hl]
@@ -854,8 +853,7 @@ Slots_UpdateReelPositionAndOAM: ; 92b53 (24:6b53)
 
 ; 92bbe (24:6bbe)
 
-; unreferenced
-Function92bbe: ; 92bbe
+Unreferenced_Function92bbe: ; 92bbe
 	push hl
 	srl a
 	srl a

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -85,7 +85,7 @@ _SlotMachine:
 	call PlaySFX
 	call WaitSFX
 	call ClearBGPalettes
-	farcall TrainerRankings_EndSlotsWinStreak
+	farcall StubbedTrainerRankings_EndSlotsWinStreak
 	ld hl, Options
 	res NO_TEXT_SCROLL, [hl]
 	ld hl, rLCDC
@@ -1935,7 +1935,7 @@ Slots_GetPayout: ; 93124 (24:7124)
 	ld a, [hl]
 	ld [wPayout], a
 	ld d, a
-	farcall TrainerRankings_AddToSlotsPayouts
+	farcall StubbedTrainerRankings_AddToSlotsPayouts
 	ret
 
 .PayoutTable:
@@ -1959,7 +1959,7 @@ Slots_PayoutText: ; 93158 (24:7158)
 	jr nz, .MatchedSomething
 	ld hl, .Text_Darn
 	call PrintText
-	farcall TrainerRankings_EndSlotsWinStreak
+	farcall StubbedTrainerRankings_EndSlotsWinStreak
 	ret
 
 .MatchedSomething:
@@ -1983,7 +1983,7 @@ Slots_PayoutText: ; 93158 (24:7158)
 .return
 	ld hl, .Text_PrintPayout
 	call PrintText
-	farcall TrainerRankings_AddToSlotsWinStreak
+	farcall StubbedTrainerRankings_AddToSlotsWinStreak
 	ret
 
 ; 93195 (24:7195)

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -15,7 +15,7 @@ Special:: ; c01b
 ; c029
 
 SpecialsPointers:: ; c029
-	add_special WarpToSpawnPoint
+	add_special Special_WarpToSpawnPoint
 
 ; Communications
 	add_special Special_SetBitsForLinkTradeRequest
@@ -25,7 +25,7 @@ SpecialsPointers:: ; c029
 	add_special Special_CheckBothSelectedSameRoom
 	add_special Special_FailedLinkToPast
 	add_special Special_CloseLink
-	add_special WaitForOtherPlayerToExit
+	add_special Special_WaitForOtherPlayerToExit
 	add_special Special_SetBitsForBattleRequest
 	add_special Special_SetBitsForTimeCapsuleRequest
 	add_special Special_CheckTimeCapsuleCompatibility
@@ -39,92 +39,92 @@ SpecialsPointers:: ; c029
 	add_special Special_UnlockMysteryGift
 
 ; Map Events
-	add_special BugContestJudging
-	add_special CheckPartyFullAfterContest
-	add_special ContestDropOffMons
-	add_special ContestReturnMons
+	add_special Special_BugContestJudging
+	add_special Special_CheckPartyFullAfterContest
+	add_special Special_ContestDropOffMons
+	add_special Special_ContestReturnMons
 	add_special Special_GiveParkBalls
 	add_special Special_CheckMagikarpLength
 	add_special Special_MagikarpHouseSign
-	add_special HealParty
-	add_special PokemonCenterPC
+	add_special HealParty ; this is both a special and a predef
+	add_special Special_PokemonCenterPC
 	add_special Special_KrissHousePC
 	add_special Special_DayCareMan
 	add_special Special_DayCareLady
 	add_special Special_DayCareManOutside
-	add_special MoveDeletion
+	add_special Special_MoveDeletion
 	add_special Special_BankOfMom
 	add_special Special_MagnetTrain
-	add_special SpecialNameRival
+	add_special Special_NameRival
 	add_special Special_SetDayOfWeek
 	add_special Special_TownMap
 	add_special Special_UnownPrinter
-	add_special MapRadio
+	add_special Special_MapRadio
 	add_special Special_UnownPuzzle
 	add_special Special_SlotMachine
 	add_special Special_CardFlip
 	add_special Special_DummyNonfunctionalGameCornerGame
 	add_special Special_ClearBGPalettesBufferScreen
-	add_special FadeOutPalettes
+	add_special Special_FadeOutPalettes
 	add_special Special_BattleTowerFade
 	add_special Special_FadeBlackQuickly
-	add_special FadeInPalettes
+	add_special Special_FadeInPalettes
 	add_special Special_FadeInQuickly
 	add_special Special_ReloadSpritesNoPalettes
-	add_special ClearBGPalettes
-	add_special UpdateTimePals
-	add_special ClearTileMap
-	add_special UpdateSprites
-	add_special ReplaceKrisSprite
+	add_special ClearBGPalettes ; bank 0
+	add_special Special_UpdateTimePals
+	add_special ClearTileMap ; bank 0
+	add_special UpdateSprites ; bank 0
+	add_special ReplaceKrisSprite ; bank 0
 	add_special Special_GameCornerPrizeMonCheckDex
-	add_special SpecialSeenMon
-	add_special WaitSFX
-	add_special PlayMapMusic
-	add_special RestartMapMusic
-	add_special HealMachineAnim
+	add_special UnusedSpecial_SeenMon
+	add_special WaitSFX ; bank 0
+	add_special PlayMapMusic ; bank 0
+	add_special RestartMapMusic ; bank 0
+	add_special Special_HealMachineAnim
 	add_special Special_SurfStartStep
 	add_special Special_FindGreaterThanThatLevel
 	add_special Special_FindAtLeastThatHappy
 	add_special Special_FindThatSpecies
 	add_special Special_FindThatSpeciesYourTrainerID
-	add_special Special_CheckUnusedTwoDayTimer ; unreferenced
+	add_special UnusedSpecial_CheckUnusedTwoDayTimer
 	add_special Special_DayCareMon1
 	add_special Special_DayCareMon2
 	add_special Special_SelectRandomBugContestContestants
 	add_special Special_ActivateFishingSwarm
-	add_special ToggleMaptileDecorations
-	add_special ToggleDecorationsVisibility
-	add_special SpecialGiveShuckle
-	add_special SpecialReturnShuckle
+	add_special Special_ToggleMaptileDecorations
+	add_special Special_ToggleDecorationsVisibility
+	add_special Special_GiveShuckle
+	add_special Special_ReturnShuckle
 	add_special Special_BillsGrandfather
-	add_special SpecialCheckPokerus
+	add_special Special_CheckPokerus
 	add_special Special_DisplayCoinCaseBalance
 	add_special Special_DisplayMoneyAndCoinBalance
-	add_special PlaceMoneyTopRight
+	add_special Special_PlaceMoneyTopRight
 	add_special Special_CheckForLuckyNumberWinners
 	add_special Special_CheckLuckyNumberShowFlag
 	add_special Special_ResetLuckyNumberShowFlag
 	add_special Special_PrintTodaysLuckyNumber
 	add_special Special_SelectApricornForKurt
-	add_special SpecialNameRater
+	add_special Special_NameRater
 	add_special Special_DisplayLinkRecord
-	add_special GetFirstPokemonHappiness
-	add_special CheckFirstMonIsEgg
-	add_special RandomUnseenWildMon
-	add_special RandomPhoneWildMon
-	add_special RandomPhoneMon
-	add_special MapCallbackSprites_LoadUsedSpritesGFX
-	add_special PlaySlowCry
-	add_special SpecialSnorlaxAwake
+	add_special Special_GetFirstPokemonHappiness
+	add_special Special_CheckFirstMonIsEgg
+	add_special Special_RandomUnseenWildMon
+	add_special Special_RandomPhoneWildMon
+	add_special Special_RandomPhoneMon
+	add_special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	add_special Special_PlaySlowCry
+	add_special Special_SnorlaxAwake
 	add_special Special_YoungerHaircutBrother
 	add_special Special_OlderHaircutBrother
 	add_special Special_DaisyMassage
-	add_special PlayCurMonCry
-	add_special ProfOaksPCBoot
-	add_special SpecialGameboyCheck
-	add_special SpecialTrainerHouse
-	add_special PhotoStudio
-	add_special InitRoamMons
+	add_special Special_PlayCurMonCry
+	add_special Special_ProfOaksPCBoot
+	add_special Special_GameboyCheck
+	add_special Special_TrainerHouse
+	add_special Special_PhotoStudio
+	add_special Special_InitRoamMons
 	add_special Special_FadeOutMusic
 	add_special Diploma
 	add_special PrintDiploma
@@ -219,7 +219,7 @@ Special_GameCornerPrizeMonCheckDex: ; c230
 	ret
 ; c252
 
-SpecialSeenMon: ; c252
+UnusedSpecial_SeenMon: ; c252
 	ld a, [ScriptVar]
 	dec a
 	call SetSeenMon
@@ -265,7 +265,7 @@ FoundNone: ; c298
 	ret
 ; c29d
 
-SpecialNameRival: ; 0xc29d
+Special_NameRival: ; 0xc29d
 	ld b, $2 ; rival
 	ld de, RivalName
 	farcall _NamingScreen
@@ -279,7 +279,7 @@ SpecialNameRival: ; 0xc29d
 DefaultRivalName: ; 0xc2b2
 	db "SILVER@"
 
-SpecialNameRater: ; c2b9
+Special_NameRater: ; c2b9
 	farcall NameRater
 	ret
 ; c2c0
@@ -363,14 +363,14 @@ Special_GetMysteryGiftItem: ; c309
 	db "@"
 ; 0xc34a
 
-BugContestJudging: ; c34a
-	farcall _BugContestJudging
+Special_BugContestJudging: ; c34a
+	farcall _Special_BugContestJudging
 	ld a, b
 	ld [ScriptVar], a
 	ret
 ; c355
 
-MapRadio: ; c355
+Special_MapRadio: ; c355
 	ld a, [ScriptVar]
 	ld e, a
 	farcall PlayRadio
@@ -483,7 +483,7 @@ ScriptReturnCarry: ; c3e2
 	ret
 ; c3ef
 
-Special_CheckUnusedTwoDayTimer: ; c3ef
+UnusedSpecial_CheckUnusedTwoDayTimer: ; c3ef
 	farcall CheckUnusedTwoDayTimer
 	ld a, [wUnusedTwoDayTimer]
 	ld [ScriptVar], a
@@ -517,7 +517,7 @@ StoreSwarmMapIndices:: ; c403
 ; c419
 
 
-SpecialCheckPokerus: ; c419
+Special_CheckPokerus: ; c419
 ; Check if a monster in your party has Pokerus
 	farcall CheckPokerus
 	jp ScriptReturnCarry
@@ -536,7 +536,7 @@ Special_CheckLuckyNumberShowFlag: ; c434
 	jp ScriptReturnCarry
 ; c43d
 
-SpecialSnorlaxAwake: ; 0xc43d
+Special_SnorlaxAwake: ; 0xc43d
 ; Check if the Poké Flute channel is playing, and if the player is standing
 ; next to Snorlax.
 
@@ -587,13 +587,13 @@ SpecialSnorlaxAwake: ; 0xc43d
 	db -1
 
 
-PlayCurMonCry: ; c472
+Special_PlayCurMonCry: ; c472
 	ld a, [CurPartySpecies]
 	jp PlayCry
 ; c478
 
 
-SpecialGameboyCheck: ; c478
+Special_GameboyCheck: ; c478
 	ld a, [hCGB]
 	and a
 	jr nz, .cgb
@@ -639,7 +639,7 @@ PrintDiploma: ; c4ac
 	ret
 ; c4b9
 
-SpecialTrainerHouse: ; 0xc4b9
+Special_TrainerHouse: ; 0xc4b9
 	ld a, BANK(sMysteryGiftTrainerHouseFlag)
 	call GetSRAMBank
 	ld a, [sMysteryGiftTrainerHouseFlag]

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -178,7 +178,7 @@ SpecialsPointers:: ; c029
 	add_special Special_Mobile_SelectThreeMons
 	add_special Special_Function1037eb
 	add_special Special_Function10383c
-	add_special Special_TrainerRankings_Healings
+	add_special Special_StubbedTrainerRankings_Healings
 	add_special Special_RefreshSprites
 	add_special Special_Function1037c2
 	add_special Special_Mobile_DummyReturnFalse

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -113,7 +113,7 @@ SpecialsPointers:: ; c029
 	add_special Special_RandomUnseenWildMon
 	add_special Special_RandomPhoneWildMon
 	add_special Special_RandomPhoneMon
-	add_special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	add_special Special_LoadUsedSpritesGFX
 	add_special Special_PlaySlowCry
 	add_special Special_SnorlaxAwake
 	add_special Special_YoungerHaircutBrother

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -142,7 +142,7 @@ SpecialsPointers:: ; c029
 	add_special Special_Function170114
 	add_special Special_BattleTowerBattle
 	add_special UnusedSpecial_Function1704e1
-	add_special DummySpecial17021d
+	add_special DummySpecial_17021d
 	add_special Special_LoadOpponentTrainerAndPokemonWithOTSprite
 	add_special Special_Function11ba38
 	add_special Special_CheckForBattleTowerRules
@@ -174,7 +174,7 @@ SpecialsPointers:: ; c029
 	add_special Special_BeastsCheck
 	add_special Special_MonCheck
 	add_special Special_SetPlayerPalette
-	add_special DummySpecial170bd2
+	add_special DummySpecial_170bd2
 	add_special Special_Mobile_SelectThreeMons
 	add_special Special_Function1037eb
 	add_special Special_Function10383c
@@ -189,10 +189,10 @@ SpecialsPointers:: ; c029
 	add_special UnusedSpecial_FindItemInPCOrBag
 	add_special Special_InitialSetDSTFlag
 	add_special Special_InitialClearDSTFlag
-	add_special DummySpecialc224
+	add_special DummySpecial_c224
 ; c224
 
-DummySpecialc224: ; c224
+DummySpecial_c224: ; c224
 	ret
 ; c225
 

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -70,9 +70,9 @@ SpecialsPointers:: ; c029
 	add_special Special_FadeBlackQuickly
 	add_special Special_FadeInPalettes
 	add_special Special_FadeInQuickly
-	add_special Special_ReloadSpritesNoPalettes
+	add_special ReloadSpritesNoPalettes ; bank 0
 	add_special ClearBGPalettes ; bank 0
-	add_special Special_UpdateTimePals
+	add_special UpdateTimePals ; bank 0
 	add_special ClearTileMap ; bank 0
 	add_special UpdateSprites ; bank 0
 	add_special ReplaceKrisSprite ; bank 0
@@ -214,7 +214,7 @@ Special_GameCornerPrizeMonCheckDex: ; c230
 	call FadeToMenu
 	ld a, [ScriptVar]
 	ld [wd265], a
-	farcall NewPokedexEntry
+	farcall Predef_NewPokedexEntry
 	call ExitAllMenus
 	ret
 ; c252

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -141,7 +141,7 @@ SpecialsPointers:: ; c029
 	add_special Special_Function1700ba
 	add_special Special_Function170114
 	add_special Special_BattleTowerBattle
-	add_special Special_Function1704e1
+	add_special UnusedSpecial_Function1704e1
 	add_special DummySpecial17021d
 	add_special Special_LoadOpponentTrainerAndPokemonWithOTSprite
 	add_special Special_Function11ba38

--- a/engine/specials.asm
+++ b/engine/specials.asm
@@ -126,73 +126,73 @@ SpecialsPointers:: ; c029
 	add_special Special_PhotoStudio
 	add_special Special_InitRoamMons
 	add_special Special_FadeOutMusic
-	add_special Diploma
-	add_special PrintDiploma
+	add_special Special_Diploma
+	add_special Special_PrintDiploma
 
 	; Crystal
-	add_special Function11ac3e
-	add_special Function11b444
-	add_special Function11b5e8
-	add_special Function11b7e5
-	add_special Function11b879
-	add_special Function11b920
-	add_special Function11b93b
-	add_special BattleTowerRoomMenu
-	add_special Function1700ba
-	add_special Function170114
-	add_special BattleTowerBattle
-	add_special Function1704e1
-	add_special EmptySpecial_17021d
-	add_special Function_LoadOpponentTrainerAndPokemonsWithOTSprite
-	add_special Function11ba38
-	add_special SpecialCheckForBattleTowerRules
+	add_special Special_Function11ac3e
+	add_special Special_Function11b444
+	add_special Special_Function11b5e8
+	add_special Special_Function11b7e5
+	add_special Special_Function11b879
+	add_special Special_Function11b920
+	add_special Special_Function11b93b
+	add_special Special_BattleTowerRoomMenu
+	add_special Special_Function1700ba
+	add_special Special_Function170114
+	add_special Special_BattleTowerBattle
+	add_special Special_Function1704e1
+	add_special DummySpecial17021d
+	add_special Special_LoadOpponentTrainerAndPokemonWithOTSprite
+	add_special Special_Function11ba38
+	add_special Special_CheckForBattleTowerRules
 	add_special Special_GiveOddEgg
-	add_special Reset
-	add_special Function1011f1
-	add_special Function101220
-	add_special Function101225
-	add_special Function101231
+	add_special Reset ; bank 0
+	add_special Special_Function1011f1
+	add_special Special_Function101220
+	add_special Special_Function101225
+	add_special Special_Function101231
 	add_special Special_MoveTutor
-	add_special SpecialOmanyteChamber
-	add_special Function11c1ab
-	add_special BattleTowerAction
+	add_special Special_OmanyteChamber
+	add_special Special_Function11c1ab
+	add_special Special_BattleTowerAction
 	add_special Special_DisplayUnownWords
 	add_special Special_Menu_ChallengeExplanationCancel
-	add_special Function17d2b6
-	add_special Function17d2ce
-	add_special BattleTowerMobileError
-	add_special AskMobileOrCable
-	add_special SpecialHoOhChamber
-	add_special Function102142
+	add_special Special_Function17d2b6
+	add_special Special_Function17d2ce
+	add_special Special_BattleTowerMobileError
+	add_special Special_AskMobileOrCable
+	add_special Special_HoOhChamber
+	add_special Special_Function102142
 	add_special Special_CelebiShrineEvent
-	add_special CheckCaughtCelebi
-	add_special SpecialPokeSeer
-	add_special SpecialBuenasPassword
-	add_special SpecialBuenaPrize
-	add_special SpecialDratini
+	add_special Special_CheckCaughtCelebi
+	add_special Special_PokeSeer
+	add_special Special_BuenasPassword
+	add_special Special_BuenaPrize
+	add_special Special_Dratini
 	add_special Special_SampleKenjiBreakCountdown
-	add_special SpecialBeastsCheck
-	add_special SpecialMonCheck
+	add_special Special_BeastsCheck
+	add_special Special_MonCheck
 	add_special Special_SetPlayerPalette
-	add_special ret_170bd2
-	add_special Mobile_SelectThreeMons
-	add_special Function1037eb
-	add_special Function10383c
-	add_special TrainerRankings_Healings
-	add_special RefreshSprites
-	add_special Function1037c2
-	add_special Mobile_DummyReturnFalse
-	add_special Function103780
-	add_special Function10387b
-	add_special AskRememberPassword
-	add_special LoadMapPalettes
-	add_special FindItemInPCOrBag
+	add_special DummySpecial170bd2
+	add_special Special_Mobile_SelectThreeMons
+	add_special Special_Function1037eb
+	add_special Special_Function10383c
+	add_special Special_TrainerRankings_Healings
+	add_special Special_RefreshSprites
+	add_special Special_Function1037c2
+	add_special Special_Mobile_DummyReturnFalse
+	add_special Special_Function103780
+	add_special Special_Function10387b
+	add_special Special_AskRememberPassword
+	add_special Special_LoadMapPalettes
+	add_special UnusedSpecial_FindItemInPCOrBag
 	add_special Special_InitialSetDSTFlag
 	add_special Special_InitialClearDSTFlag
-	add_special SpecialNone
+	add_special DummySpecialc224
 ; c224
 
-SpecialNone: ; c224
+DummySpecialc224: ; c224
 	ret
 ; c225
 
@@ -625,14 +625,14 @@ Special_FadeOutMusic: ; c48f
 	ret
 ; c49f
 
-Diploma: ; c49f
+Special_Diploma: ; c49f
 	call FadeToMenu
 	farcall _Diploma
 	call ExitAllMenus
 	ret
 ; c4ac
 
-PrintDiploma: ; c4ac
+Special_PrintDiploma: ; c4ac
 	call FadeToMenu
 	farcall _PrintDiploma
 	call ExitAllMenus

--- a/engine/sprite_anims.asm
+++ b/engine/sprite_anims.asm
@@ -404,7 +404,7 @@ DoAnimFrame: ; 8d24b
 	ret
 
 .ForUnusedCursor ; 8d46e (23:546e)
-	callfar ret_e00ed
+	callfar Ret_e00ed
 	ret
 
 .PokegearArrow ; 8d475 (23:5475)

--- a/engine/sprite_anims.asm
+++ b/engine/sprite_anims.asm
@@ -404,7 +404,7 @@ DoAnimFrame: ; 8d24b
 	ret
 
 .ForUnusedCursor ; 8d46e (23:546e)
-	callfar Ret_e00ed
+	callfar ret_e00ed
 	ret
 
 .PokegearArrow ; 8d475 (23:5475)

--- a/engine/sprites.asm
+++ b/engine/sprites.asm
@@ -527,8 +527,7 @@ GetFrameOAMPointer: ; 8d1a2
 	ret
 ; 8d1ac
 
-BrokenGetStdGraphics: ; 8d1ac
-; dummied out
+Unreferenced_BrokenGetStdGraphics: ; 8d1ac
 	push hl
 	ld l, a
 	ld h, 0

--- a/engine/start_menu.asm
+++ b/engine/start_menu.asm
@@ -25,12 +25,12 @@ StartMenu:: ; 125cd
 	call _OpenAndCloseMenu_HDMATransferTileMapAndAttrMap
 	farcall LoadFonts_NoOAMUpdate
 	call .DrawBugContestStatus
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	jr .Select
 
 .Reopen:
 	call UpdateSprites
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	call .SetUpMenuItems
 	ld a, [wBattleMenuCursorBuffer]
 	ld [wMenuCursorBuffer], a
@@ -78,7 +78,7 @@ StartMenu:: ; 125cd
 	call ExitMenu
 .ReturnEnd2:
 	call CloseText
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	ret
 
 .GetInput:
@@ -593,7 +593,7 @@ HasNoItems: ; 129d5
 
 TossItemFromPC: ; 129f4
 	push de
-	call PartyMonItemName
+	call Predef_PartyMonItemName
 	farcall _CheckTossableItem
 	ld a, [wItemAttributeParamBuffer]
 	and a
@@ -616,7 +616,7 @@ TossItemFromPC: ; 129f4
 	pop hl
 	ld a, [CurItemQuantity]
 	call TossItem
-	call PartyMonItemName
+	call Predef_PartyMonItemName
 	ld hl, .TossedThisMany
 	call MenuTextBox
 	call ExitMenu
@@ -668,7 +668,7 @@ CantUseItemText: ; 12a67
 ; 12a6c
 
 
-PartyMonItemName: ; 12a6c
+Predef_PartyMonItemName: ; 12a6c
 	ld a, [CurItem]
 	ld [wd265], a
 	call GetItemName
@@ -862,7 +862,7 @@ GiveTakePartyMonItem: ; 12b60
 TryGiveItemToPartymon: ; 12bd9
 
 	call SpeechTextBox
-	call PartyMonItemName
+	call Predef_PartyMonItemName
 	call GetPartyItemLocation
 	ld a, [hl]
 	and a
@@ -1225,7 +1225,7 @@ OpenPartyStats: ; 12e00
 	xor a
 	ld [MonType], a
 	call LowVolume
-	predef StatsScreenInit
+	predef Predef_StatsScreenInit
 	call MaxVolume
 	call Call_ExitMenu
 	ld a, 0
@@ -1792,7 +1792,7 @@ SetUpMoveScreenBG: ; 13172
 	hlcoord 5, 1
 	call PlaceString
 	push bc
-	farcall CopyPkmnToTempMon
+	farcall Predef_CopyPkmnToTempMon
 	pop hl
 	call PrintLevel
 	ld hl, PlayerHPPal
@@ -1809,7 +1809,7 @@ SetUpMoveList: ; 131ef
 	ld [hBGMapMode], a
 	ld [wMoveSwapBuffer], a
 	ld [MonType], a
-	predef CopyPkmnToTempMon
+	predef Predef_CopyPkmnToTempMon
 	ld hl, TempMonMoves
 	ld de, wListMoves_MoveIndicesBuffer
 	ld bc, NUM_MOVES
@@ -1817,9 +1817,9 @@ SetUpMoveList: ; 131ef
 	ld a, SCREEN_WIDTH * 2
 	ld [Buffer1], a
 	hlcoord 2, 3
-	predef ListMoves
+	predef Predef_ListMoves
 	hlcoord 10, 4
-	predef ListMovePP
+	predef Predef_ListMovePP
 	call WaitBGMap
 	call SetPalettes
 	ld a, [wNumMoves]
@@ -1863,7 +1863,7 @@ PlaceMoveData: ; 13256
 	ld a, [CurMove]
 	ld b, a
 	hlcoord 2, 12
-	predef PrintMoveType
+	predef Predef_PrintMoveType
 	ld a, [CurMove]
 	dec a
 	ld hl, Moves + MOVE_POWER
@@ -1886,7 +1886,7 @@ PlaceMoveData: ; 13256
 
 .description
 	hlcoord 1, 14
-	predef PrintMoveDesc
+	predef Predef_PrintMoveDesc
 	ld a, $1
 	ld [hBGMapMode], a
 	ret

--- a/engine/start_menu.asm
+++ b/engine/start_menu.asm
@@ -1268,7 +1268,7 @@ MonMenu_Fly: ; 12e30
 	ld a, $0
 	ret
 
-.Unused:
+.Unreferenced:
 	ld a, $1
 	ret
 ; 12e55

--- a/engine/start_menu.asm
+++ b/engine/start_menu.asm
@@ -1255,7 +1255,7 @@ MonMenu_Fly: ; 12e30
 	jr z, .Fail
 	cp $0
 	jr z, .Error
-	farcall TrainerRankings_Fly
+	farcall StubbedTrainerRankings_Fly
 	ld b, $4
 	ld a, $2
 	ret

--- a/engine/start_menu.asm
+++ b/engine/start_menu.asm
@@ -25,12 +25,12 @@ StartMenu:: ; 125cd
 	call _OpenAndCloseMenu_HDMATransferTileMapAndAttrMap
 	farcall LoadFonts_NoOAMUpdate
 	call .DrawBugContestStatus
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	jr .Select
 
 .Reopen:
 	call UpdateSprites
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	call .SetUpMenuItems
 	ld a, [wBattleMenuCursorBuffer]
 	ld [wMenuCursorBuffer], a
@@ -78,7 +78,7 @@ StartMenu:: ; 125cd
 	call ExitMenu
 .ReturnEnd2:
 	call CloseText
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	ret
 
 .GetInput:

--- a/engine/stats_screen.asm
+++ b/engine/stats_screen.asm
@@ -447,8 +447,7 @@ StatsScreen_InitUpperHalf: ; 4deea (13:5eea)
 	dw wBufferMonNick
 ; 4df7f
 
-Function4df7f: ; 4df7f
-; unreferenced
+Unreferenced_Function4df7f: ; 4df7f
 	hlcoord 7, 0
 	ld bc, SCREEN_WIDTH
 	ld d, SCREEN_HEIGHT
@@ -962,8 +961,7 @@ StatsScreen_LoadTextBoxSpaceGFX: ; 4e307 (13:6307)
 	ret
 ; 4e32a (13:632a)
 
-; unreferenced
-Unknown_4e32a: ; 4e32a
+Unreferenced_4e32a: ; 4e32a
 ; A blank tile?
 	ds 16
 ; 4e33a

--- a/engine/stats_screen.asm
+++ b/engine/stats_screen.asm
@@ -1,14 +1,14 @@
 BattleStatsScreenInit: ; 4dc7b (13:5c7b)
 	ld a, [wLinkMode]
 	cp LINK_MOBILE
-	jr nz, StatsScreenInit
+	jr nz, Predef_StatsScreenInit
 
 	ld a, [wBattleMode]
 	and a
-	jr z, StatsScreenInit
+	jr z, Predef_StatsScreenInit
 	jr _MobileStatsScreenInit
 
-StatsScreenInit: ; 4dc8a
+Predef_StatsScreenInit: ; 4dc8a
 	ld hl, StatsScreenMain
 	jr StatsScreenInit_gotaddress
 
@@ -234,7 +234,7 @@ StatsScreen_CopyToTempMon: ; 4ddf2 (13:5df2)
 	jr .done
 
 .breedmon
-	farcall CopyPkmnToTempMon
+	farcall Predef_CopyPkmnToTempMon
 	ld a, [CurPartySpecies]
 	cp EGG
 	jr z, .done
@@ -419,7 +419,7 @@ StatsScreen_InitUpperHalf: ; 4deea (13:5eea)
 	ld a, [hli]
 	ld d, a
 	ld e, [hl]
-	farcall ComputeHPBarPixels
+	farcall Predef_ComputeHPBarPixels
 	ld hl, wCurHPPal
 	call SetHPPal
 	ld b, SCGB_STATS_SCREEN_HP_PALS
@@ -429,7 +429,7 @@ StatsScreen_InitUpperHalf: ; 4deea (13:5eea)
 
 .PlaceGenderChar: ; 4df66 (13:5f66)
 	push hl
-	farcall GetGender
+	farcall Predef_GetGender
 	pop hl
 	ret c
 	ld a, "♂"
@@ -540,7 +540,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 .PinkPage: ; 4e013 (13:6013)
 	hlcoord 0, 9
 	ld b, $0
-	predef DrawPlayerHP
+	predef Predef_DrawPlayerHP
 	hlcoord 8, 9
 	ld [hl], $41
 	ld de, .Status_Type
@@ -562,7 +562,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	hlcoord 6, 13
 	push hl
 	ld de, TempMonStatus
-	predef PlaceStatusString
+	predef Predef_PlaceStatusString
 	pop hl
 	jr nz, .done_status
 	jr .StatusOK
@@ -576,7 +576,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	call PlaceString
 .done_status
 	hlcoord 1, 15
-	predef PrintMonTypes
+	predef Predef_PrintMonTypes
 	hlcoord 9, 8
 	ld de, SCREEN_WIDTH
 	ld b, 10
@@ -610,7 +610,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	ld a, [TempMonLevel]
 	ld b, a
 	ld de, TempMonExp + 2
-	predef FillInExpBar
+	predef Predef_FillInExpBar
 	hlcoord 10, 16
 	ld [hl], $40
 	hlcoord 19, 16
@@ -703,11 +703,11 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	hlcoord 8, 10
 	ld a, SCREEN_WIDTH * 2
 	ld [Buffer1], a
-	predef ListMoves
+	predef Predef_ListMoves
 	hlcoord 12, 11
 	ld a, SCREEN_WIDTH * 2
 	ld [Buffer1], a
-	predef ListMovePP
+	predef Predef_ListMovePP
 	ret
 
 .GetItemName: ; 4e189 (13:6189)
@@ -748,7 +748,7 @@ StatsScreen_LoadGFX: ; 4dfb6 (13:5fb6)
 	jr nz, .BluePageVerticalDivider
 	hlcoord 11, 8
 	ld bc, 6
-	predef PrintTempMonStats
+	predef Predef_PrintTempMonStats
 	ret
 
 .PlaceOTInfo: ; 4e1cc (13:61cc)
@@ -801,7 +801,7 @@ OTString: ; 4e222
 
 StatsScreen_PlaceFrontpic: ; 4e226 (13:6226)
 	ld hl, TempMonDVs
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	call StatsScreen_GetAnimationParam
 	jr c, .egg
 	and a
@@ -863,11 +863,11 @@ StatsScreen_PlaceFrontpic: ; 4e226 (13:6226)
 	ret c
 	call StatsScreen_LoadTextBoxSpaceGFX
 	ld de, vTiles2 tile $00
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	hlcoord 0, 0
 	ld d, $0
 	ld e, ANIM_MON_MENU
-	predef LoadMonAnimation
+	predef Predef_LoadMonAnimation
 	ld hl, wcf64
 	set 6, [hl]
 	ret
@@ -1067,11 +1067,11 @@ StatsScreen_AnimateEgg: ; 4e497 (13:6497)
 	ld [wBoxAlignment], a
 	call StatsScreen_LoadTextBoxSpaceGFX
 	ld de, vTiles2 tile $00
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	pop de
 	hlcoord 0, 0
 	ld d, $0
-	predef LoadMonAnimation
+	predef Predef_LoadMonAnimation
 	ld hl, wcf64
 	set 6, [hl]
 	ret

--- a/engine/tempmon.asm
+++ b/engine/tempmon.asm
@@ -1,4 +1,4 @@
-CopyPkmnToTempMon: ; 5084a
+Predef_CopyPkmnToTempMon: ; 5084a
 ; gets the BaseData of a Pkmn
 ; and copys the PkmnStructure to TempMon
 
@@ -51,7 +51,7 @@ _TempMonStatsCalculation: ; 50893
 	add hl, bc
 	push bc
 	ld b, $1
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop bc
 	ld hl, MON_HP
 	add hl, bc

--- a/engine/time.asm
+++ b/engine/time.asm
@@ -225,13 +225,13 @@ CheckUnusedTwoDayTimer: ; 1150c
 	ret
 ; 1151c
 
-; XXX
+; unused
 	ld hl, wDailyFlags
 	set 2, [hl]
 	ret
 ; 11522
 
-; XXX
+; unused
 	and a
 	ld hl, wDailyFlags
 	bit 2, [hl]

--- a/engine/time_capsule_2.asm
+++ b/engine/time_capsule_2.asm
@@ -18,7 +18,7 @@ ConvertMon_2to1: ; fb8f1
 	ret
 ; fb908
 
-ConvertMon_1to2: ; fb908
+Predef_ConvertMon_1to2: ; fb908
 ; Takes the Gen-1 Pokemon number stored in wd265 and returns the corresponding value from Pokered_MonIndices in wd265.
 	push bc
 	push hl

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -98,7 +98,7 @@ _TimeOfDayPals:: ; 8c011
 	ld [rSVBK], a
 
 ; update palettes
-	call _UpdateTimePals
+	call _Special_UpdateTimePals
 	call DelayFrame
 
 ; successful change
@@ -112,14 +112,14 @@ _TimeOfDayPals:: ; 8c011
 ; 8c070
 
 
-_UpdateTimePals:: ; 8c070
+_Special_UpdateTimePals:: ; 8c070
 	ld c, $9 ; normal
 	call GetTimePalFade
 	call DmgToCgbTimePals
 	ret
 ; 8c079
 
-FadeInPalettes:: ; 8c079
+Special_FadeInPalettes:: ; 8c079
 	ld c, $12
 	call GetTimePalFade
 	ld b, $4
@@ -127,7 +127,7 @@ FadeInPalettes:: ; 8c079
 	ret
 ; 8c084
 
-FadeOutPalettes:: ; 8c084
+Special_FadeOutPalettes:: ; 8c084
 	call FillWhiteBGColor
 	ld c, $9
 	call GetTimePalFade

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -98,7 +98,7 @@ _TimeOfDayPals:: ; 8c011
 	ld [rSVBK], a
 
 ; update palettes
-	call _Special_UpdateTimePals
+	call _UpdateTimePals
 	call DelayFrame
 
 ; successful change
@@ -112,7 +112,7 @@ _TimeOfDayPals:: ; 8c011
 ; 8c070
 
 
-_Special_UpdateTimePals:: ; 8c070
+_UpdateTimePals:: ; 8c070
 	ld c, $9 ; normal
 	call GetTimePalFade
 	call DmgToCgbTimePals

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -1,5 +1,5 @@
-Predef35: ; 8c000
-Predef36:
+DummyPredef35: ; 8c000
+DummyPredef36:
 	ret
 
 UpdateTimeOfDayPal:: ; 8c001

--- a/engine/tmhm.asm
+++ b/engine/tmhm.asm
@@ -1,4 +1,4 @@
-CanLearnTMHMMove: ; 11639
+Predef_CanLearnTMHMMove: ; 11639
 	ld a, [CurPartySpecies]
 	ld [CurSpecies], a
 	call GetBaseData
@@ -23,7 +23,7 @@ CanLearnTMHMMove: ; 11639
 	ld b, CHECK_FLAG
 	push de
 	ld d, 0
-	predef FlagPredef
+	predef Predef_Flag
 	pop de
 	ret
 
@@ -33,7 +33,7 @@ CanLearnTMHMMove: ; 11639
 	ret
 ; 1166a
 
-GetTMHMMove: ; 1166a
+Predef_GetTMHMMove: ; 1166a
 	ld a, [wd265]
 	dec a
 	ld hl, TMHMMoves

--- a/engine/tmhm.asm
+++ b/engine/tmhm.asm
@@ -23,7 +23,7 @@ Predef_CanLearnTMHMMove: ; 11639
 	ld b, CHECK_FLAG
 	push de
 	ld d, 0
-	predef Predef_Flag
+	predef Predef_FlagAction
 	pop de
 	ret
 

--- a/engine/tmhm.asm
+++ b/engine/tmhm.asm
@@ -23,7 +23,7 @@ Predef_CanLearnTMHMMove: ; 11639
 	ld b, CHECK_FLAG
 	push de
 	ld d, 0
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	pop de
 	ret
 

--- a/engine/tmhm2.asm
+++ b/engine/tmhm2.asm
@@ -447,8 +447,7 @@ TMHMPocket_GetCurrentLineCoord: ; 2ca86 (b:4a86)
 	ret
 ; 2ca95 (b:4a95)
 
-Function2ca95: ; 2ca95
-; unreferenced
+Unreferenced_Function2ca95: ; 2ca95
 	pop hl
 	ld bc, 3
 	add hl, bc
@@ -499,8 +498,7 @@ TMHM_PlaySFX_ReadText2: ; 2cad6 (b:4ad6)
 	ret
 ; 2cadf (b:4adf)
 
-Function2cadf: ; 2cadf
-; unreferenced
+Unreferenced_Function2cadf: ; 2cadf
 	call ConvertCurItemIntoCurTMHM
 	call .CheckHaveRoomForTMHM
 	ld hl, .NoRoomText

--- a/engine/tmhm2.asm
+++ b/engine/tmhm2.asm
@@ -38,7 +38,7 @@ ConvertCurItemIntoCurTMHM: ; 2c7a7 (b:47a7)
 
 GetTMHMItemMove: ; 2c7b6 (b:47b6)
 	call ConvertCurItemIntoCurTMHM
-	predef GetTMHMMove
+	predef Predef_GetTMHMMove
 	ret
 
 AskTeachTMHM: ; 2c7bf (b:47bf)
@@ -118,7 +118,7 @@ ChooseMonToLearnTMHM_NoRefresh: ; 2c80a
 ; 2c867
 
 TeachTMHM: ; 2c867
-	predef CanLearnTMHMMove
+	predef Predef_CanLearnTMHMMove
 
 	push bc
 	ld a, [CurPartyMon]
@@ -141,7 +141,7 @@ TeachTMHM: ; 2c867
 	callfar KnowsMove
 	jr c, .nope
 
-	predef LearnMove
+	predef Predef_LearnMove
 	ld a, b
 	and a
 	jr z, .nope
@@ -258,11 +258,11 @@ TMHM_ShowTMMoveDescription: ; 2c946 (b:4946)
 	cp NUM_TMS + NUM_HMS + 1
 	jr nc, TMHM_JoypadLoop
 	ld [wd265], a
-	predef GetTMHMMove
+	predef Predef_GetTMHMMove
 	ld a, [wd265]
 	ld [CurSpecies], a
 	hlcoord 1, 14
-	call PrintMoveDesc
+	call Predef_PrintMoveDesc
 	jp TMHM_JoypadLoop
 
 TMHM_ChooseTMorHM: ; 2c974 (b:4974)
@@ -386,7 +386,7 @@ TMHM_DisplayPocketItems: ; 2c9e2 (b:49e2)
 	pop af
 	ld [wd265], a
 .okay
-	predef GetTMHMMove
+	predef Predef_GetTMHMMove
 	ld a, [wd265]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
@@ -451,7 +451,7 @@ Unreferenced_Function2ca95: ; 2ca95
 	pop hl
 	ld bc, 3
 	add hl, bc
-	predef GetTMHMMove
+	predef Predef_GetTMHMMove
 	ld a, [wd265]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
@@ -572,7 +572,7 @@ CountTMsHMs: ; 2cb2a (b:4b2a)
 	ld [wd265], a
 	ret
 
-PrintMoveDesc: ; 2cb3e
+Predef_PrintMoveDesc: ; 2cb3e
 	push hl
 	ld hl, MoveDescriptions
 	ld a, [CurSpecies]

--- a/engine/tmhm2.asm
+++ b/engine/tmhm2.asm
@@ -146,7 +146,7 @@ TeachTMHM: ; 2c867
 	and a
 	jr z, .nope
 
-	farcall TrainerRankings_TMsHMsTaught
+	farcall StubbedTrainerRankings_TMsHMsTaught
 	ld a, [CurItem]
 	call IsHM
 	ret c

--- a/engine/trade_animation.asm
+++ b/engine/trade_animation.asm
@@ -1563,8 +1563,8 @@ TradeAnim_WaitAnim2: ; 29886
 ; 29893
 
 
-DebugTrade: ; 29893
-; This function is unreferenced.
+Unreferenced_DebugTrade: ; 29893
+; This function is not referenced.
 ; It was meant for use in Japanese versions, so the
 ; constant used for copy length was changed by accident.
 

--- a/engine/trade_animation.asm
+++ b/engine/trade_animation.asm
@@ -1,4 +1,4 @@
-TradeAnimation: ; 28f24
+Predef_TradeAnimation: ; 28f24
 	xor a
 	ld [wcf66], a
 	ld hl, wPlayerTrademonSenderName
@@ -49,7 +49,7 @@ TradeAnimation: ; 28f24
 	tradeanim_scroll_out_right
 	tradeanim_end
 
-TradeAnimationPlayer2: ; 28f63
+Predef_TradeAnimationPlayer2: ; 28f63
 	xor a
 	ld [wcf66], a
 	ld hl, wOTTrademonSenderName
@@ -871,13 +871,13 @@ TradeAnim_AnimateFrontpic: ; 29487
 TradeAnim_GetFrontpic: ; 29491
 	push de
 	push af
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop af
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	call GetBaseData
 	pop de
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	ret
 
 ; 294a9
@@ -911,7 +911,7 @@ TradeAnim_ShowFrontpic: ; 294c3
 	xor a
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	call WaitBGMap
 	ret
 

--- a/engine/trainer_card.asm
+++ b/engine/trainer_card.asm
@@ -243,7 +243,7 @@ TrainerCard_PrintTopHalfOfCard: ; 25299 (9:5299)
 	lb bc, 5, 7
 	xor a
 	ld [hGraphicStartTile], a
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	ret
 
 ; 252ec (9:52ec)

--- a/engine/trainer_card.asm
+++ b/engine/trainer_card.asm
@@ -117,8 +117,7 @@ TrainerCard_Page1_Joypad: ; 251d7 (9:51d7)
 	ld [wJumptableIndex], a
 	ret
 
-.KantoCheck:
-; unreferenced
+.Unreferenced_KantoCheck:
 	ld a, [wKantoBadges]
 	and a
 	ret z
@@ -163,8 +162,7 @@ TrainerCard_Page2_Joypad: ; 25221 (9:5221)
 	ld [wJumptableIndex], a
 	ret
 
-.KantoCheck:
-; unreferenced
+.Unreferenced_KantoCheck:
 	ld a, [wKantoBadges]
 	and a
 	ret z

--- a/engine/types.asm
+++ b/engine/types.asm
@@ -1,4 +1,4 @@
-PrintMonTypes: ; 5090d
+Predef_PrintMonTypes: ; 5090d
 ; Print one or both types of [CurSpecies]
 ; on the stats screen at hl.
 
@@ -24,7 +24,7 @@ PrintMonTypes: ; 5090d
 
 .Print:
 	ld b, a
-	jr PrintType
+	jr Predef_PrintType
 
 .hide_type_2
 	; Erase any type name that was here before.
@@ -40,7 +40,7 @@ PrintMonTypes: ; 5090d
 ; 5093a
 
 
-PrintMoveType: ; 5093a
+Predef_PrintMoveType: ; 5093a
 ; Print the type of move b at hl.
 
 	push hl
@@ -58,7 +58,7 @@ PrintMoveType: ; 5093a
 	ld b, a
 
 
-PrintType: ; 50953
+Predef_PrintType: ; 50953
 ; Print type b at hl.
 
 	ld a, b
@@ -78,7 +78,7 @@ PrintType: ; 50953
 ; 50964
 
 
-GetTypeName: ; 50964
+Predef_GetTypeName: ; 50964
 ; Copy the name of type [wd265] to StringBuffer1.
 
 	ld a, [wd265]

--- a/engine/warp_connection.asm
+++ b/engine/warp_connection.asm
@@ -298,12 +298,12 @@ LoadGraphics: ; 1047cf
 	ld [hMapAnims], a
 	xor a
 	ld [hTileAnimFrame], a
-	farcall RefreshSprites
+	farcall Special_RefreshSprites
 	call LoadFontsExtra
 	farcall LoadOverworldFont
 	ret
 
-LoadMapPalettes: ; 1047eb
+Special_LoadMapPalettes: ; 1047eb
 	ld b, SCGB_MAPPALS
 	jp GetSGBLayout
 ; 1047f0

--- a/engine/wildmons.asm
+++ b/engine/wildmons.asm
@@ -508,7 +508,7 @@ LookUpWildmonsForMapDE: ; 2a288
 ; 2a2a0
 
 
-InitRoamMons: ; 2a2a0
+Special_InitRoamMons: ; 2a2a0
 ; initialize wRoamMon structs
 
 ; species
@@ -804,7 +804,7 @@ ValidateTempWildMonSpecies: ; 2a4a0
 
 ; Finds a rare wild Pokemon in the route of the trainer calling, then checks if it's been Seen already.
 ; The trainer will then tell you about the Pokemon if you haven't seen it.
-RandomUnseenWildMon: ; 2a4ab
+Special_RandomUnseenWildMon: ; 2a4ab
 	farcall GetCallerLocation
 	ld d, b
 	ld e, c
@@ -877,7 +877,7 @@ RandomUnseenWildMon: ; 2a4ab
 	db "@"
 ; 0x2a51f
 
-RandomPhoneWildMon: ; 2a51f
+Special_RandomPhoneWildMon: ; 2a51f
 	farcall GetCallerLocation
 	ld d, b
 	ld e, c
@@ -917,7 +917,7 @@ RandomPhoneWildMon: ; 2a51f
 	jp CopyBytes
 ; 2a567
 
-RandomPhoneMon: ; 2a567
+Special_RandomPhoneMon: ; 2a567
 ; Get a random monster owned by the trainer who's calling.
 	farcall GetCallerLocation
 	ld hl, TrainerGroups

--- a/gfx/font.asm
+++ b/gfx/font.asm
@@ -84,18 +84,18 @@ INCLUDE "gfx/footprints.asm"
 
 ; This and the following two functions are unreferenced.
 ; Debug, perhaps?
-Unknown_fb434:
+Unreferenced_fb434:
 	db 0
 
-Functionfb435: ; 4b435
-	ld a, [Unknown_fb434]
+Unreferenced_Functionfb435: ; 4b435
+	ld a, [Unreferenced_fb434]
 	and a
 	jp nz, Get1bpp_2
 	jp Get1bpp
 ; fb43f
 
-Functionfb43f: ; fb43f
-	ld a, [Unknown_fb434]
+Unreferenced_Functionfb43f: ; fb43f
+	ld a, [Unreferenced_fb434]
 	and a
 	jp nz, Get2bpp_2
 	jp Get2bpp

--- a/gfx/load_pics.asm
+++ b/gfx/load_pics.asm
@@ -1,4 +1,4 @@
-GetUnownLetter: ; 51040
+Predef_GetUnownLetter: ; 51040
 ; Return Unown letter in UnownLetter based on DVs at hl
 
 ; Take the middle 2 bits of each DV and place them in order:
@@ -48,7 +48,7 @@ GetUnownLetter: ; 51040
 	ld [UnownLetter], a
 	ret
 
-GetMonFrontpic: ; 51077
+Predef_GetMonFrontpic: ; 51077
 	ld a, [CurPartySpecies]
 	ld [CurSpecies], a
 	call IsAPokemon
@@ -60,7 +60,7 @@ GetMonFrontpic: ; 51077
 	ld [rSVBK], a
 	ret
 
-GetAnimatedFrontpicPredef: ; 5108b
+Predef_GetAnimatedFrontpic: ; 5108b
 	ld a, [CurPartySpecies]
 	ld [CurSpecies], a
 	call IsAPokemon
@@ -195,7 +195,7 @@ LoadFrontpicTiles: ; 5114f
 	jr nz, .loop
 	ret
 
-GetMonBackpic: ; 5116c
+Predef_GetMonBackpic: ; 5116c
 	ld a, [CurPartySpecies]
 	call IsAPokemon
 	ret c
@@ -311,7 +311,7 @@ Function511ec: ; 511ec
 	call FarDecompress
 	ret
 
-GetTrainerPic: ; 5120d
+Predef_GetTrainerPic: ; 5120d
 	ld a, [TrainerClass]
 	and a
 	ret z
@@ -353,7 +353,7 @@ GetTrainerPic: ; 5120d
 	ld [hBGMapMode], a
 	ret
 
-DecompressPredef: ; 5125d
+Predef_Decompress: ; 5125d
 ; Decompress lz data from b:hl to scratch space at 6:d000, then copy it to address de.
 
 	ld a, [rSVBK]

--- a/home.asm
+++ b/home.asm
@@ -552,7 +552,7 @@ CopyTilemapAtOnce:: ; 323d
 	jr .CopyTilemapAtOnce
 ; 323f
 
-; XXX
+; unused
 	farcall HDMATransferAttrMapAndTileMapToWRAMBank3
 	ret
 ; 3246
@@ -1127,8 +1127,7 @@ Print8BitNumRightAlign:: ; 3842
 	jp PrintNum
 ; 384d
 
-Function384d:: ; 384d
-; XXX
+Unreferenced_Function384d:: ; 384d
 ; GetNthMove
 	ld hl, wListMoves_MoveIndicesBuffer
 	ld c, a
@@ -1321,8 +1320,7 @@ GetPartyLocation:: ; 3927
 	jp AddNTimes
 ; 392d
 
-Function392d:: ; 392d
-; XXX
+Unreferenced_Function392d:: ; 392d
 ; GetDexNumber
 ; Probably used in gen 1 to convert index number to dex number
 ; Not required in gen 2 because index number == dex number

--- a/home.asm
+++ b/home.asm
@@ -712,7 +712,7 @@ GetSGBLayout:: ; 3340
 	ret z
 
 .sgb
-	predef_jump Predef_LoadSGBLayout ; LoadSGBLayout
+	predef_jump LoadSGBLayout
 ; 334e
 
 SetHPPal:: ; 334e

--- a/home.asm
+++ b/home.asm
@@ -57,8 +57,7 @@ INCLUDE "home/predef.asm"
 INCLUDE "home/window.asm"
 INCLUDE "home/flag.asm"
 
-Function2ebb:: ; 2ebb
-; unreferenced
+Unreferenced_Function2ebb:: ; 2ebb
 	ld a, [wMonStatusFlags]
 	bit 1, a
 	ret z
@@ -79,8 +78,7 @@ xor_a_dec_a:: ; 2ec8
 	ret
 ; 2ecb
 
-Function2ecb:: ; 2ecb
-; unreferenced
+Unreferenced_Function2ecb:: ; 2ecb
 	push hl
 	ld hl, wMonStatusFlags
 	bit 1, [hl]

--- a/home.asm
+++ b/home.asm
@@ -793,7 +793,7 @@ ScrollingMenu:: ; 350c
 .UpdatePalettes: ; 3524
 	ld hl, VramState
 	bit 0, [hl]
-	jp nz, UpdateTimePals
+	jp nz, Special_UpdateTimePals
 	jp SetPalettes
 ; 352f
 

--- a/home.asm
+++ b/home.asm
@@ -44,6 +44,7 @@ INCLUDE "home/game_time.asm"
 INCLUDE "home/map.asm"
 
 InexplicablyEmptyFunction:: ; 2d43
+; unused
 ; Inexplicably empty.
 ; Seen in PredefPointers.
 rept 16
@@ -710,7 +711,7 @@ GetSGBLayout:: ; 3340
 	ret z
 
 .sgb
-	predef_jump LoadSGBLayout
+	predef_jump Predef_LoadSGBLayout
 ; 334e
 
 SetHPPal:: ; 334e
@@ -793,7 +794,7 @@ ScrollingMenu:: ; 350c
 .UpdatePalettes: ; 3524
 	ld hl, VramState
 	bit 0, [hl]
-	jp nz, Special_UpdateTimePals
+	jp nz, UpdateTimePals
 	jp SetPalettes
 ; 352f
 
@@ -1073,12 +1074,12 @@ _PrepMonFrontpic:: ; 378b
 
 	push hl
 	ld de, vTiles2
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	pop hl
 	xor a
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	xor a
 	ld [wBoxAlignment], a
 	ret

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -502,10 +502,9 @@ GetMapMusic:: ; 3d97
 	ret
 ; 3d9f
 
-Function3d9f:: ; 3d9f
+Unreferenced_Function3d9f:: ; 3d9f
 ; Places a BCD number at the
 ; upper center of the screen.
-; Unreferenced.
 	ld a, 4 * 8
 	ld [Sprites + 38 * 4], a
 	ld [Sprites + 39 * 4], a

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -130,8 +130,8 @@ RefreshBattleHuds:: ; 39c9
 ; 39d4
 
 UpdateBattleHuds:: ; 39d4
-	farcall UpdatePlayerHUD
-	farcall UpdateEnemyHUD
+	farcall Predef_UpdatePlayerHUD
+	farcall Predef_UpdateEnemyHUD
 	ret
 ; 39e1
 

--- a/home/fade.asm
+++ b/home/fade.asm
@@ -1,8 +1,7 @@
 ; Functions to fade the screen in and out.
 
 
-Function48c:: ; 48c
-; XXX
+Unreferenced_Function48c:: ; 48c
 ; TimeOfDayFade
 	ld a, [TimeOfDayPal]
 	ld b, a

--- a/home/init.asm
+++ b/home/init.asm
@@ -166,7 +166,7 @@ Init:: ; 17d
 
 	call DelayFrame
 
-	predef InitSGBBorder ; SGB init
+	predef Predef_InitSGBBorder ; SGB init
 
 	call MapSetup_Sound_Off
 	xor a

--- a/home/lcd.asm
+++ b/home/lcd.asm
@@ -1,8 +1,7 @@
 ; LCD handling
 
 
-Function547:: ; 547
-; Unreferenced
+Unreferenced_Function547:: ; 547
 	ld a, [hLCDCPointer]
 	cp rSCX - $ff00
 	ret nz

--- a/home/map.asm
+++ b/home/map.asm
@@ -1983,7 +1983,7 @@ FadeToMenu:: ; 2b29
 	xor a
 	ld [hBGMapMode], a
 	call LoadStandardMenuDataHeader
-	farcall FadeOutPalettes
+	farcall Special_FadeOutPalettes
 	call ClearSprites
 	call DisableSpriteUpdates
 	ret
@@ -2009,7 +2009,7 @@ FinishExitMenu:: ; 2b5c
 	call GetSGBLayout
 	farcall LoadOW_BGPal7
 	call WaitBGMap2
-	farcall FadeInPalettes
+	farcall Special_FadeInPalettes
 	call EnableSpriteUpdates
 	ret
 ; 2b74
@@ -2031,7 +2031,7 @@ ReturnToMapWithSpeechTextbox:: ; 0x2b74
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
 	farcall LoadOW_BGPal7
-	call UpdateTimePals
+	call Special_UpdateTimePals
 	call DelayFrame
 	ld a, $1
 	ld [hMapAnims], a

--- a/home/map.asm
+++ b/home/map.asm
@@ -1383,7 +1383,7 @@ UpdateBGMapColumn:: ; 27f8
 	ret
 ; 2816
 
-; unreferenced
+Unreferenced_Function2816::
 	ld hl, BGMapBuffer
 	ld bc, BGMapBufferEnd - BGMapBuffer
 	xor a

--- a/home/map.asm
+++ b/home/map.asm
@@ -2031,7 +2031,7 @@ ReturnToMapWithSpeechTextbox:: ; 0x2b74
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
 	farcall LoadOW_BGPal7
-	call Special_UpdateTimePals
+	call UpdateTimePals
 	call DelayFrame
 	ld a, $1
 	ld [hMapAnims], a

--- a/home/map.asm
+++ b/home/map.asm
@@ -2042,7 +2042,7 @@ ReturnToMapWithSpeechTextbox:: ; 0x2b74
 ReloadTilesetAndPalettes:: ; 2bae
 	call DisableLCD
 	call ClearSprites
-	farcall RefreshSprites
+	farcall Special_RefreshSprites
 	call LoadStandardFont
 	call LoadFontsExtra
 	ld a, [hROMBank]

--- a/home/map.asm
+++ b/home/map.asm
@@ -384,7 +384,7 @@ CheckIndoorMap:: ; 22f4
 	ret
 ; 2300
 
-; XXX
+; unused
 	cp INDOOR
 	ret z
 	cp GATE
@@ -2075,7 +2075,6 @@ GetAnyMapHeaderPointer:: ; 0x2bed
 
 ; inputs:
 ; b = map group, c = map number
-; XXX de = ???
 
 ; outputs:
 ; hl points to the map header
@@ -2247,7 +2246,7 @@ GetMapEnvironment:: ; 2c8a
 	ret
 ; 2c98
 
-	ret ; XXX
+	ret ; unused
 ; 2c99
 
 GetAnyMapEnvironment:: ; 2c99

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -316,7 +316,7 @@ CheckObjectTime:: ; 18f5
 	ret
 ; 194d
 
-; XXX
+; unused
 	ld [hMapObjectIndexBuffer], a
 	call GetMapObject
 	call CopyObjectStruct
@@ -383,7 +383,7 @@ CopyPlayerObjectTemplate:: ; 19a6
 	ret
 ; 19b8
 
-; XXX
+Unreferenced_Function19b8:
 	call GetMapObject
 	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
 	add hl, bc

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -28,8 +28,7 @@ MenuTextBox:: ; 1d4f
 	jp PrintText
 ; 1d57
 
-ret_1d57:: ; 1d57
-; unreferenced
+; unused
 	ret
 ; 1d58
 
@@ -453,8 +452,7 @@ PlaceNthMenuStrings:: ; 1f8d
 	ret
 ; 1f9e
 
-Function1f9e:: ; 1f9e
-; unreferenced
+Unreferenced_Function1f9e:: ; 1f9e
 	call GetMenuDataPointerTableEntry
 	inc hl
 	inc hl

--- a/home/mobile.asm
+++ b/home/mobile.asm
@@ -127,8 +127,7 @@ Timer:: ; 3e93
 	reti
 ; 3ed7
 
-Function3ed7:: ; 3ed7
-; unreferenced
+Unreferenced_Function3ed7:: ; 3ed7
 	ld [$dc02], a
 	ld a, [hROMBank]
 	push af
@@ -160,8 +159,7 @@ Function3eea:: ; 3eea
 	ret
 ; 3efd
 
-Function3efd:: ; 3efd
-; unreferenced
+Unreferenced_Function3efd:: ; 3efd
 	push hl
 	hlcoord 0, 12
 	ld b, 4

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -319,7 +319,7 @@ ret_d90:: ; d90
 ; d91
 
 
-Special_ReloadSpritesNoPalettes:: ; d91
+ReloadSpritesNoPalettes:: ; d91
 	ld a, [hCGB]
 	and a
 	ret z

--- a/home/pokedex_flags.asm
+++ b/home/pokedex_flags.asm
@@ -31,7 +31,7 @@ CheckSeenMon:: ; 339b
 
 PokedexFlagAction:: ; 33a1
 	ld d, 0
-	predef Predef_FlagAction
+	predef Predef_SmallFarFlagAction
 	ld a, c
 	and a
 	ret

--- a/home/pokedex_flags.asm
+++ b/home/pokedex_flags.asm
@@ -31,7 +31,7 @@ CheckSeenMon:: ; 339b
 
 PokedexFlagAction:: ; 33a1
 	ld d, 0
-	predef FlagPredef
+	predef Predef_Flag
 	ld a, c
 	and a
 	ret

--- a/home/pokedex_flags.asm
+++ b/home/pokedex_flags.asm
@@ -31,7 +31,7 @@ CheckSeenMon:: ; 339b
 
 PokedexFlagAction:: ; 33a1
 	ld d, 0
-	predef Predef_Flag
+	predef Predef_FlagAction
 	ld a, c
 	and a
 	ret

--- a/home/rtc.asm
+++ b/home/rtc.asm
@@ -18,7 +18,7 @@ TimeOfDayPals:: ; 47e
 	ret
 ; 485
 
-Special_UpdateTimePals:: ; 485
-	callfar _Special_UpdateTimePals
+UpdateTimePals:: ; 485
+	callfar _UpdateTimePals
 	ret
 ; 48c

--- a/home/rtc.asm
+++ b/home/rtc.asm
@@ -18,7 +18,7 @@ TimeOfDayPals:: ; 47e
 	ret
 ; 485
 
-UpdateTimePals:: ; 485
-	callfar _UpdateTimePals
+Special_UpdateTimePals:: ; 485
+	callfar _Special_UpdateTimePals
 	ret
 ; 48c

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -398,8 +398,7 @@ LinkDataReceived:: ; 908
 	ret
 ; 919
 
-Function919:: ; 919
-; XXX
+Unreferenced_Function919:: ; 919
 	ld a, [wLinkMode]
 	and a
 	ret nz

--- a/home/text.asm
+++ b/home/text.asm
@@ -1015,8 +1015,7 @@ Text_PlaySound:: ; 1500
 	ret
 ; 1522
 
-Function1522:: ; 1522
-; XXX
+Unreferenced_Function1522:: ; 1522
 ; TX_CRY
 	push de
 	ld e, [hl]

--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -240,7 +240,7 @@ PrintWinLossText:: ; 3718
 	cp BATTLETYPE_CANLOSE
 	jr .canlose ; ??????????
 
-; unreferenced
+; unused
 	ld hl, wWinTextPointer
 	jr .ok
 

--- a/home/window.asm
+++ b/home/window.asm
@@ -99,7 +99,7 @@ SafeUpdateSprites:: ; 2e31
 	ld [hOAMUpdate], a
 	ret
 
-; XXX
+; unused
 	scf
 	ret
 ; 2e50

--- a/lib/mobile/main.asm
+++ b/lib/mobile/main.asm
@@ -6908,7 +6908,7 @@ Function112d33: ; 112d33
 	dec a
 	jp .asm_112e46
 
-; XXX
+; unused
 	ret
 
 .asm_112d4d
@@ -8611,7 +8611,7 @@ endr
 	ld [$cc0d], a
 	ld a, l
 	ld [$cc0c], a
-	cp $8e ; XXX ; LOW(Unknown_113b8e + $100) ???
+	cp $8e ; XXX LOW(Unknown_113b8e + $100) ???
 	jp nz, .asm_113751
 	ld de, $cc18
 	ld hl, $cbe7

--- a/lib/mobile/main.asm
+++ b/lib/mobile/main.asm
@@ -9515,8 +9515,7 @@ Function113eb8: ; 113eb8
 	jp Function111f97
 ; 113ec7
 
-Function113ec7: ; 113ec7
-; Unreferenced
+Unreferenced_Function113ec7: ; 113ec7
 	ld hl, $c822
 	ld a, [hl]
 	push af

--- a/macros/code.asm
+++ b/macros/code.asm
@@ -35,9 +35,6 @@ jumptable: MACRO
 	jp hl
 ENDM
 
-; Many mobile functions were dummied out in localization.
-mobile EQUS "ret"
-
 maskbits: MACRO
 ; example usage in rejection sampling:
 ; .loop

--- a/main.asm
+++ b/main.asm
@@ -209,14 +209,6 @@ SECTION "bank13", ROMX
 
 INCLUDE "engine/map_palettes.asm"
 INCLUDE "tilesets/palette_maps.asm"
-
-; unused
-; 0x4ce05
-rept 26
-	db $06
-endr
-; 0x4ce1f
-
 INCLUDE "data/collision_permissions.asm"
 INCLUDE "engine/routines/emptyallsrambanks.asm"
 INCLUDE "engine/routines/savemenu_copytilemapatonce.asm"
@@ -272,20 +264,7 @@ INCLUDE "gfx/load_pics.asm"
 INCLUDE "engine/move_mon_wo_mail.asm"
 INCLUDE "data/pokemon/base_stats.asm"
 INCLUDE "data/pokemon/names.asm"
-
-Unreferenced_53d84:
-	db $1a, $15
-	db $33, $16
-	db $4b, $17
-	db $62, $18
-	db $79, $19
-	db $90, $1a
-	db $a8, $1b
-	db $c4, $1c
-	db $e0, $1d
-	db $f6, $1e
-	db $ff, $1f
-	db $ff, $20
+INCLUDE "data/unknown_table.asm"
 
 UnknownEggPic:: ; 53d9c
 ; Another egg pic. This is shifted up a few pixels.
@@ -450,15 +429,6 @@ INCLUDE "gfx/pokemon/unown_frames.asm"
 SECTION "bank38", ROMX
 
 INCLUDE "engine/events/print_unown_2.asm"
-
-Unknown_e00ed:
-; Graphics for an unused Game Corner
-; game were meant to be here.
-
-ret_e00ed: ; e00ed (38:40ed)
-; How many coins?
-	ret
-
 INCLUDE "engine/card_flip.asm"
 INCLUDE "engine/unown_puzzle.asm"
 INCLUDE "engine/dummy_game.asm"

--- a/main.asm
+++ b/main.asm
@@ -210,7 +210,7 @@ SECTION "bank13", ROMX
 INCLUDE "engine/map_palettes.asm"
 INCLUDE "tilesets/palette_maps.asm"
 
-; unreferenced
+; unused
 ; 0x4ce05
 rept 26
 	db $06
@@ -273,7 +273,7 @@ INCLUDE "engine/move_mon_wo_mail.asm"
 INCLUDE "data/pokemon/base_stats.asm"
 INCLUDE "data/pokemon/names.asm"
 
-Unknown_53d84: ; unreferenced
+Unreferenced_53d84:
 	db $1a, $15
 	db $33, $16
 	db $4b, $17

--- a/maps/BattleTower1F.asm
+++ b/maps/BattleTower1F.asm
@@ -16,10 +16,10 @@ BattleTower1F_MapScriptHeader:
 
 .Scene0:
 	writebyte BATTLETOWERACTION_CHECKSAVEFILEISYOURS
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	iffalse .SkipEverything
 	writebyte BATTLETOWERACTION_GET_CHALLENGE_STATE ; copybytetovar sBattleTowerChallengeState
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal $0, .SkipEverything
 	if_equal $2, .priorityjump1
 	if_equal $3, .SkipEverything
@@ -34,9 +34,9 @@ BattleTower1F_MapScriptHeader:
 .priorityjump1
 	priorityjump BattleTower_LeftWithoutSaving
 	writebyte BATTLETOWERACTION_CHALLENGECANCELED
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_06
-	special BattleTowerAction
+	special Special_BattleTowerAction
 .SkipEverything:
 	setscene $1
 .Scene1:
@@ -55,13 +55,13 @@ UnknownScript_0x9e3e0:
 
 ReceptionistScript_0x9e3e2:
 	writebyte BATTLETOWERACTION_GET_CHALLENGE_STATE ; copybytetovar sBattleTowerChallengeState
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal $3, Script_BeatenAllTrainers2 ; maps/BattleTowerBattleRoom.asm
 	opentext
 	writetext Text_BattleTowerWelcomesYou
 	buttonsound
 	writebyte BATTLETOWERACTION_CHECK_EXPLANATION_READ ; if new save file: bit 1, [sBattleTowerSaveFileFlags]
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_not_equal $0, Script_Menu_ChallengeExplanationCancel
 	jump Script_BattleTowerIntroductionYesNo
 
@@ -75,8 +75,8 @@ Script_Menu_ChallengeExplanationCancel: ; 0x9e3fc
 
 Script_ChooseChallenge: ; 0x9e40f
 	writebyte BATTLETOWERACTION_RESETDATA ; ResetBattleTowerTrainerSRAM
-	special BattleTowerAction
-	special SpecialCheckForBattleTowerRules
+	special Special_BattleTowerAction
+	special Special_CheckForBattleTowerRules
 	if_not_equal $0, Script_WaitButton
 	writetext Text_SaveBeforeEnteringBattleRoom
 	yesorno
@@ -86,23 +86,23 @@ Script_ChooseChallenge: ; 0x9e40f
 	iffalse Script_Menu_ChallengeExplanationCancel
 	setscene $1
 	writebyte BATTLETOWERACTION_SET_EXPLANATION_READ ; set 1, [sBattleTowerSaveFileFlags]
-	special BattleTowerAction
-	special BattleTowerRoomMenu
+	special Special_BattleTowerAction
+	special Special_BattleTowerRoomMenu
 	if_equal $a, Script_Menu_ChallengeExplanationCancel
 	if_not_equal $0, Script_MobileError
 	writebyte BATTLETOWERACTION_11
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writetext Text_RightThisWayToYourBattleRoom
 	waitbutton
 	closetext
 	writebyte BATTLETOWERACTION_CHOOSEREWARD
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	jump Script_WalkToBattleTowerElevator
 
 Script_ResumeBattleTowerChallenge:
 	closetext
 	writebyte BATTLETOWERACTION_LOADLEVELGROUP ; load choice of level group
-	special BattleTowerAction
+	special Special_BattleTowerAction
 Script_WalkToBattleTowerElevator:
 	musicfadeout MUSIC_NONE, 8
 	setmapscene BATTLE_TOWER_BATTLE_ROOM, $0
@@ -111,7 +111,7 @@ Script_WalkToBattleTowerElevator:
 	follow BATTLETOWER1F_RECEPTIONIST, PLAYER
 	applymovement BATTLETOWER1F_RECEPTIONIST, MovementData_BattleTower1FWalkToElevator
 	writebyte BATTLETOWERACTION_0A
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	warpsound
 	disappear BATTLETOWER1F_RECEPTIONIST
 	stopfollow
@@ -121,15 +121,15 @@ Script_WalkToBattleTowerElevator:
 
 Script_GivePlayerHisPrize: ; 0x9e47a
 	writebyte BATTLETOWERACTION_1C
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_GIVEREWARD
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal POTION, Script_YourPackIsStuffedFull
 	itemtotext $0, $1
 	giveitem ITEM_FROM_MEM, 5
 	writetext Text_PlayerGotFive
 	writebyte BATTLETOWERACTION_1D
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	closetext
 	end
 
@@ -147,7 +147,7 @@ Script_BattleTowerExplanation: ; 0x9e4a5
 	writetext Text_BattleTowerIntroduction_2
 Script_BattleTowerSkipExplanation:
 	writebyte BATTLETOWERACTION_SET_EXPLANATION_READ
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	jump Script_Menu_ChallengeExplanationCancel
 
 Script_BattleTowerHopeToServeYouAgain:
@@ -157,7 +157,7 @@ Script_BattleTowerHopeToServeYouAgain:
 	end
 
 UnreferencedScript_0x9e4b6:
-	special BattleTowerMobileError
+	special Special_BattleTowerMobileError
 	closetext
 	end
 
@@ -173,8 +173,8 @@ UnreferencedScript_0x9e4be:
 	special Special_TryQuickSave
 	iffalse Script_Menu_ChallengeExplanationCancel
 	writebyte BATTLETOWERACTION_SET_EXPLANATION_READ
-	special BattleTowerAction
-	special Function1700ba
+	special Special_BattleTowerAction
+	special Special_Function1700ba
 	if_equal $a, Script_Menu_ChallengeExplanationCancel
 	if_not_equal $0, Script_MobileError
 	writetext Text_ReceivedAListOfLeadersOnTheHonorRoll
@@ -187,15 +187,15 @@ UnreferencedScript_0x9e4be:
 
 UnreferencedScript_0x9e4ea:
 	writebyte BATTLETOWERACTION_LEVEL_CHECK
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_not_equal $0, Script_APkmnLevelExceeds
 	writebyte BATTLETOWERACTION_UBERS_CHECK
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_not_equal $0, Script_MayNotEnterABattleRoomUnderL70
-	special SpecialCheckForBattleTowerRules
+	special Special_CheckForBattleTowerRules
 	if_not_equal $0, Script_WaitButton
 	writebyte BATTLETOWERACTION_05
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal $0, .zero
 	writetext Text_CantBeRegistered_PreviousRecordDeleted
 	jump continue
@@ -213,9 +213,9 @@ continue:
 	iffalse Script_Menu_ChallengeExplanationCancel
 	setscene $1
 	writebyte BATTLETOWERACTION_06
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_12
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writetext Text_RightThisWayToYourBattleRoom
 	waitbutton
 	jump Script_ResumeBattleTowerChallenge
@@ -236,7 +236,7 @@ Script_MayNotEnterABattleRoomUnderL70: ; 0x9e549
 	jump Script_Menu_ChallengeExplanationCancel
 
 Script_MobileError:
-	special BattleTowerMobileError
+	special Special_BattleTowerMobileError
 	closetext
 	end
 

--- a/maps/BattleTowerBattleRoom.asm
+++ b/maps/BattleTowerBattleRoom.asm
@@ -33,7 +33,7 @@ Script_BattleRoomLoop: ; 0x9f425
 	buttonsound
 	closetext
 	special BattleTowerBattle ; calls predef startbattle
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	reloadmap
 	if_not_equal $0, Script_FailedBattleTowerChallenge
 	copybytetovar wNrOfBeatenBattleTowerTrainers ; wcf64
@@ -48,10 +48,10 @@ Script_BattleRoomLoop: ; 0x9f425
 	waitbutton
 	closetext
 	playmusic MUSIC_HEAL
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	special LoadMapPalettes
 	pause 60
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	special RestartMapMusic
 	opentext
 	writetext Text_NextUpOpponentNo
@@ -75,7 +75,7 @@ Script_DontBattleNextOpponent: ; 0x9f483
 	special BattleTowerAction
 	playsound SFX_SAVE
 	waitsfx
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	special Reset
 Script_DontSaveAndEndTheSession: ; 0x9f4a3
 	writetext Text_CancelYourBattleRoomChallenge
@@ -86,7 +86,7 @@ Script_DontSaveAndEndTheSession: ; 0x9f4a3
 	writebyte BATTLETOWERACTION_06
 	special BattleTowerAction
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	warpfacing UP, BATTLE_TOWER_1F, $7, $7
 	opentext
 	jump Script_BattleTowerHopeToServeYouAgain

--- a/maps/BattleTowerBattleRoom.asm
+++ b/maps/BattleTowerBattleRoom.asm
@@ -23,7 +23,7 @@ Script_BattleRoom: ; 0x9f421
 ; beat all 7 opponents in a row
 Script_BattleRoomLoop: ; 0x9f425
 	writebyte BATTLETOWERBATTLEROOM_YOUNGSTER
-	special Function_LoadOpponentTrainerAndPokemonsWithOTSprite
+	special Special_LoadOpponentTrainerAndPokemonWithOTSprite
 	appear BATTLETOWERBATTLEROOM_YOUNGSTER
 	warpsound
 	waitsfx
@@ -32,7 +32,7 @@ Script_BattleRoomLoop: ; 0x9f425
 	battletowertext 1
 	buttonsound
 	closetext
-	special BattleTowerBattle ; calls predef startbattle
+	special Special_BattleTowerBattle ; calls predef startbattle
 	special Special_FadeOutPalettes
 	reloadmap
 	if_not_equal $0, Script_FailedBattleTowerChallenge
@@ -49,7 +49,7 @@ Script_BattleRoomLoop: ; 0x9f425
 	closetext
 	playmusic MUSIC_HEAL
 	special Special_FadeOutPalettes
-	special LoadMapPalettes
+	special Special_LoadMapPalettes
 	pause 60
 	special Special_FadeInPalettes
 	special RestartMapMusic
@@ -68,11 +68,11 @@ Script_DontBattleNextOpponent: ; 0x9f483
 	yesorno
 	iffalse Script_DontSaveAndEndTheSession
 	writebyte BATTLETOWERACTION_SAVELEVELGROUP ; save level group
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_SAVEOPTIONS ; choose reward
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_SAVE_AND_QUIT ; quicksave
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	playsound SFX_SAVE
 	waitsfx
 	special Special_FadeOutPalettes
@@ -82,9 +82,9 @@ Script_DontSaveAndEndTheSession: ; 0x9f4a3
 	yesorno
 	iffalse Script_ContinueAndBattleNextOpponent
 	writebyte BATTLETOWERACTION_CHALLENGECANCELED
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_06
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	closetext
 	special Special_FadeOutPalettes
 	warpfacing UP, BATTLE_TOWER_1F, $7, $7
@@ -96,7 +96,7 @@ Script_FailedBattleTowerChallenge:
 	special Special_BattleTowerFade
 	warpfacing UP, BATTLE_TOWER_1F, $7, $7
 	writebyte BATTLETOWERACTION_CHALLENGECANCELED
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	opentext
 	writetext Text_ThanksForVisiting
 	waitbutton
@@ -114,7 +114,7 @@ Script_BeatenAllTrainers2:
 
 UnreferencedScript_0x9f4eb:
 	writebyte BATTLETOWERACTION_CHALLENGECANCELED
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	opentext
 	writetext Text_TooMuchTimeElapsedNoRegister
 	waitbutton
@@ -123,9 +123,9 @@ UnreferencedScript_0x9f4eb:
 
 UnreferencedScript_0x9f4f7:
 	writebyte BATTLETOWERACTION_CHALLENGECANCELED
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	writebyte BATTLETOWERACTION_06
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	opentext
 	writetext Text_ThanksForVisiting
 	writetext Text_WeHopeToServeYouAgain

--- a/maps/BattleTowerElevator.asm
+++ b/maps/BattleTowerElevator.asm
@@ -22,7 +22,7 @@ BattleTowerElevator_MapScriptHeader:
 	applymovement BATTLETOWERELEVATOR_RECEPTIONIST, MovementData_BattleTowerElevatorReceptionistWalksIn
 	applymovement PLAYER, MovementData_BattleTowerElevatorPlayerWalksIn
 	writebyte BATTLETOWERACTION_0A
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	playsound SFX_ELEVATOR
 	earthquake 60
 	waitsfx

--- a/maps/BluesHouse.asm
+++ b/maps/BluesHouse.asm
@@ -33,14 +33,14 @@ DaisyScript:
 	writetext DaisyAlrightText
 	waitbutton
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	special RestartMapMusic
 	opentext
 	writetext GroomedMonLooksContentText
-	special PlayCurMonCry
+	special Special_PlayCurMonCry
 	buttonsound
 	writetext DaisyAllDoneText
 	waitbutton

--- a/maps/BurnedTowerB1F.asm
+++ b/maps/BurnedTowerB1F.asm
@@ -83,7 +83,7 @@ ReleaseTheBeasts:
 	special RestartMapMusic
 	setscene $1
 	setevent EVENT_RELEASED_THE_BEASTS
-	special InitRoamMons
+	special Special_InitRoamMons
 	setmapscene ECRUTEAK_GYM, $1
 	setmapscene CIANWOOD_CITY, $1
 	clearevent EVENT_SAW_SUICUNE_AT_CIANWOOD_CITY

--- a/maps/CeladonDeptStore6F.asm
+++ b/maps/CeladonDeptStore6F.asm
@@ -24,7 +24,7 @@ CeladonDeptStore6FVendingMachine:
 	opentext
 	writetext CeladonVendingText
 .Start:
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	loadmenudata .MenuData
 	verticalmenu
 	closewindow

--- a/maps/CeladonGameCorner.asm
+++ b/maps/CeladonGameCorner.asm
@@ -144,7 +144,7 @@ MapCeladonGameCornerSignpost9Script:
 	end
 
 MovementData_0x721cd:
-; Unreferenced.
+; unused
 	step RIGHT
 	turn_head LEFT
 	step_end

--- a/maps/CeladonMansion3F.asm
+++ b/maps/CeladonMansion3F.asm
@@ -28,7 +28,7 @@ UnknownScript_0x7167e:
 	waitsfx
 	writetext UnknownText_0x71760
 	buttonsound
-	special Diploma
+	special Special_Diploma
 	writetext UnknownText_0x71763
 	waitbutton
 	closetext
@@ -49,7 +49,7 @@ UnknownScript_0x716a4:
 	writetext UnknownText_0x717d8
 	yesorno
 	iffalse UnknownScript_0x716b0
-	special PrintDiploma
+	special Special_PrintDiploma
 	closetext
 	end
 

--- a/maps/CeladonPokecenter1F.asm
+++ b/maps/CeladonPokecenter1F.asm
@@ -30,9 +30,9 @@ CeladonEusine:
 	writetext CeladonEusineText1
 	buttonsound
 	writebyte SUICUNE
-	special SpecialMonCheck
+	special Special_MonCheck
 	iffalse .NoSuicune
-	special SpecialBeastsCheck
+	special Special_BeastsCheck
 	iftrue .HoOh
 	writetext NoBeastsText
 	waitbutton

--- a/maps/CeruleanPokecenter1F.asm
+++ b/maps/CeruleanPokecenter1F.asm
@@ -14,7 +14,7 @@ NurseScript_0x18820f:
 	jumpstd pokecenternurse
 
 SuperNerdScript_0x188212:
-	special Mobile_DummyReturnFalse
+	special Special_Mobile_DummyReturnFalse
 	iftrue .mobile
 	jumptextfaceplayer UnknownText_0x188221
 

--- a/maps/CianwoodCityPhotoStudio.asm
+++ b/maps/CianwoodCityPhotoStudio.asm
@@ -16,7 +16,7 @@ FishingGuruScript_0x9e0e0:
 	iffalse UnknownScript_0x9e0f3
 	writetext UnknownText_0x9e142
 	waitbutton
-	special PhotoStudio
+	special Special_PhotoStudio
 	waitbutton
 	closetext
 	end

--- a/maps/CopycatsHouse2F.asm
+++ b/maps/CopycatsHouse2F.asm
@@ -46,7 +46,7 @@ Copycat:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_KRIS
 .Default_Merge_1:
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	checkevent EVENT_RETURNED_MACHINE_PART
 	iftrue .TalkAboutLostItem
 	opentext
@@ -70,7 +70,7 @@ Copycat:
 .Default_Merge_3a:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_QuickMimicking
 	waitbutton
@@ -99,7 +99,7 @@ Copycat:
 .Default_Merge_3b:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_Worried
 	waitbutton
@@ -142,7 +142,7 @@ Copycat:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_KRIS
 .GotPass_Merge_1:
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	checkflag ENGINE_PLAYER_IS_FEMALE
 	iftrue .GotPass_Female_2
@@ -164,7 +164,7 @@ Copycat:
 .GotPass_Merge_3:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_ItsAScream
 	waitbutton

--- a/maps/CopycatsHouse2F.asm
+++ b/maps/CopycatsHouse2F.asm
@@ -46,7 +46,7 @@ Copycat:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_KRIS
 .Default_Merge_1:
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	checkevent EVENT_RETURNED_MACHINE_PART
 	iftrue .TalkAboutLostItem
 	opentext
@@ -70,7 +70,7 @@ Copycat:
 .Default_Merge_3a:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_QuickMimicking
 	waitbutton
@@ -99,7 +99,7 @@ Copycat:
 .Default_Merge_3b:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_Worried
 	waitbutton
@@ -142,7 +142,7 @@ Copycat:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_KRIS
 .GotPass_Merge_1:
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	checkflag ENGINE_PLAYER_IS_FEMALE
 	iftrue .GotPass_Female_2
@@ -164,7 +164,7 @@ Copycat:
 .GotPass_Merge_3:
 	faceplayer
 	variablesprite SPRITE_COPYCAT, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	writetext CopycatText_ItsAScream
 	waitbutton

--- a/maps/DragonShrine.asm
+++ b/maps/DragonShrine.asm
@@ -217,7 +217,7 @@ ElderScript_0x18d1a5:
 	waitsfx
 	givepoke DRATINI, 15
 	checkevent EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG
-	special SpecialDratini
+	special Special_Dratini
 	setevent EVENT_GOT_DRATINI
 	setevent EVENT_JUST_RECEIVED_DRATINI
 	writetext UnknownText_0x18d6ca

--- a/maps/EcruteakGym.asm
+++ b/maps/EcruteakGym.asm
@@ -91,7 +91,7 @@ EcruteakGymClosed:
 	follow PLAYER, ECRUTEAKGYM_GRAMPS
 	applymovement PLAYER, MovementData_0x99e5f
 	stopfollow
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	playsound SFX_ENTER_DOOR
 	waitsfx
 	warp ECRUTEAK_CITY, $6, $1b

--- a/maps/EcruteakPokecenter1F.asm
+++ b/maps/EcruteakPokecenter1F.asm
@@ -61,7 +61,7 @@ EcruteakPokecenter1FNurseScript:
 	jumpstd pokecenternurse
 
 EcruteakPokecenter1FPokefanMScript:
-	special Mobile_DummyReturnFalse
+	special Special_Mobile_DummyReturnFalse
 	iftrue .mobile
 	jumptextfaceplayer EcruteakPokecenter1FPokefanMText
 

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -308,7 +308,7 @@ ElmsLabHealingMachine:
 	end
 
 ElmsLabHealingMachine_HealParty:
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	special HealParty
 	playmusic MUSIC_NONE
 	writebyte 1 ; Machine is in Elm's Lab

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -308,7 +308,7 @@ ElmsLabHealingMachine:
 	end
 
 ElmsLabHealingMachine_HealParty:
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	special HealParty
 	playmusic MUSIC_NONE
 	writebyte 1 ; Machine is in Elm's Lab

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -312,7 +312,7 @@ ElmsLabHealingMachine_HealParty:
 	special HealParty
 	playmusic MUSIC_NONE
 	writebyte 1 ; Machine is in Elm's Lab
-	special HealMachineAnim
+	special Special_HealMachineAnim
 	pause 30
 	special RestartMapMusic
 	closetext
@@ -556,7 +556,7 @@ CopScript:
 	opentext
 	writetext ElmsLabOfficerText1
 	buttonsound
-	special SpecialNameRival
+	special Special_NameRival
 	writetext ElmsLabOfficerText2
 	waitbutton
 	closetext

--- a/maps/FastShip1F.asm
+++ b/maps/FastShip1F.asm
@@ -68,7 +68,7 @@ SailorScript_0x75160:
 	closetext
 	scall .LetThePlayerOut
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	setevent EVENT_VERMILION_PORT_SAILOR_AT_GANGWAY
 	setmapscene VERMILION_PORT, $1
@@ -81,7 +81,7 @@ SailorScript_0x75160:
 	closetext
 	scall .LetThePlayerOut
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	setevent EVENT_OLIVINE_PORT_SAILOR_AT_GANGWAY
 	setmapscene OLIVINE_PORT, $1

--- a/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
+++ b/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
@@ -18,7 +18,7 @@ FastShipCabins_SE_SSE_CaptainsCabin_MapScriptHeader:
 .MapCallbacks:
 	db 0
 
-Unused_0x75ea6:
+Unreferenced_0x75ea6:
 	end
 
 SSAquaCaptain:

--- a/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
+++ b/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
@@ -49,7 +49,7 @@ SSAquaGranddaughterBefore:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN2
 	applymovement PLAYER, MovementData_0x76004
 	moveobject FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN1, $3, $13

--- a/maps/FastShipCabins_SW_SSW_NW.asm
+++ b/maps/FastShipCabins_SW_SSW_NW.asm
@@ -71,7 +71,7 @@ FastShipBed:
 	closetext
 	special Special_FadeBlackQuickly
 	special ReloadSpritesNoPalettes
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	special HealParty
 	playmusic MUSIC_HEAL
 	pause 60

--- a/maps/FastShipCabins_SW_SSW_NW.asm
+++ b/maps/FastShipCabins_SW_SSW_NW.asm
@@ -49,7 +49,7 @@ TrainerGuitaristClyde:
 
 .Script:
 	end_if_just_battled
-	special Mobile_DummyReturnFalse
+	special Special_Mobile_DummyReturnFalse
 	iftrue .mobile
 	opentext
 	writetext UnknownText_0x75d65
@@ -71,7 +71,7 @@ FastShipBed:
 	closetext
 	special Special_FadeBlackQuickly
 	special Special_ReloadSpritesNoPalettes
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	special HealParty
 	playmusic MUSIC_HEAL
 	pause 60

--- a/maps/FastShipCabins_SW_SSW_NW.asm
+++ b/maps/FastShipCabins_SW_SSW_NW.asm
@@ -70,7 +70,7 @@ FastShipBed:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	special Special_TrainerRankings_Healings
 	special HealParty
 	playmusic MUSIC_HEAL

--- a/maps/FuchsiaGym.asm
+++ b/maps/FuchsiaGym.asm
@@ -35,7 +35,7 @@ FuchsiaGymJanineScript:
 	variablesprite SPRITE_FUCHSIA_GYM_2, SPRITE_LASS
 	variablesprite SPRITE_FUCHSIA_GYM_3, SPRITE_LASS
 	variablesprite SPRITE_FUCHSIA_GYM_4, SPRITE_YOUNGSTER
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	writetext Text_ReceivedSoulBadge
 	playsound SFX_GET_BADGE
@@ -65,7 +65,7 @@ LassAliceScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_1, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_1, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 .AliceUnmasked:
 	faceplayer
 	opentext
@@ -99,7 +99,7 @@ LassLindaScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_2, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_2, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 .LindaUnmasked:
 	faceplayer
 	opentext
@@ -133,7 +133,7 @@ PicnickerCindyScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_3, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_3, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 .CindyUnmasked:
 	faceplayer
 	opentext
@@ -167,7 +167,7 @@ CamperBarryScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_4, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_4, SPRITE_YOUNGSTER
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 .BarryUnmasked:
 	faceplayer
 	opentext

--- a/maps/FuchsiaGym.asm
+++ b/maps/FuchsiaGym.asm
@@ -35,7 +35,7 @@ FuchsiaGymJanineScript:
 	variablesprite SPRITE_FUCHSIA_GYM_2, SPRITE_LASS
 	variablesprite SPRITE_FUCHSIA_GYM_3, SPRITE_LASS
 	variablesprite SPRITE_FUCHSIA_GYM_4, SPRITE_YOUNGSTER
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	writetext Text_ReceivedSoulBadge
 	playsound SFX_GET_BADGE
@@ -65,7 +65,7 @@ LassAliceScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_1, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_1, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 .AliceUnmasked:
 	faceplayer
 	opentext
@@ -99,7 +99,7 @@ LassLindaScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_2, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_2, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 .LindaUnmasked:
 	faceplayer
 	opentext
@@ -133,7 +133,7 @@ PicnickerCindyScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_3, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_3, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 .CindyUnmasked:
 	faceplayer
 	opentext
@@ -167,7 +167,7 @@ CamperBarryScript:
 	applymovement FUCHSIAGYM_FUCHSIA_GYM_4, Movement_NinjaSpin
 	faceplayer
 	variablesprite SPRITE_FUCHSIA_GYM_4, SPRITE_YOUNGSTER
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 .BarryUnmasked:
 	faceplayer
 	opentext

--- a/maps/FuchsiaPokecenter1F.asm
+++ b/maps/FuchsiaPokecenter1F.asm
@@ -33,7 +33,7 @@ JanineImpersonatorScript_0x196462:
 	applymovement FUCHSIAPOKECENTER1F_JANINE_IMPERSONATOR, MovementData_0x196486
 	faceplayer
 	variablesprite SPRITE_JANINE_IMPERSONATOR, SPRITE_JANINE
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	opentext
 	writetext UnknownText_0x19654e
 	waitbutton
@@ -41,7 +41,7 @@ JanineImpersonatorScript_0x196462:
 	applymovement FUCHSIAPOKECENTER1F_JANINE_IMPERSONATOR, MovementData_0x196486
 	faceplayer
 	variablesprite SPRITE_JANINE_IMPERSONATOR, SPRITE_LASS
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	end
 
 MovementData_0x196486:

--- a/maps/FuchsiaPokecenter1F.asm
+++ b/maps/FuchsiaPokecenter1F.asm
@@ -33,7 +33,7 @@ JanineImpersonatorScript_0x196462:
 	applymovement FUCHSIAPOKECENTER1F_JANINE_IMPERSONATOR, MovementData_0x196486
 	faceplayer
 	variablesprite SPRITE_JANINE_IMPERSONATOR, SPRITE_JANINE
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	opentext
 	writetext UnknownText_0x19654e
 	waitbutton
@@ -41,7 +41,7 @@ JanineImpersonatorScript_0x196462:
 	applymovement FUCHSIAPOKECENTER1F_JANINE_IMPERSONATOR, MovementData_0x196486
 	faceplayer
 	variablesprite SPRITE_JANINE_IMPERSONATOR, SPRITE_LASS
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	end
 
 MovementData_0x196486:

--- a/maps/GoldenrodDeptStore2F.asm
+++ b/maps/GoldenrodDeptStore2F.asm
@@ -41,8 +41,8 @@ GoldenrodDeptStore2FDirectory:
 GoldenrodDeptStore2FElevatorButton:
 	jumpstd elevatorbutton
 
-; possibly unused
-UnknownText_0x55b7c:
+; unused
+UnusedText_0x55b7c:
 	text "We intend to sell"
 	line "items for #MON"
 	cont "to hold."
@@ -52,8 +52,8 @@ UnknownText_0x55b7c:
 	cont "MON hold it."
 	done
 
-; possibly unused
-UnknownText_0x55bd3:
+; unused
+UnusedText_0x55bd3:
 	text "By giving #MON"
 	line "items to hold, I"
 

--- a/maps/GoldenrodDeptStore5F.asm
+++ b/maps/GoldenrodDeptStore5F.asm
@@ -65,7 +65,7 @@ ReceptionistScript_0x560ce:
 	if_not_equal SUNDAY, .EventIsOver
 	checkflag ENGINE_GOLDENROD_MALL_5F_HAPPINESS_EVENT
 	iftrue .EventIsOver
-	special GetFirstPokemonHappiness
+	special Special_GetFirstPokemonHappiness
 	writetext UnknownText_0x56143
 	buttonsound
 	if_greater_than $95, .VeryHappy
@@ -106,7 +106,7 @@ ReceptionistScript_0x560ce:
 Carrie:
 	faceplayer
 	opentext
-	special SpecialGameboyCheck
+	special Special_GameboyCheck
 	if_not_equal $2, .NotGBC ; This is a dummy check from Gold and Silver.  In normal gameplay, this would not be checked.
 	writetext UnknownText_0x56241
 	waitbutton

--- a/maps/GoldenrodDeptStore6F.asm
+++ b/maps/GoldenrodDeptStore6F.asm
@@ -13,7 +13,7 @@ GoldenrodVendingMachine:
 	opentext
 	writetext GoldenrodVendingText
 .Start:
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	loadmenudata .MenuData
 	verticalmenu
 	closewindow

--- a/maps/GoldenrodHappinessRater.asm
+++ b/maps/GoldenrodHappinessRater.asm
@@ -13,7 +13,7 @@ GoldenrodHappinessRater_MapScriptHeader:
 TeacherScript_0x54953:
 	faceplayer
 	opentext
-	special GetFirstPokemonHappiness
+	special Special_GetFirstPokemonHappiness
 	writetext UnknownText_0x549a3
 	buttonsound
 	if_greater_than $f9, UnknownScript_0x54973

--- a/maps/GoldenrodNameRater.asm
+++ b/maps/GoldenrodNameRater.asm
@@ -11,7 +11,7 @@ GoldenrodNameRater_MapScriptHeader:
 GoldenrodNameRater:
 	faceplayer
 	opentext
-	special SpecialNameRater
+	special Special_NameRater
 	waitbutton
 	closetext
 	end

--- a/maps/GoldenrodPokecenter1F.asm
+++ b/maps/GoldenrodPokecenter1F.asm
@@ -17,7 +17,7 @@ NurseScript_0x60f91:
 
 GoldenrodPokecenter1F_GSBallSceneLeft:
 	writebyte BATTLETOWERACTION_CHECKMOBILEEVENT
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal MOBILE_EVENT_OBJECT_GS_BALL, .gsball
 	end
 
@@ -49,7 +49,7 @@ GoldenrodPokecenter1F_GSBallSceneLeft:
 
 GoldenrodPokecenter1F_GSBallSceneRight:
 	writebyte BATTLETOWERACTION_CHECKMOBILEEVENT
-	special BattleTowerAction
+	special Special_BattleTowerAction
 	if_equal MOBILE_EVENT_OBJECT_GS_BALL, .gsball
 	end
 

--- a/maps/GoldenrodUnderground.asm
+++ b/maps/GoldenrodUnderground.asm
@@ -192,7 +192,7 @@ OlderHaircutBrotherScript:
 .DoHaircut:
 	checkflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
 	iftrue .AlreadyGotHaircut
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	writetext UnknownText_0x7c5f9
 	yesorno
 	iffalse .Refused
@@ -228,14 +228,14 @@ OlderHaircutBrotherScript:
 
 .then
 	takemoney $0, 500
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	writetext UnknownText_0x7c6b8
 	waitbutton
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	special RestartMapMusic
 	opentext
 	writetext UnknownText_0x7c6d8
@@ -275,7 +275,7 @@ YoungerHaircutBrotherScript:
 .DoHaircut:
 	checkflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
 	iftrue .AlreadyGotHaircut
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	writetext UnknownText_0x7c75c
 	yesorno
 	iffalse .Refused
@@ -311,14 +311,14 @@ YoungerHaircutBrotherScript:
 
 .then
 	takemoney $0, 300
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	writetext UnknownText_0x7c80e
 	waitbutton
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	special RestartMapMusic
 	opentext
 	writetext UnknownText_0x7c82a
@@ -349,21 +349,21 @@ YoungerHaircutBrotherScript:
 
 UnknownScript_0x7c2bb:
 	writetext HaircutBrosText_SlightlyHappier
-	special PlayCurMonCry
+	special Special_PlayCurMonCry
 	waitbutton
 	closetext
 	end
 
 UnknownScript_0x7c2c4:
 	writetext HaircutBrosText_Happier
-	special PlayCurMonCry
+	special Special_PlayCurMonCry
 	waitbutton
 	closetext
 	end
 
 UnknownScript_0x7c2cd:
 	writetext HaircutBrosText_MuchHappier
-	special PlayCurMonCry
+	special Special_PlayCurMonCry
 	waitbutton
 	closetext
 	end

--- a/maps/HallOfFame.asm
+++ b/maps/HallOfFame.asm
@@ -31,7 +31,7 @@ HallOfFame_MapScriptHeader:
 	setscene $1
 	pause 15
 	writebyte 2 ; Machine is in the Hall of Fame
-	special HealMachineAnim
+	special Special_HealMachineAnim
 	setevent EVENT_BEAT_ELITE_FOUR
 	setevent EVENT_TELEPORT_GUY
 	setevent EVENT_RIVAL_SPROUT_TOWER

--- a/maps/IlexForest.asm
+++ b/maps/IlexForest.asm
@@ -472,7 +472,7 @@ MapIlexForestSignpost4Script:
 	startbattle
 	reloadmapafterbattle
 	pause 20
-	special CheckCaughtCelebi
+	special Special_CheckCaughtCelebi
 	iffalse .DidntCatchCelebi
 	appear ILEXFOREST_KURT
 	applymovement ILEXFOREST_KURT, MovementData_0x6ef4e

--- a/maps/IndigoPlateauPokecenter1F.asm
+++ b/maps/IndigoPlateauPokecenter1F.asm
@@ -158,7 +158,7 @@ TeleportGuyScript:
 	waitbutton
 	closetext
 	playsound SFX_WARP_TO
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	warp NEW_BARK_TOWN, $d, $6
 	end

--- a/maps/KrissHouse2F.asm
+++ b/maps/KrissHouse2F.asm
@@ -17,7 +17,7 @@ KrissHouse2F_MapScriptHeader:
 	end
 
 .InitializeRoom:
-	special ToggleDecorationsVisibility
+	special Special_ToggleDecorationsVisibility
 	setevent EVENT_IN_YOUR_ROOM
 	checkevent EVENT_INITIALIZED_EVENTS
 	iftrue .SkipInizialization
@@ -28,7 +28,7 @@ KrissHouse2F_MapScriptHeader:
 	return
 
 .SetSpawn:
-	special ToggleMaptileDecorations
+	special Special_ToggleMaptileDecorations
 	return
 
 

--- a/maps/LancesRoom.asm
+++ b/maps/LancesRoom.asm
@@ -125,7 +125,7 @@ LanceScript_0x180e7b:
 	pause 30
 	closetext
 	applymovement LANCESROOM_MARY, LancesRoomMovementData_MaryRunsBackAndForth
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	pause 15
 	warpfacing UP, HALL_OF_FAME, $4, $d
 	end

--- a/maps/LavenderNameRater.asm
+++ b/maps/LavenderNameRater.asm
@@ -15,7 +15,7 @@ LavenderNameRater_MapScriptHeader:
 LavenderNameRater:
 	faceplayer
 	opentext
-	special SpecialNameRater
+	special Special_NameRater
 	waitbutton
 	closetext
 	end

--- a/maps/MahoganyTown.asm
+++ b/maps/MahoganyTown.asm
@@ -53,7 +53,7 @@ UnknownScript_0x190039:
 UnknownScript_0x190040:
 	opentext
 	writetext UnknownText_0x1900b0
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	yesorno
 	iffalse UnknownScript_0x190072
 	checkmoney $0, 300
@@ -63,7 +63,7 @@ UnknownScript_0x190040:
 	waitsfx
 	playsound SFX_TRANSACTION
 	takemoney $0, 300
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	writetext UnknownText_0x19014a
 	waitbutton
 	closetext

--- a/maps/ManiasHouse.asm
+++ b/maps/ManiasHouse.asm
@@ -18,7 +18,7 @@ ManiaScript:
 	writetext ManiaText_AskLookAfterShuckle
 	yesorno
 	iffalse .refusetotakeshuckie
-	special SpecialGiveShuckle
+	special Special_GiveShuckle
 	iffalse .partyfull
 	writetext ManiaText_TakeCareOfShuckle
 	buttonsound
@@ -54,7 +54,7 @@ ManiaScript:
 	writetext ManiaText_CanIHaveMyMonBack
 	yesorno
 	iffalse .refused
-	special SpecialReturnShuckle
+	special Special_ReturnShuckle
 	if_equal $0, .wrong
 	if_equal $1, .refused
 	if_equal $3, .superhappy

--- a/maps/MobileBattleRoom.asm
+++ b/maps/MobileBattleRoom.asm
@@ -41,7 +41,7 @@ MapMobileBattleRoomSignpost0Script:
 	special RestartMapMusic
 	refreshscreen $0
 .two_
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	special HealParty
 	special Special_Function10383c
 	iftrue .false

--- a/maps/MobileBattleRoom.asm
+++ b/maps/MobileBattleRoom.asm
@@ -21,9 +21,9 @@ MobileBattleRoom_MapScriptHeader:
 
 MapMobileBattleRoomSignpost0Script:
 	refreshscreen $0
-	special Function1037c2
+	special Special_Function1037c2
 	if_equal $1, .one
-	special Function1037eb
+	special Special_Function1037eb
 	iffalse .false
 	if_equal $1, .one_
 	if_equal $2, .two_
@@ -35,22 +35,22 @@ MapMobileBattleRoomSignpost0Script:
 	closetext
 	special Special_FadeOutPalettes
 	playmusic MUSIC_HEAL
-	special LoadMapPalettes
+	special Special_LoadMapPalettes
 	pause 60
 	special Special_FadeInPalettes
 	special RestartMapMusic
 	refreshscreen $0
 .two_
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	special HealParty
-	special Function10383c
+	special Special_Function10383c
 	iftrue .false
 .one
-	special Function10387b
+	special Special_Function10387b
 	writetext MobileBattleRoom_EstablishingCommsText
 	waitbutton
 	reloadmappart
-	special Function101225
+	special Special_Function101225
 .false
 	closetext
 	end

--- a/maps/MobileBattleRoom.asm
+++ b/maps/MobileBattleRoom.asm
@@ -33,11 +33,11 @@ MapMobileBattleRoomSignpost0Script:
 	writetext MobileBattleRoom_HealText
 	pause 20
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	playmusic MUSIC_HEAL
 	special LoadMapPalettes
 	pause 60
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	special RestartMapMusic
 	refreshscreen $0
 .two_

--- a/maps/MobileTradeRoomMobile.asm
+++ b/maps/MobileTradeRoomMobile.asm
@@ -21,11 +21,11 @@ MobileTradeRoomMobile_MapScriptHeader:
 
 MapMobileTradeRoomMobileSignpost0Script:
 	refreshscreen $0
-	special Function1037c2
+	special Special_Function1037c2
 	writetext MobileTradeRoomMobile_EstablishingCommsText
 	waitbutton
 	reloadmappart
-	special Function101231
+	special Special_Function101231
 	closetext
 	end
 

--- a/maps/MoveDeletersHouse.asm
+++ b/maps/MoveDeletersHouse.asm
@@ -11,7 +11,7 @@ MoveDeletersHouse_MapScriptHeader:
 MoveDeleter:
 	faceplayer
 	opentext
-	special MoveDeletion
+	special Special_MoveDeletion
 	waitbutton
 	closetext
 	end

--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -111,7 +111,7 @@ MrPokemonsHouse_OakScript:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	playmusic MUSIC_HEAL
 	special Special_TrainerRankings_Healings
 	special HealParty

--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -113,7 +113,7 @@ MrPokemonsHouse_OakScript:
 	special Special_FadeBlackQuickly
 	special Special_ReloadSpritesNoPalettes
 	playmusic MUSIC_HEAL
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	special HealParty
 	pause 60
 	special Special_FadeInQuickly

--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -113,7 +113,7 @@ MrPokemonsHouse_OakScript:
 	special Special_FadeBlackQuickly
 	special ReloadSpritesNoPalettes
 	playmusic MUSIC_HEAL
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	special HealParty
 	pause 60
 	special Special_FadeInQuickly

--- a/maps/OaksLab.asm
+++ b/maps/OaksLab.asm
@@ -33,7 +33,7 @@ Oak:
 .CheckPokedex:
 	writetext OakLabDexCheckText
 	waitbutton
-	special ProfOaksPCBoot
+	special Special_ProfOaksPCBoot
 	writetext OakLabGoodbyeText
 	waitbutton
 	closetext

--- a/maps/OlivineCity.asm
+++ b/maps/OlivineCity.asm
@@ -45,7 +45,7 @@ UnknownScript_0x1a8833:
 	disappear OLIVINECITY_OLIVINE_RIVAL
 	special RestartMapMusic
 	variablesprite SPRITE_OLIVINE_RIVAL, SPRITE_SWIMMER_GUY
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	end
 
 UnknownScript_0x1a886b:
@@ -69,7 +69,7 @@ UnknownScript_0x1a886b:
 	setscene $1
 	special RestartMapMusic
 	variablesprite SPRITE_OLIVINE_RIVAL, SPRITE_SWIMMER_GUY
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	end
 
 OlivineCitySailor1Script:

--- a/maps/OlivineCity.asm
+++ b/maps/OlivineCity.asm
@@ -45,7 +45,7 @@ UnknownScript_0x1a8833:
 	disappear OLIVINECITY_OLIVINE_RIVAL
 	special RestartMapMusic
 	variablesprite SPRITE_OLIVINE_RIVAL, SPRITE_SWIMMER_GUY
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	end
 
 UnknownScript_0x1a886b:
@@ -69,7 +69,7 @@ UnknownScript_0x1a886b:
 	setscene $1
 	special RestartMapMusic
 	variablesprite SPRITE_OLIVINE_RIVAL, SPRITE_SWIMMER_GUY
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	end
 
 OlivineCitySailor1Script:

--- a/maps/OlivineLighthouse2F.asm
+++ b/maps/OlivineLighthouse2F.asm
@@ -164,8 +164,8 @@ SailorHuey1BeatenText:
 	line "I lose!"
 	done
 
-; possibly unused
-UnknownText_0x5b0be:
+; unused
+UnusedText_0x5b0be:
 	text "What power!"
 	line "How would you like"
 

--- a/maps/OlivineLighthouse6F.asm
+++ b/maps/OlivineLighthouse6F.asm
@@ -47,9 +47,9 @@ UnknownScript_0x60bab:
 	closetext
 	special RestartMapMusic
 	cry AMPHAROS
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	pause 10
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	opentext
 	writetext UnknownText_0x60f3d
 	waitbutton
@@ -109,7 +109,7 @@ MonsterScript_0x60c3a:
 	iftrue UnknownScript_0x60c51
 	writetext UnknownText_0x60f03
 	writebyte AMPHAROS
-	special PlaySlowCry
+	special Special_PlaySlowCry
 	buttonsound
 	writetext UnknownText_0x60f19
 	waitbutton
@@ -121,10 +121,10 @@ UnknownScript_0x60c51:
 	cry AMPHAROS
 	waitbutton
 	closetext
-	special FadeOutPalettes
-	special FadeInPalettes
-	special FadeOutPalettes
-	special FadeInPalettes
+	special Special_FadeOutPalettes
+	special Special_FadeInPalettes
+	special Special_FadeOutPalettes
+	special Special_FadeInPalettes
 	end
 
 OlivineLighthouse6FSuperPotion:

--- a/maps/OlivinePort.asm
+++ b/maps/OlivinePort.asm
@@ -46,7 +46,7 @@ SailorScript_0x748c0:
 	waitsfx
 	applymovement PLAYER, MovementData_0x74a30
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	checkevent EVENT_FAST_SHIP_FIRST_TIME
 	iffalse UnknownScript_0x7490a

--- a/maps/PokeSeersHouse.asm
+++ b/maps/PokeSeersHouse.asm
@@ -11,7 +11,7 @@ PokeSeersHouse_MapScriptHeader:
 SeerScript:
 	faceplayer
 	opentext
-	special SpecialPokeSeer
+	special Special_PokeSeer
 	waitbutton
 	closetext
 	end

--- a/maps/Pokecenter2F.asm
+++ b/maps/Pokecenter2F.asm
@@ -76,10 +76,10 @@ LinkReceptionistScript_Trade:
 	writetext Text_TradeReceptionistIntro
 	yesorno
 	iffalse .Cancel
-	special Mobile_DummyReturnFalse ; always returns false
+	special Special_Mobile_DummyReturnFalse ; always returns false
 	iffalse .NoMobile
 	writetext Text_TradeReceptionistMobile
-	special AskMobileOrCable
+	special Special_AskMobileOrCable
 	iffalse .Cancel
 	if_equal $1, .Mobile
 .NoMobile:
@@ -153,7 +153,7 @@ LinkReceptionistScript_Trade:
 	iffalse .Mobile_DidNotSave
 	special Special_TryQuickSave
 	iffalse .Mobile_DidNotSave
-	special Function1011f1
+	special Special_Function1011f1
 	writetext Text_PleaseComeIn2
 	waitbutton
 	closetext
@@ -178,10 +178,10 @@ LinkReceptionistScript_Battle:
 	writetext Text_BattleReceptionistIntro
 	yesorno
 	iffalse .Cancel
-	special Mobile_DummyReturnFalse ; always returns false
+	special Special_Mobile_DummyReturnFalse ; always returns false
 	iffalse .NoMobile
 	writetext Text_BattleReceptionistMobile
-	special AskMobileOrCable
+	special Special_AskMobileOrCable
 	iffalse .Cancel
 	if_equal $1, .Mobile
 .NoMobile:
@@ -255,9 +255,9 @@ LinkReceptionistScript_Battle:
 	writetext Text_MustSaveGame
 	yesorno
 	iffalse .Mobile_DidNotSave
-	special Function103780
+	special Special_Function103780
 	iffalse .Mobile_DidNotSave
-	special Function1011f1
+	special Special_Function1011f1
 	writetext Text_PleaseComeIn2
 	waitbutton
 	closetext
@@ -271,7 +271,7 @@ LinkReceptionistScript_Battle:
 	end
 
 .SelectThreeMons:
-	special Mobile_SelectThreeMons
+	special Special_Mobile_SelectThreeMons
 	iffalse .Mobile_DidNotSelect
 	if_equal $1, .Mobile_OK
 	if_equal $2, .Mobile_OK
@@ -381,7 +381,7 @@ Script_LeftCableTradeCenter:
 	end
 
 Script_LeftMobileTradeRoom:
-	special Function101220
+	special Special_Function101220
 	scall Script_WalkOutOfMobileTradeRoom
 	setscene $0
 	setmapscene MOBILE_TRADE_ROOM_MOBILE, $0
@@ -401,7 +401,7 @@ Script_LeftCableColosseum:
 	end
 
 Script_LeftMobileBattleRoom:
-	special Function101220
+	special Special_Function101220
 	scall Script_WalkOutOfMobileBattleRoom
 	setscene $0
 	setmapscene MOBILE_BATTLE_ROOM, $0

--- a/maps/Pokecenter2F.asm
+++ b/maps/Pokecenter2F.asm
@@ -107,7 +107,7 @@ LinkReceptionistScript_Trade:
 	end
 
 .FriendNotReady:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	writetext Text_FriendNotReady
 	closetext
 	end
@@ -132,7 +132,7 @@ LinkReceptionistScript_Trade:
 .DidNotSave:
 	writetext Text_PleaseComeAgain
 .AbortLink:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 .Cancel:
 	closetext
 	end
@@ -209,7 +209,7 @@ LinkReceptionistScript_Battle:
 	end
 
 .FriendNotReady:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	writetext Text_FriendNotReady
 	closetext
 	end
@@ -234,7 +234,7 @@ LinkReceptionistScript_Battle:
 .DidNotSave:
 	writetext Text_PleaseComeAgain
 .AbortLink:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 .Cancel:
 	closetext
 	end
@@ -342,7 +342,7 @@ LinkReceptionistScript_TimeCapsule:
 	end
 
 .FriendNotReady:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	writetext Text_FriendNotReady
 	closetext
 	end
@@ -354,7 +354,7 @@ LinkReceptionistScript_TimeCapsule:
 .DidNotSave:
 	writetext Text_PleaseComeAgain
 .Cancel:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	closetext
 	end
 
@@ -374,7 +374,7 @@ LinkReceptionistScript_TimeCapsule:
 	end
 
 Script_LeftCableTradeCenter:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	scall Script_WalkOutOfLinkTradeRoom
 	setscene $0
 	setmapscene TRADE_CENTER, $0
@@ -394,7 +394,7 @@ Script_WalkOutOfMobileTradeRoom:
 	end
 
 Script_LeftCableColosseum:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	scall Script_WalkOutOfLinkBattleRoom
 	setscene $0
 	setmapscene COLOSSEUM, $0
@@ -558,7 +558,7 @@ TimeCapsuleScript_CheckPlayerGender:
 	end
 
 Script_LeftTimeCapsule:
-	special WaitForOtherPlayerToExit
+	special Special_WaitForOtherPlayerToExit
 	checkflag ENGINE_KRIS_IN_CABLE_CLUB
 	iftrue .Female
 	applymovement POKECENTER2F_TIME_CAPSULE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsLeftLooksRight

--- a/maps/RadioTower2F.asm
+++ b/maps/RadioTower2F.asm
@@ -117,7 +117,7 @@ Buena:
 	if_equal 30, UnknownScript_0x5d87f
 	playmusic MUSIC_BUENAS_PASSWORD
 	writetext UnknownText_0x5de35
-	special AskRememberPassword
+	special Special_AskRememberPassword
 	iffalse UnknownScript_0x5d81e
 	writetext UnknownText_0x5de84
 	waitbutton
@@ -134,7 +134,7 @@ UnknownScript_0x5d7be:
 	closetext
 	spriteface RADIOTOWER2F_BUENA, DOWN
 	refreshscreen $0
-	special SpecialBuenasPassword
+	special Special_BuenasPassword
 	closetext
 	iffalse UnknownScript_0x5d845
 	opentext
@@ -316,7 +316,7 @@ ReceptionistScript_0x5d8ff:
 	iffalse UnknownScript_0x5d90f
 	writetext UnknownText_0x5e392
 	buttonsound
-	special SpecialBuenaPrize
+	special Special_BuenaPrize
 	closetext
 	end
 

--- a/maps/RadioTower5F.asm
+++ b/maps/RadioTower5F.asm
@@ -96,7 +96,7 @@ RadioTower5FRocketBossScene:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear RADIOTOWER5F_ROCKET
 	disappear RADIOTOWER5F_ROCKET_GIRL
 	pause 15

--- a/maps/Route24.asm
+++ b/maps/Route24.asm
@@ -29,7 +29,7 @@ RocketScript_0x1adbfa:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear ROUTE24_ROCKET
 	pause 25
 	special Special_FadeInQuickly

--- a/maps/Route26HealSpeechHouse.asm
+++ b/maps/Route26HealSpeechHouse.asm
@@ -15,7 +15,7 @@ TeacherScript_0x7b125:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	special Special_TrainerRankings_Healings
 	playmusic MUSIC_HEAL
 	special HealParty

--- a/maps/Route26HealSpeechHouse.asm
+++ b/maps/Route26HealSpeechHouse.asm
@@ -16,7 +16,7 @@ TeacherScript_0x7b125:
 	closetext
 	special Special_FadeBlackQuickly
 	special Special_ReloadSpritesNoPalettes
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	playmusic MUSIC_HEAL
 	special HealParty
 	pause 60

--- a/maps/Route26HealSpeechHouse.asm
+++ b/maps/Route26HealSpeechHouse.asm
@@ -16,7 +16,7 @@ TeacherScript_0x7b125:
 	closetext
 	special Special_FadeBlackQuickly
 	special ReloadSpritesNoPalettes
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	playmusic MUSIC_HEAL
 	special HealParty
 	pause 60

--- a/maps/Route27SandstormHouse.asm
+++ b/maps/Route27SandstormHouse.asm
@@ -13,7 +13,7 @@ SandstormHouseWoman:
 	opentext
 	checkevent EVENT_GOT_TM37_SANDSTORM
 	iftrue .AlreadyGotItem
-	special GetFirstPokemonHappiness
+	special Special_GetFirstPokemonHappiness
 	writetext SandstormHouseWomanText1
 	buttonsound
 	if_greater_than $95, .Loyal

--- a/maps/Route29.asm
+++ b/maps/Route29.asm
@@ -324,7 +324,7 @@ Route29FisherText:
 	line "progress."
 	done
 
-; possibly unused
+; unused
 Text_WaitingForDay:
 	text "I'm waiting for"
 	line "#MON that"

--- a/maps/Route32.asm
+++ b/maps/Route32.asm
@@ -59,7 +59,7 @@ Route32CooltrainerMContinueScene:
 	closetext
 	end
 
-.Unused:
+.Unreferenced:
 	writetext Route32CooltrainerMText_UnusedSproutTower
 	waitbutton
 	closetext
@@ -839,7 +839,7 @@ BirdKeeperPeterAfterText:
 	cont "in VIOLET CITY."
 	done
 
-; possibly unused
+; unused
 Route32UnusedText:
 	text "The fishermen"
 	line "yelled at me for"

--- a/maps/Route35NationalParkGate.asm
+++ b/maps/Route35NationalParkGate.asm
@@ -74,7 +74,7 @@ Route35NationalParkGate_MapScriptHeader:
 	closetext
 	scall Route35NationalParkGate_EnterContest
 	playsound SFX_ENTER_DOOR
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	warpfacing UP, NATIONAL_PARK_BUG_CONTEST, $a, $2f
 	end
@@ -95,7 +95,7 @@ OfficerScript_0x6a204:
 	iffalse Route35NationalParkGate_DeclinedToParticipate
 	checkcode VAR_PARTYCOUNT
 	if_greater_than $1, Route35NationalParkGate_LeaveTheRestBehind
-	special ContestDropOffMons
+	special Special_ContestDropOffMons
 	clearevent EVENT_LEFT_MONS_WITH_CONTEST_OFFICER
 Route35NationalParkGate_OkayToProceed:
 	setflag ENGINE_BUG_CONTEST_TIMER
@@ -111,7 +111,7 @@ Route35NationalParkGate_OkayToProceed:
 	special Special_GiveParkBalls
 	scall Route35NationalParkGate_EnterContest
 	playsound SFX_ENTER_DOOR
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	special Special_SelectRandomBugContestContestants
 	warpfacing UP, NATIONAL_PARK_BUG_CONTEST, $a, $2f
@@ -134,12 +134,12 @@ Route35NationalParkGate_LeaveTheRestBehind:
 	if_equal 0, Route35NationalParkGate_NoRoomInBox
 
 Route35NationalParkGate_LessThanFullParty: ; 6a27d
-	special CheckFirstMonIsEgg
+	special Special_CheckFirstMonIsEgg
 	if_equal $1, Route35NationalParkGate_FirstMonIsEgg
 	writetext UnknownText_0x6a4c6
 	yesorno
 	iffalse Route35NationalParkGate_DeclinedToLeaveMonsBehind
-	special ContestDropOffMons
+	special Special_ContestDropOffMons
 	iftrue Route35NationalParkGate_FirstMonIsFainted
 	setevent EVENT_LEFT_MONS_WITH_CONTEST_OFFICER
 	writetext UnknownText_0x6a537

--- a/maps/Route36.asm
+++ b/maps/Route36.asm
@@ -95,7 +95,7 @@ DidntCatchSudowoodo:
 	disappear ROUTE36_WEIRD_TREE
 	variablesprite SPRITE_WEIRD_TREE, SPRITE_TWIN
 	special Special_MapCallbackSprites_LoadUsedSpritesGFX
-	special RefreshSprites
+	special Special_RefreshSprites
 	end
 
 Route36FloriaScript:

--- a/maps/Route36.asm
+++ b/maps/Route36.asm
@@ -94,7 +94,7 @@ DidntCatchSudowoodo:
 	applymovement ROUTE36_WEIRD_TREE, WeirdTreeMovement_Flee
 	disappear ROUTE36_WEIRD_TREE
 	variablesprite SPRITE_WEIRD_TREE, SPRITE_TWIN
-	special MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_MapCallbackSprites_LoadUsedSpritesGFX
 	special RefreshSprites
 	end
 

--- a/maps/Route36.asm
+++ b/maps/Route36.asm
@@ -94,7 +94,7 @@ DidntCatchSudowoodo:
 	applymovement ROUTE36_WEIRD_TREE, WeirdTreeMovement_Flee
 	disappear ROUTE36_WEIRD_TREE
 	variablesprite SPRITE_WEIRD_TREE, SPRITE_TWIN
-	special Special_MapCallbackSprites_LoadUsedSpritesGFX
+	special Special_LoadUsedSpritesGFX
 	special Special_RefreshSprites
 	end
 

--- a/maps/Route36NationalParkGate.asm
+++ b/maps/Route36NationalParkGate.asm
@@ -91,7 +91,7 @@ Route36NationalParkGate_MapScriptHeader:
 	closetext
 	spriteface PLAYER, LEFT
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	warpfacing LEFT, NATIONAL_PARK_BUG_CONTEST, $21, $12
 	end
@@ -156,7 +156,7 @@ Route36OfficerScriptContest:
 	iffalse .DecidedNotToJoinContest
 	checkcode VAR_PARTYCOUNT
 	if_greater_than $1, .LeaveMonsWithOfficer
-	special ContestDropOffMons
+	special Special_ContestDropOffMons
 	clearevent EVENT_LEFT_MONS_WITH_CONTEST_OFFICER
 .ResumeStartingContest:
 	setflag ENGINE_BUG_CONTEST_TIMER
@@ -174,7 +174,7 @@ Route36OfficerScriptContest:
 	special Special_GiveParkBalls
 	spriteface PLAYER, LEFT
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	special Special_SelectRandomBugContestContestants
 	warpfacing LEFT, NATIONAL_PARK_BUG_CONTEST, $21, $12
@@ -186,12 +186,12 @@ Route36OfficerScriptContest:
 	checkcode VAR_BOXSPACE
 	if_equal $0, .BoxFull
 .ContinueLeavingMons:
-	special CheckFirstMonIsEgg
+	special Special_CheckFirstMonIsEgg
 	if_equal $1, .FirstMonIsEgg
 	writetext UnknownText_0x6afb0
 	yesorno
 	iffalse .RefusedToLeaveMons
-	special ContestDropOffMons
+	special Special_ContestDropOffMons
 	iftrue .FirstMonIsFainted
 	setevent EVENT_LEFT_MONS_WITH_CONTEST_OFFICER
 	writetext UnknownText_0x6b021

--- a/maps/Route36NationalParkGate.asm
+++ b/maps/Route36NationalParkGate.asm
@@ -799,7 +799,6 @@ UnknownText_0x6b7af:
 ; This text is unused and unreferenced in the final game.
 ; The tree Pokémon is Sudowoodo.
 ; The Silph Scope 2 was later reworked into the Squirtbottle.
-
 UnusedSudowoodoText:
 	text "I hear there's a"
 	line "#MON that looks"

--- a/maps/Route36NationalParkGate.asm
+++ b/maps/Route36NationalParkGate.asm
@@ -76,7 +76,7 @@ Route36NationalParkGate_MapScriptHeader:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	scall .CopyContestants
 	disappear ROUTE36NATIONALPARKGATE_OFFICER1
 	appear ROUTE36NATIONALPARKGATE_OFFICER2

--- a/maps/Route39Barn.asm
+++ b/maps/Route39Barn.asm
@@ -52,7 +52,7 @@ MooMoo:
 	iftrue .HappyCow
 	writetext Text_WeakMoo
 	writebyte MILTANK
-	special PlaySlowCry
+	special Special_PlaySlowCry
 	buttonsound
 	writetext Text_ItsCryIsWeak
 	checkevent EVENT_TALKED_TO_FARMER_ABOUT_MOOMOO

--- a/maps/Route39Farmhouse.asm
+++ b/maps/Route39Farmhouse.asm
@@ -24,7 +24,7 @@ FarmerMScript_SellMilk:
 	checkitem MOOMOO_MILK
 	iftrue FarmerMScript_Milking
 	writetext FarmerMText_BuyMilk
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	yesorno
 	iffalse FarmerMScript_NoSale
 	checkmoney $0, 500
@@ -32,7 +32,7 @@ FarmerMScript_SellMilk:
 	giveitem MOOMOO_MILK
 	iffalse FarmerMScript_NoRoom
 	takemoney $0, 500
-	special PlaceMoneyTopRight
+	special Special_PlaceMoneyTopRight
 	waitsfx
 	playsound SFX_TRANSACTION
 	writetext FarmerMText_GotMilk

--- a/maps/Route40.asm
+++ b/maps/Route40.asm
@@ -79,7 +79,7 @@ Route40Lass1Script:
 	jumptextfaceplayer Route40Lass1Text
 
 PokefanMScript_0x1a61c7:
-	special Mobile_DummyReturnFalse
+	special Special_Mobile_DummyReturnFalse
 	iftrue .mobile
 	jumptextfaceplayer UnknownText_0x1a646a
 

--- a/maps/RuinsOfAlphAerodactylChamber.asm
+++ b/maps/RuinsOfAlphAerodactylChamber.asm
@@ -114,8 +114,8 @@ UnknownText_0x58e4f:
 	line "on the walls…"
 	done
 
-; possibly unused.. again?
-UnknownText_0x58e70:
+; unused
+UnusedText_0x58e70:
 	text "It's UNOWN text!"
 	done
 

--- a/maps/RuinsOfAlphHoOhChamber.asm
+++ b/maps/RuinsOfAlphHoOhChamber.asm
@@ -115,8 +115,8 @@ UnknownText_0x58612:
 	line "on the walls…"
 	done
 
-; possibly unused
-UnknownText_0x58633:
+; unused
+UnusedText_0x58633:
 	text "It's UNOWN text!"
 	done
 

--- a/maps/RuinsOfAlphHoOhChamber.asm
+++ b/maps/RuinsOfAlphHoOhChamber.asm
@@ -9,7 +9,7 @@ RuinsOfAlphHoOhChamber_MapScriptHeader:
 	dbw MAPCALLBACK_TILES, .HiddenDoors
 
 .CheckWall:
-	special SpecialHoOhChamber
+	special Special_HoOhChamber
 	checkevent EVENT_WALL_OPENED_IN_HO_OH_CHAMBER
 	iftrue .OpenWall
 	end

--- a/maps/RuinsOfAlphKabutoChamber.asm
+++ b/maps/RuinsOfAlphKabutoChamber.asm
@@ -202,8 +202,8 @@ UnknownText_0x589b8:
 	cont "this wall here…"
 	done
 
-; possibly unused
-UnknownText_0x58a03:
+; unused
+UnusedText_0x58a03:
 	text "The patterns on"
 	line "the wall appear to"
 	cont "be words!"
@@ -226,8 +226,8 @@ UnknownText_0x58aa7:
 	line "on the walls…"
 	done
 
-; possibly unused
-UnknownText_0x58ac8:
+; unused
+UnusedText_0x58ac8:
 	text "It's UNOWN text!"
 	done
 

--- a/maps/RuinsOfAlphOmanyteChamber.asm
+++ b/maps/RuinsOfAlphOmanyteChamber.asm
@@ -115,8 +115,8 @@ UnknownText_0x58c8e:
 	line "on the walls…"
 	done
 
-; possibly unused.. this again?
-UnknownText_0x58caf:
+; unused
+UnusedText_0x58caf:
 	text "It's UNOWN text!"
 	done
 

--- a/maps/RuinsOfAlphOmanyteChamber.asm
+++ b/maps/RuinsOfAlphOmanyteChamber.asm
@@ -9,7 +9,7 @@ RuinsOfAlphOmanyteChamber_MapScriptHeader:
 	dbw MAPCALLBACK_TILES, .HiddenDoors
 
 .CheckWall:
-	special SpecialOmanyteChamber
+	special Special_OmanyteChamber
 	checkevent EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER
 	iftrue .OpenWall
 	end

--- a/maps/RuinsOfAlphResearchCenter.asm
+++ b/maps/RuinsOfAlphResearchCenter.asm
@@ -169,8 +169,8 @@ UnknownScript_0x59260:
 	closetext
 	end
 
-UnknownScript_0x59269:
-	jumptext UnknownText_0x59848
+UnreferencedScript_0x59269:
+	jumptext UnusedText_0x59848
 
 MapRuinsOfAlphResearchCenterSignpost0Script:
 	jumptext UnknownText_0x59886
@@ -308,8 +308,8 @@ UnknownText_0x595cb:
 	cont "kinds of them…"
 	done
 
-; possibly unused
-UnknownText_0x59669:
+; unused
+UnusedText_0x59669:
 	text "We think something"
 	line "caused the cryptic"
 
@@ -320,8 +320,8 @@ UnknownText_0x59669:
 	line "studies on that."
 	done
 
-; possibly unused
-UnknownText_0x596d3:
+; unused
+UnusedText_0x596d3:
 	text "According to my"
 	line "research…"
 
@@ -374,8 +374,8 @@ UnknownText_0x5982d:
 	line "printed out."
 	done
 
-; possibly unused
-UnknownText_0x59848:
+; unused
+UnusedText_0x59848:
 	text "It's a photo of"
 	line "the RESEARCH"
 

--- a/maps/SaffronPokecenter1F.asm
+++ b/maps/SaffronPokecenter1F.asm
@@ -15,7 +15,7 @@ NurseScript_0x18a47d:
 	jumpstd pokecenternurse
 
 TeacherScript_0x18a480:
-	special Mobile_DummyReturnFalse
+	special Special_Mobile_DummyReturnFalse
 	iftrue .mobile
 	jumptextfaceplayer UnknownText_0x18a4a3
 

--- a/maps/SilverCaveRoom3.asm
+++ b/maps/SilverCaveRoom3.asm
@@ -26,7 +26,7 @@ Red:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear SILVERCAVEROOM3_RED
 	pause 15
 	special Special_FadeInQuickly

--- a/maps/SlowpokeWellB1F.asm
+++ b/maps/SlowpokeWellB1F.asm
@@ -39,7 +39,7 @@ TrainerGruntM1:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear SLOWPOKEWELLB1F_ROCKET1
 	disappear SLOWPOKEWELLB1F_ROCKET2
 	disappear SLOWPOKEWELLB1F_ROCKET3

--- a/maps/SlowpokeWellB1F.asm
+++ b/maps/SlowpokeWellB1F.asm
@@ -67,7 +67,7 @@ TrainerGruntM1:
 	clearevent EVENT_AZALEA_TOWN_SLOWPOKES
 	clearevent EVENT_KURTS_HOUSE_SLOWPOKE
 	clearevent EVENT_KURTS_HOUSE_KURT_1
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	special HealParty
 	pause 15
 	warp KURTS_HOUSE, $3, $3

--- a/maps/SproutTower3F.asm
+++ b/maps/SproutTower3F.asm
@@ -55,7 +55,7 @@ UnknownScript_0x184947:
 	closetext
 	playsound SFX_WARP_TO
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear SPROUTTOWER3F_SILVER
 	waitsfx
 	special Special_FadeInQuickly

--- a/maps/TeamRocketBaseB1F.asm
+++ b/maps/TeamRocketBaseB1F.asm
@@ -448,9 +448,9 @@ ExplodingTrap22:
 	end
 
 VoltorbExplodingTrap:
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	cry VOLTORB
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	setlasttalked -1
 	writecode VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon VOLTORB, 23
@@ -458,9 +458,9 @@ VoltorbExplodingTrap:
 	end
 
 GeodudeExplodingTrap:
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	cry GEODUDE
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	setlasttalked -1
 	writecode VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon GEODUDE, 21
@@ -468,9 +468,9 @@ GeodudeExplodingTrap:
 	end
 
 KoffingExplodingTrap:
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	cry KOFFING
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	setlasttalked -1
 	writecode VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon KOFFING, 21

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -166,11 +166,11 @@ LanceHealsCommon:
 	writetext LanceHealsText1
 	waitbutton
 	closetext
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	special TrainerRankings_Healings
 	playsound SFX_FULL_HEAL
 	special HealParty
-	special FadeInPalettes
+	special Special_FadeInPalettes
 	opentext
 	writetext LanceHealsText2
 	waitbutton

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -110,7 +110,7 @@ UnknownScript_0x6cfac:
 	waitbutton
 	closetext
 	special Special_FadeBlackQuickly
-	special Special_ReloadSpritesNoPalettes
+	special ReloadSpritesNoPalettes
 	disappear TEAMROCKETBASEB2F_ROCKET1
 	disappear TEAMROCKETBASEB2F_ROCKET_GIRL
 	disappear TEAMROCKETBASEB2F_ROCKET2

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -167,7 +167,7 @@ LanceHealsCommon:
 	waitbutton
 	closetext
 	special Special_FadeOutPalettes
-	special Special_TrainerRankings_Healings
+	special Special_StubbedTrainerRankings_Healings
 	playsound SFX_FULL_HEAL
 	special HealParty
 	special Special_FadeInPalettes

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -167,7 +167,7 @@ LanceHealsCommon:
 	waitbutton
 	closetext
 	special Special_FadeOutPalettes
-	special TrainerRankings_Healings
+	special Special_TrainerRankings_Healings
 	playsound SFX_FULL_HEAL
 	special HealParty
 	special Special_FadeInPalettes

--- a/maps/TinTower1F.asm
+++ b/maps/TinTower1F.asm
@@ -33,7 +33,7 @@ TinTower1F_MapScriptHeader:
 	iftrue .GotRainbowWing
 	checkevent EVENT_BEAT_ELITE_FOUR
 	iffalse .FaceBeasts
-	special SpecialBeastsCheck
+	special Special_BeastsCheck
 	iffalse .FaceBeasts
 	clearevent EVENT_TIN_TOWER_1F_WISE_TRIO_2
 	setevent EVENT_TIN_TOWER_1F_WISE_TRIO_1
@@ -49,7 +49,7 @@ TinTower1F_MapScriptHeader:
 	iftrue .FoughtSuicune
 	appear TINTOWER1F_SUICUNE
 	writebyte RAIKOU
-	special SpecialMonCheck
+	special Special_MonCheck
 	iftrue .NoRaikou
 	appear TINTOWER1F_RAIKOU
 	jump .CheckEntei
@@ -58,7 +58,7 @@ TinTower1F_MapScriptHeader:
 	disappear TINTOWER1F_RAIKOU
 .CheckEntei:
 	writebyte ENTEI
-	special SpecialMonCheck
+	special Special_MonCheck
 	iftrue .NoEntei
 	appear TINTOWER1F_ENTEI
 	jump .BeastsDone
@@ -87,7 +87,7 @@ TinTower1F_MapScriptHeader:
 	applymovement PLAYER, TinTowerPlayerMovement1
 	pause 15
 	writebyte RAIKOU
-	special SpecialMonCheck
+	special Special_MonCheck
 	iftrue .Next1 ; if player caught Raikou, he doesn't appear in Tin Tower
 	applymovement TINTOWER1F_RAIKOU, TinTowerRaikouMovement1
 	spriteface PLAYER, LEFT
@@ -100,7 +100,7 @@ TinTower1F_MapScriptHeader:
 	waitsfx
 .Next1:
 	writebyte ENTEI
-	special SpecialMonCheck
+	special Special_MonCheck
 	iftrue .Next2 ; if player caught Entei, he doesn't appear in Tin Tower
 	applymovement TINTOWER1F_ENTEI, TinTowerEnteiMovement1
 	spriteface PLAYER, RIGHT

--- a/maps/TrainerHouseB1F.asm
+++ b/maps/TrainerHouseB1F.asm
@@ -20,7 +20,7 @@ TrainerHouseReceptionistScript:
 	iftrue .FoughtTooManyTimes
 	writetext TrainerHouseB1FIntroText
 	buttonsound
-	special SpecialTrainerHouse
+	special Special_TrainerHouse
 	iffalse .GetCal3Name
 	trainertotext CAL, CAL2, $0
 	jump .GotName
@@ -42,7 +42,7 @@ TrainerHouseReceptionistScript:
 	writetext TrainerHouseB1FCalBeforeText
 	waitbutton
 	closetext
-	special SpecialTrainerHouse
+	special Special_TrainerHouse
 	iffalse .NoSpecialBattle
 	winlosstext TrainerHouseB1FCalBeatenText, 0
 	setlasttalked TRAINERHOUSEB1F_CHRIS

--- a/maps/VermilionCity.asm
+++ b/maps/VermilionCity.asm
@@ -42,7 +42,7 @@ VermilionCitySuperNerdScript:
 
 VermilionSnorlax:
 	opentext
-	special SpecialSnorlaxAwake
+	special Special_SnorlaxAwake
 	iftrue UnknownScript_0x1aa9ab
 	writetext UnknownText_0x1aab64
 	waitbutton

--- a/maps/VermilionPort.asm
+++ b/maps/VermilionPort.asm
@@ -52,7 +52,7 @@ SailorScript_0x74dc4:
 	waitsfx
 	applymovement PLAYER, MovementData_0x74ef1
 	playsound SFX_EXIT_BUILDING
-	special FadeOutPalettes
+	special Special_FadeOutPalettes
 	waitsfx
 	setevent EVENT_FAST_SHIP_PASSENGERS_EASTBOUND
 	clearevent EVENT_FAST_SHIP_PASSENGERS_WESTBOUND

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -243,7 +243,7 @@ RunBattleTowerTrainer: ; 17024d
 
 	xor a
 	ld [wLinkMode], a
-	farcall Special_TrainerRankings_Healings
+	farcall Special_StubbedTrainerRankings_Healings
 	farcall HealParty
 	call ReadBTTrainerParty
 	call Clears5_a89a

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -248,7 +248,7 @@ RunBattleTowerTrainer: ; 17024d
 	call ReadBTTrainerParty
 	call Clears5_a89a
 
-	predef StartBattle
+	predef Predef_StartBattle
 
 	farcall LoadPokemonData
 	farcall HealParty
@@ -484,7 +484,7 @@ endr
 	ld hl, MON_STAT_EXP - 1
 	add hl, bc
 	ld b, $1
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop de
 	pop hl
 	dec de

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -654,8 +654,7 @@ Unreferenced_Function1704ca: ; 1704ca
 	ret
 ; 1704e1
 
-Special_Function1704e1: ; 1704e1
-; unreferenced special
+UnusedSpecial_Function1704e1: ; 1704e1
 	call SpeechTextBox
 	call FadeToMenu
 	call InitBattleTowerChallengeRAM

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -1,11 +1,11 @@
-BattleTowerRoomMenu: ; 1700b0
+Special_BattleTowerRoomMenu: ; 1700b0
 ; special
 	call InitBattleTowerChallengeRAM
 	farcall _BattleTowerRoomMenu
 	ret
 ; 1700ba
 
-Function1700ba: ; 1700ba
+Special_Function1700ba: ; 1700ba
 	call InitBattleTowerChallengeRAM
 	farcall Function11811a
 	ret
@@ -53,7 +53,7 @@ Function1700c4: ; 1700c4
 	ret
 ; 170114
 
-Function170114: ; 170114
+Special_Function170114: ; 170114
 	call InitBattleTowerChallengeRAM
 	call .Function170121
 	farcall Function11805f
@@ -182,14 +182,14 @@ Function170139: ; 170139
 	ret
 ; 170215
 
-BattleTowerBattle: ; 170215
+Special_BattleTowerBattle: ; 170215
 	xor a
 	ld [wBattleTowerBattleEnded], a
 	call _BattleTowerBattle
 	ret
 ; 17021d
 
-EmptySpecial_17021d: ; 17021d
+DummySpecial17021d: ; 17021d
 	ret
 ; 17021e
 
@@ -243,7 +243,7 @@ RunBattleTowerTrainer: ; 17024d
 
 	xor a
 	ld [wLinkMode], a
-	farcall TrainerRankings_Healings
+	farcall Special_TrainerRankings_Healings
 	farcall HealParty
 	call ReadBTTrainerParty
 	call Clears5_a89a
@@ -654,7 +654,7 @@ Unreferenced_Function1704ca: ; 1704ca
 	ret
 ; 1704e1
 
-Function1704e1: ; 1704e1
+Special_Function1704e1: ; 1704e1
 ; unreferenced special
 	call SpeechTextBox
 	call FadeToMenu
@@ -936,7 +936,7 @@ Function1704e1: ; 1704e1
 	db "れきだいりーダーいちらん@"
 ; 170687
 
-BattleTowerAction: ; 170687
+Special_BattleTowerAction: ; 170687
 	ld a, [ScriptVar]
 	ld e, a
 	ld d, 0
@@ -1639,7 +1639,7 @@ BattleTowerAction_UbersCheck: ; 170b16 (5c:4b16) BattleTowerAction $19
 	ld [ScriptVar], a
 	ret
 
-Function_LoadOpponentTrainerAndPokemonsWithOTSprite: ; 0x170b44
+Special_LoadOpponentTrainerAndPokemonWithOTSprite: ; 0x170b44
 	farcall Function_LoadOpponentTrainerAndPokemons
 	ld a, [rSVBK]
 	push af
@@ -1752,11 +1752,11 @@ Function_LoadOpponentTrainerAndPokemonsWithOTSprite: ; 0x170b44
 	db SPRITE_OFFICER
 	db SPRITE_ROCKET_GIRL
 
-ret_170bd2: ; 170bd2
+DummySpecial170bd2: ; 170bd2
 	ret
 ; 170bd3
 
-SpecialCheckForBattleTowerRules: ; 170bd3
+Special_CheckForBattleTowerRules: ; 170bd3
 	farcall CheckForBattleTowerRules
 	jr c, .asm_170bde
 	xor a

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -189,7 +189,7 @@ Special_BattleTowerBattle: ; 170215
 	ret
 ; 17021d
 
-DummySpecial17021d: ; 17021d
+DummySpecial_17021d: ; 17021d
 	ret
 ; 17021e
 
@@ -1751,7 +1751,7 @@ Special_LoadOpponentTrainerAndPokemonWithOTSprite: ; 0x170b44
 	db SPRITE_OFFICER
 	db SPRITE_ROCKET_GIRL
 
-DummySpecial170bd2: ; 170bd2
+DummySpecial_170bd2: ; 170bd2
 	ret
 ; 170bd3
 

--- a/mobile/battle_tower_5c.asm
+++ b/mobile/battle_tower_5c.asm
@@ -634,8 +634,7 @@ SkipBattleTowerTrainer: ; 1704c9
 	ret
 ; 1704ca
 
-Function1704ca: ; 1704ca
-; unreferenced mobile function
+Unreferenced_Function1704ca: ; 1704ca
 	ld a, [$be46]
 	cp $7
 	jr c, .asm_1704d3

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -33,8 +33,7 @@ Function11c075: ; 11c075
 	ret
 ; 11c082
 
-Function11c082: ; 11c082
-; XXX
+Unreferenced_Function11c082: ; 11c082
 	push de
 	ld a, c
 	call Function11c254

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -274,7 +274,7 @@ CopyMobileEZChatToC608: ; 11c156
 	jr .copy_string
 ; 11c1ab
 
-Function11c1ab: ; 11c1ab
+Special_Function11c1ab: ; 11c1ab
 	ld a, [hInMenu]
 	push af
 	ld a, $1

--- a/mobile/mobile_12.asm
+++ b/mobile/mobile_12.asm
@@ -1621,9 +1621,8 @@ Function48c63: ; 48c63
 	ret
 ; 48c8e
 
-Function48c8e: ; 48c8e
-; unreferenced
-	ld hl, $d02a
+Unreferenced_Function48c8e: ; 48c8e
+	ld hl, wd019 + $11
 	ld d, h
 	ld e, l
 	farcall Function48c63

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -159,7 +159,7 @@ MobileCheckOwnMonAnywhere: ; 4a843
 	ret
 ; 4a927
 
-FindItemInPCOrBag: ; 4a927
+UnusedSpecial_FindItemInPCOrBag: ; 4a927
 	ld a, [ScriptVar]
 	ld [CurItem], a
 	ld hl, PCItems

--- a/mobile/mobile_22.asm
+++ b/mobile/mobile_22.asm
@@ -1228,7 +1228,7 @@ Function897af: ; 897af
 	xor a
 	ld [CurPartySpecies], a
 	ld de, vTiles2 tile $37
-	farcall GetTrainerPic
+	farcall Predef_GetTrainerPic
 	pop bc
 	ret
 ; 897d5
@@ -1260,7 +1260,7 @@ Function897d5: ; 897d5
 	ld [hGraphicStartTile], a
 	hlcoord 12, 3
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	call Function8963d
 	pop bc
 	ret

--- a/mobile/mobile_22_2.asm
+++ b/mobile/mobile_22_2.asm
@@ -1,6 +1,6 @@
 Function8b342:: ; 8b342
 ; Loads the secondary map header pointer, then runs through a
-; dw with three dummy functions.  Spends a lot of energy
+; dw with three dummy functions. Spends a lot of energy
 ; doing pretty much nothing.
 	call GetSecondaryMapHeaderPointer
 	ld d, h
@@ -26,15 +26,15 @@ Function8b342:: ; 8b342
 ; 8b35a
 
 .zero ; 8b35a
-	mobile
+	ret
 ; 8b35b
 
 .one ; 8b35b
-	mobile
+	ret
 ; 8b35c
 
 .two ; 8b35c
-	mobile
+	ret
 ; 8b35d
 
 Function8b35d: ; 8b35d

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -318,7 +318,7 @@ Function10016f: ; 10016f
 Function10020b: ; 10020b
 	xor a
 	ld [wc303], a
-	farcall FadeOutPalettes
+	farcall Special_FadeOutPalettes
 	farcall Function106464
 	call HideSprites
 	call DelayFrame

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -3093,7 +3093,7 @@ Function1013dd: ; 1013dd
 	ret
 ; 1013e1
 
-Function1013e1: ; 1013e1 ; unreferenced
+Unreferenced_Function1013e1: ; 1013e1 
 	push de
 	inc de
 	ld b, a
@@ -3130,7 +3130,7 @@ Function1013f5: ; 1013f5
 	ret
 ; 101400
 
-Function101400: ; 101400 ; unreferenced
+Unreferenced_Function101400: ; 101400 
 	ld a, [de]
 	inc de
 	cp [hl]
@@ -3318,7 +3318,7 @@ Function101507: ; 101507
 	ret
 ; 10151d
 
-Function10151d: ; 10151d ; unreferenced
+Unreferenced_Function10151d: ; 10151d 
 	ld a, $34
 	call Function3e32
 	ld a, [wMobileCommsJumptableIndex]
@@ -3513,7 +3513,7 @@ Function101663: ; 101663
 	ret
 ; 101674
 
-Function101674: ; 101674 ; unreferenced
+Unreferenced_Function101674: ; 101674 
 	ld a, $05
 	ld hl, w5_dc00
 	call Function101635
@@ -4402,7 +4402,7 @@ Function101cbc: ; 101cbc
 	ret
 ; 101cc2
 
-Function101cc2: ; 101cc2 ; unreferenced
+Unreferenced_Function101cc2: ; 101cc2 
 	ld a, $02
 	ld [wcd2b], a
 	ret
@@ -4683,7 +4683,7 @@ Function101e64: ; 101e64
 	ret
 ; 101e82
 
-Function101e82: ; 101e82 ; unreferenced
+Unreferenced_Function101e82: ; 101e82 
 	call Function101ecc
 	ld a, [wMobileCommsJumptableIndex]
 	inc a
@@ -4691,7 +4691,7 @@ Function101e82: ; 101e82 ; unreferenced
 	ret
 ; 101e8d
 
-Function101e8d: ; 101e8d ; unreferenced
+Unreferenced_Function101e8d: ; 101e8d 
 	call Function101ed3
 	ld a, [wMobileCommsJumptableIndex]
 	inc a
@@ -6506,7 +6506,7 @@ Function102b4e: ; 102b4e
 	ret
 ; 102b68
 
-Function102b68: ; 102b68 ; unreferenced
+Unreferenced_Function102b68: ; 102b68 
 	xor a
 	ld hl, wWindowStackPointer
 	ld bc, $10

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -1985,7 +1985,7 @@ Function100c74: ; 100c74
 	ld a, SCREEN_WIDTH * 2
 	ld [Buffer1], a
 	hlcoord 2, 10
-	predef ListMoves
+	predef Predef_ListMoves
 	ret
 ; 100c98
 
@@ -6796,7 +6796,7 @@ Function102d48: ; 102d48
 	ld bc, PARTYMON_STRUCT_LENGTH
 	ld hl, PartyMon1DVs
 	call AddNTimes
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	farcall UpdateUnownDex
 	ld a, [wFirstUnownSeen]
 	and a

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -40,7 +40,7 @@ Function100022: ; 100022
 	ld a, b
 	ld [wcd24], a
 	farcall Function10127e
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464 ; load broken gfx
 	farcall Function11615a ; init RAM
 	ld hl, VramState
@@ -3077,7 +3077,7 @@ Function1013aa: ; 1013aa
 
 Function1013c0: ; 1013c0
 	farcall BlankScreen
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	call FinishExitMenu
 	ret
@@ -5454,7 +5454,7 @@ Function102423: ; 102423
 	call Function102921
 	ret nc
 	farcall SaveAfterLinkTrade
-	farcall TrainerRankings_Trades
+	farcall StubbedTrainerRankings_Trades
 	farcall BackupMobileEventIndex
 	ld hl, wcd4b
 	set 1, [hl]

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -2804,7 +2804,7 @@ LoadSelectedPartiesForColosseum: ; 1010f2
 	ret
 ; 1011f1
 
-Function1011f1: ; 1011f1
+Special_Function1011f1: ; 1011f1
 	ld a, $04
 	call GetSRAMBank
 	ld a, [$a60c]
@@ -2828,20 +2828,20 @@ Function1011f1: ; 1011f1
 	ret
 ; 101220
 
-Function101220: ; 101220
+Special_Function101220: ; 101220
 	xor a
 	ld [wLinkMode], a
 	ret
 ; 101225
 
-Function101225: ; 101225
+Special_Function101225: ; 101225
 	ld d, 1
 	ld e, BANK(Jumptable_101297)
 	ld bc, Jumptable_101297
 	call Function100000
 	jr Function10123d
 
-Function101231: ; 101231
+Special_Function101231: ; 101231
 	ld d, 2
 	ld e, BANK(Jumptable_101297)
 	ld bc, Jumptable_101297
@@ -2872,7 +2872,7 @@ Function101251: ; 101251
 	call Function1021e0
 	call Function1020ea
 	ret c
-	call Function102142
+	call Special_Function102142
 	ret
 ; 101265
 
@@ -5025,7 +5025,7 @@ Function102112: ; 102112
 	ret
 ; 102142
 
-Function102142: ; 102142
+Special_Function102142: ; 102142
 	call Function10218d
 	call Function102180
 	ld hl, UnknownText_0x1021d1
@@ -7724,9 +7724,9 @@ Unknown_1035d7: ; 1035d7
 	dw Unknown_103608
 	dw Unknown_103608
 	dw Unknown_1035fe
-	dw AskMobileOrCable
-	dw AskMobileOrCable
-	dw AskMobileOrCable
+	dw Special_AskMobileOrCable
+	dw Special_AskMobileOrCable
+	dw Special_AskMobileOrCable
 
 Unknown_1035e7: ; 1035e7
 	dwcoord 0, 6
@@ -7757,7 +7757,7 @@ Unknown_103608: ; 103608
 	db 2, 2, 3
 ; 103612
 
-AskMobileOrCable: ; 103612
+Special_AskMobileOrCable: ; 103612
 	ld hl, MenuDataHeader_103640
 	call LoadMenuDataHeader
 	ld a, [wMobileOrCable_LastSelection]
@@ -7814,7 +7814,7 @@ Function103654: ; 103654
 	ret
 ; 10366e
 
-Mobile_SelectThreeMons: ; 10366e
+Special_Mobile_SelectThreeMons: ; 10366e
 	farcall Mobile_AlwaysReturnNotCarry
 	bit 7, c
 	jr z, .asm_10369b
@@ -7983,7 +7983,7 @@ UnknownText_0x10377b: ; 0x10377b
 	db "@"
 ; 0x103780
 
-Function103780: ; 103780
+Special_Function103780: ; 103780
 	ld a, [wd265]
 	push af
 	call Function10378c
@@ -8025,7 +8025,7 @@ Function10378c: ; 10378c
 	ret
 ; 1037c2
 
-Function1037c2: ; 1037c2
+Special_Function1037c2: ; 1037c2
 	call Function103823
 	jr c, .nope
 	ld a, [wdc5f]
@@ -8051,7 +8051,7 @@ UnknownText_0x1037e6: ; 0x1037e6
 	db "@"
 ; 0x1037eb
 
-Function1037eb: ; 1037eb
+Special_Function1037eb: ; 1037eb
 	call Function103823
 	jr nc, .asm_103807
 	ld hl, UnknownText_0x103819
@@ -8106,7 +8106,7 @@ Function103823: ; 103823
 	ret
 ; 10383c
 
-Function10383c: ; 10383c
+Special_Function10383c: ; 10383c
 	ld a, $01
 	ld [wdc60], a
 	xor a
@@ -8139,7 +8139,7 @@ UnknownText_0x103876: ; 0x103876
 	db "@"
 ; 0x10387b
 
-Function10387b: ; 10387b
+Special_Function10387b: ; 10387b
 	farcall Mobile_AlwaysReturnNotCarry
 	bit 7, c
 	ret nz

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -244,8 +244,7 @@ TrainerRankings_StepCount: mobile ; 10602e (41:602e)
 	ld hl, sTrainerRankingStepCount
 	jp TrainerRankings_Increment4Byte
 
-; Unreferenced in English version.
-TrainerRankings_BattleTowerWins: mobile ; 106035
+Unreferenced_TrainerRankings_BattleTowerWins: mobile ; 106035
 	ld a, $5
 	call GetSRAMBank
 	ld a, [$aa8d]
@@ -520,8 +519,7 @@ RestoreMobileEventIndex: ; 10619d (41:619d)
 	ret
 ; 1061b3 (41:61b3)
 
-; Unreferenced in English version.
-VerifyTrainerRankingsChecksum: ; 1061b3
+Unreferenced_VerifyTrainerRankingsChecksum: ; 1061b3
 	call CalculateTrainerRankingsChecksum
 	ld hl, sTrainerRankingsChecksum
 	ld a, d

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -304,7 +304,7 @@ TrainerRankings_FruitPicked: mobile ; 10609b
 	ld hl, sTrainerRankingFruitPicked
 	jp TrainerRankings_Increment3Byte
 
-TrainerRankings_Healings: mobile ; 1060a2
+Special_TrainerRankings_Healings: mobile ; 1060a2
 	ld hl, sTrainerRankingHealings
 	jp TrainerRankings_Increment3Byte
 
@@ -773,7 +773,7 @@ endr
 
 ; functions related to the cable club and various NPC scripts referencing mobile communications
 
-Mobile_DummyReturnFalse: ; 10630f
+Special_Mobile_DummyReturnFalse: ; 10630f
 	xor a
 	ld [ScriptVar], a
 	ret
@@ -798,7 +798,7 @@ Mobile_AlwaysReturnNotCarry: ; 10632f
 	or a
 	ret
 
-Function106331: ; 106331 - called by Mobile_DummyReturnFalse in Crystal-J
+Function106331: ; 106331 - called by Special_Mobile_DummyReturnFalse in Crystal-J
 	; check ~[4:b000] == [7:a800]
 	ld a, $4
 	call GetSRAMBank

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -2,7 +2,8 @@
 ; which were used for Trainer Rankings in Pokémon News.
 
 ; Copies certain values at the time the player enters the Hall of Fame.
-TrainerRankings_HallOfFame2:: mobile ; 0x105ef6
+StubbedTrainerRankings_HallOfFame2:: ; 0x105ef6
+	ret
 	ld a, BANK(sTrainerRankingGameTimeHOF)
 	call GetSRAMBank
 
@@ -33,7 +34,8 @@ TrainerRankings_HallOfFame2:: mobile ; 0x105ef6
 	ret
 ; 105f33
 
-TrainerRankings_MagikarpLength: mobile ; 105f33
+StubbedTrainerRankings_MagikarpLength: ; 105f33
+	ret
 	ld a, BANK(sTrainerRankingLongestMagikarp)
 	call GetSRAMBank
 	ld de, Buffer1
@@ -101,7 +103,8 @@ TrainerRankings_MagikarpLength: mobile ; 105f33
 	ret
 ; 105f79
 
-TrainerRankings_BugContestScore: mobile ; 105f79
+StubbedTrainerRankings_BugContestScore: ; 105f79
+	ret
 	ld a, BANK(sTrainerRankingBugContestScore)
 	call GetSRAMBank
 	ld a, [hProduct]
@@ -130,7 +133,8 @@ TrainerRankings_BugContestScore: mobile ; 105f79
 	ret
 ; 105f9f
 
-TrainerRankings_AddToSlotsWinStreak: mobile ; 105f9f
+StubbedTrainerRankings_AddToSlotsWinStreak: ; 105f9f
+	ret
 	ld a, BANK(sTrainerRankingCurrentSlotsStreak)
 	call GetSRAMBank
 
@@ -170,7 +174,8 @@ TrainerRankings_AddToSlotsWinStreak: mobile ; 105f9f
 	ret
 ; 105fd0
 
-TrainerRankings_EndSlotsWinStreak: mobile ; 105fd0
+StubbedTrainerRankings_EndSlotsWinStreak: ; 105fd0
+	ret
 	ld a, BANK(sTrainerRankingCurrentSlotsStreak)
 	call GetSRAMBank
 	ld hl, sTrainerRankingCurrentSlotsStreak
@@ -182,7 +187,8 @@ TrainerRankings_EndSlotsWinStreak: mobile ; 105fd0
 	ret
 ; 105fe3
 
-TrainerRankings_AddToSlotsPayouts: mobile ; 105fe3
+StubbedTrainerRankings_AddToSlotsPayouts: ; 105fe3
+	ret
 	ld a, BANK(sTrainerRankingTotalSlotsPayouts)
 	call GetSRAMBank
 	ld hl, sTrainerRankingTotalSlotsPayouts + 3
@@ -210,7 +216,8 @@ TrainerRankings_AddToSlotsPayouts: mobile ; 105fe3
 	ret
 ; 106008
 
-TrainerRankings_AddToBattlePayouts: mobile ; 106008
+StubbedTrainerRankings_AddToBattlePayouts: ; 106008
+	ret
 	ld a, BANK(sTrainerRankingTotalBattlePayouts)
 	call GetSRAMBank
 	ld hl, sTrainerRankingTotalBattlePayouts + 3
@@ -240,11 +247,13 @@ TrainerRankings_AddToBattlePayouts: mobile ; 106008
 	ret
 ; 10602e
 
-TrainerRankings_StepCount: mobile ; 10602e (41:602e)
+StubbedTrainerRankings_StepCount: ; 10602e (41:602e)
+	ret
 	ld hl, sTrainerRankingStepCount
-	jp TrainerRankings_Increment4Byte
+	jp StubbedTrainerRankings_Increment4Byte
 
-Unreferenced_TrainerRankings_BattleTowerWins: mobile ; 106035
+Unreferenced_StubbedTrainerRankings_BattleTowerWins: ; 106035
+	ret
 	ld a, $5
 	call GetSRAMBank
 	ld a, [$aa8d]
@@ -252,167 +261,196 @@ Unreferenced_TrainerRankings_BattleTowerWins: mobile ; 106035
 	call CloseSRAM
 	ret nz
 	ld hl, sTrainerRankingBattleTowerWins
-	jp TrainerRankings_Increment2Byte
+	jp StubbedTrainerRankings_Increment2Byte
 
-TrainerRankings_TMsHMsTaught: mobile ; 106049
+StubbedTrainerRankings_TMsHMsTaught: ; 106049
+	ret
 	ld hl, sTrainerRankingTMsHMsTaught
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Battles: mobile ; 106050
+StubbedTrainerRankings_Battles: ; 106050
+	ret
 	ld a, [BattleType]
 	cp BATTLETYPE_TUTORIAL ; Exclude the Dude’s tutorial battle
 	ret z
 	ld hl, sTrainerRankingBattles
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_WildBattles: mobile ; 10605d
+StubbedTrainerRankings_WildBattles: ; 10605d
+	ret
 	ld a, [BattleType]
 	cp BATTLETYPE_TUTORIAL ; Exclude the Dude’s tutorial battle
 	ret z
 	ld hl, sTrainerRankingWildBattles
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_TrainerBattles: mobile ; 10606a
+StubbedTrainerRankings_TrainerBattles: ; 10606a
+	ret
 	ld hl, sTrainerRankingTrainerBattles
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Unused1: mobile ; 106071
+StubbedTrainerRankings_Unused1: ; 106071
+	ret
 	ld hl, sTrainerRankingUnused1
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_HallOfFame:: mobile ; 0x106078
+StubbedTrainerRankings_HallOfFame:: ; 0x106078
+	ret
 	ld hl, sTrainerRankingHOFEntries
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_WildMonsCaught: mobile ; 10607f (41:607f)
+StubbedTrainerRankings_WildMonsCaught: ; 10607f (41:607f)
+	ret
 	ld hl, sTrainerRankingWildMonsCaught
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_HookedEncounters: mobile ; 106086
+StubbedTrainerRankings_HookedEncounters: ; 106086
+	ret
 	ld hl, sTrainerRankingHookedEncounters
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_EggsHatched: mobile ; 10608d (41:608d)
+StubbedTrainerRankings_EggsHatched: ; 10608d (41:608d)
+	ret
 	ld hl, sTrainerRankingEggsHatched
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_MonsEvolved: mobile ; 106094
+StubbedTrainerRankings_MonsEvolved: ; 106094
+	ret
 	ld hl, sTrainerRankingMonsEvolved
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_FruitPicked: mobile ; 10609b
+StubbedTrainerRankings_FruitPicked: ; 10609b
+	ret
 	ld hl, sTrainerRankingFruitPicked
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-Special_TrainerRankings_Healings: mobile ; 1060a2
+Special_StubbedTrainerRankings_Healings: ; 1060a2
+	ret
 	ld hl, sTrainerRankingHealings
-	jp TrainerRankings_Increment3Byte
+	jp StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_MysteryGift: mobile ; 1060a9 (41:60a9)
+StubbedTrainerRankings_MysteryGift: ; 1060a9 (41:60a9)
+	ret
 	ld hl, sTrainerRankingMysteryGift
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Trades: mobile ; 1060af
+StubbedTrainerRankings_Trades: ; 1060af
+	ret
 	ld hl, sTrainerRankingTrades
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Fly: mobile ; 1060b5
+StubbedTrainerRankings_Fly: ; 1060b5
+	ret
 	ld hl, sTrainerRankingFly
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Surf: mobile ; 1060bb
+StubbedTrainerRankings_Surf: ; 1060bb
+	ret
 	ld hl, sTrainerRankingSurf
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Waterfall: mobile ; 1060c1
+StubbedTrainerRankings_Waterfall: ; 1060c1
+	ret
 	ld hl, sTrainerRankingWaterfall
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_WhiteOuts: mobile ; 1060c7
+StubbedTrainerRankings_WhiteOuts: ; 1060c7
+	ret
 	ld hl, sTrainerRankingWhiteOuts
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_LuckyNumberShow: mobile ; 1060cd
+StubbedTrainerRankings_LuckyNumberShow: ; 1060cd
+	ret
 	ld hl, sTrainerRankingLuckyNumberShow
-	jr TrainerRankings_Increment2Byte
+	jr StubbedTrainerRankings_Increment2Byte
 
-TrainerRankings_PhoneCalls: mobile ; 1060d3
+StubbedTrainerRankings_PhoneCalls: ; 1060d3
+	ret
 	ld hl, sTrainerRankingPhoneCalls
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Unused2: mobile ; 1060df
+StubbedTrainerRankings_Unused2: ; 1060df
+	ret
 	ld hl, sTrainerRankingUnused2
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_LinkBattles: mobile ; 1060df
+StubbedTrainerRankings_LinkBattles: ; 1060df
+	ret
 	ld hl, sTrainerRankingLinkBattles
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Splash: mobile ; 1060e5
+StubbedTrainerRankings_Splash: ; 1060e5
+	ret
 	; Only counts if it’s the player’s turn
 	ld a, [hBattleTurn]
 	and a
 	ret nz
 	ld hl, sTrainerRankingSplash
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_TreeEncounters: mobile ; 1060ef
+StubbedTrainerRankings_TreeEncounters: ; 1060ef
+	ret
 	ld hl, sTrainerRankingTreeEncounters
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_Unused3: mobile ; 1060f5
+StubbedTrainerRankings_Unused3: ; 1060f5
+	ret
 	ld hl, sTrainerRankingUnused3
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_ColosseumWins: mobile ; win
+StubbedTrainerRankings_ColosseumWins: ; win
+	ret
 	ld hl, sTrainerRankingColosseumWins
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 
-TrainerRankings_ColosseumLosses: mobile ; lose
+StubbedTrainerRankings_ColosseumLosses: ; lose
+	ret
 	ld hl, sTrainerRankingColosseumLosses
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 ; 106107
 
-TrainerRankings_ColosseumDraws: mobile ; draw
+StubbedTrainerRankings_ColosseumDraws: ; draw
+	ret
 	ld hl, sTrainerRankingColosseumDraws
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 ; 10610d
 
 ; Counts uses of both Selfdestruct and Explosion.
-TrainerRankings_Selfdestruct: mobile ; 10610d
+StubbedTrainerRankings_Selfdestruct: ; 10610d
+	ret
 	; Only counts if it’s the player’s turn
 	ld a, [hBattleTurn]
 	and a
 	ret nz
 	ld hl, sTrainerRankingSelfdestruct
-	jr TrainerRankings_Increment3Byte
+	jr StubbedTrainerRankings_Increment3Byte
 ; 106117
 
-TrainerRankings_Increment4Byte: ; 106117
+StubbedTrainerRankings_Increment4Byte: ; 106117
 	push bc
 	ld bc, 3
-	jr TrainerRankings_Increment
+	jr StubbedTrainerRankings_Increment
 ; 10611d
 
-TrainerRankings_Increment3Byte: ; 10611d
+StubbedTrainerRankings_Increment3Byte: ; 10611d
 	push bc
 	ld bc, 2
-	jr TrainerRankings_Increment
+	jr StubbedTrainerRankings_Increment
 ; 106123
 
-TrainerRankings_Increment2Byte: ; 106123
+StubbedTrainerRankings_Increment2Byte: ; 106123
 	push bc
 	ld bc, 1
-	jr TrainerRankings_Increment
+	jr StubbedTrainerRankings_Increment
 ; 106129
 
 ; unused
-TrainerRankings_Increment1Byte: ; 106129
+StubbedTrainerRankings_Increment1Byte: ; 106129
 	push bc
 	ld bc, 0
 
 ; Increments a big-endian value of bc + 1 bytes at hl
-TrainerRankings_Increment: ; 10612d
+StubbedTrainerRankings_Increment: ; 10612d
 	ld a, BANK(sTrainerRankings)
 	call GetSRAMBank
 	push hl
@@ -449,7 +487,8 @@ TrainerRankings_Increment: ; 10612d
 ; 106155
 
 ; Used when SRAM bank 5 isn’t already loaded — what’s the point of this?
-UpdateTrainerRankingsChecksum2: mobile ; 106155
+UpdateTrainerRankingsChecksum2: ; 106155
+	ret
 	ld a, BANK(sTrainerRankings)
 	call GetSRAMBank
 	call UpdateTrainerRankingsChecksum
@@ -771,7 +810,7 @@ endr
 	ret
 ; 10630f
 
-; functions related to the cable club and various NPC scripts referencing mobile communications
+; functions related to the cable club and various NPC scripts referencing communications
 
 Special_Mobile_DummyReturnFalse: ; 10630f
 	xor a
@@ -779,7 +818,8 @@ Special_Mobile_DummyReturnFalse: ; 10630f
 	ret
 ; 106314
 
-MobileFn_106314: mobile ; 106314
+Stubbed_Function106314: ; 106314
+	ret
 	ld a, $4
 	call GetSRAMBank
 	ld a, c
@@ -958,7 +998,7 @@ Function106403: ; 106403
 	or c
 	inc a
 	ld c, a
-	call MobileFn_106314
+	call Stubbed_Function106314
 	ld a, [wMobileCommsJumptableIndex]
 	inc a
 	ld [wMobileCommsJumptableIndex], a
@@ -976,7 +1016,7 @@ Function106403: ; 106403
 
 .asm_106435
 	ld c, $0
-	call MobileFn_106314
+	call Stubbed_Function106314
 	ld a, [wMobileCommsJumptableIndex]
 	inc a
 	ld [wMobileCommsJumptableIndex], a
@@ -1003,7 +1043,8 @@ Function106453: ; 106453
 	ret
 ; 106462
 
-MobileFunc_106462: mobile
+Stubbed_Function106462:
+	ret
 	ret
 ; 106464
 

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -290,26 +290,26 @@ MobileTradeAnim_ClearBGMap: ; 1081ca
 MobileTradeAnim_GetFrontpic: ; 1081e9
 	push de
 	push af
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop af
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	call GetBaseData
 	pop de
-	predef GetMonFrontpic
+	predef Predef_GetMonFrontpic
 	ret
 ; 108201
 
 Function108201: ; 108201
 	push de
 	push af
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	pop af
 	ld [CurPartySpecies], a
 	ld [CurSpecies], a
 	call GetBaseData
 	pop de
-	predef GetAnimatedFrontpicPredef
+	predef Predef_GetAnimatedFrontpic
 	ret
 ; 108219
 
@@ -318,7 +318,7 @@ Function108219: ; 108219
 	hlcoord 7, 2
 	ld d, $0
 	ld e, ANIM_MON_TRADE
-	predef AnimateFrontpic
+	predef Predef_AnimateFrontpic
 	ret
 ; 108229
 
@@ -327,7 +327,7 @@ Function108229: ; 108229
 	hlcoord 7, 2
 	ld d, $0
 	ld e, ANIM_MON_TRADE
-	predef LoadMonAnimation
+	predef Predef_LoadMonAnimation
 	ret
 ; 108239
 
@@ -1238,7 +1238,7 @@ asm_108966
 	xor a
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	call WaitBGMap
 	ret
 ; 10898a
@@ -1252,7 +1252,7 @@ Function10898a: ; 10898a
 	xor a
 	ld [hGraphicStartTile], a
 	lb bc, 7, 7
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	call WaitBGMap
 	ret
 ; 1089a8

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -361,7 +361,7 @@ MobileTradeAnim_JumptableLoop: ; 10824b
 	ld [hWY], a
 	call LoadStandardFont
 	call LoadFontsBattleExtra
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	scf
 	ret

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -1825,7 +1825,7 @@ LZ_1090a7:
 INCBIN "gfx/unknown/1090a7.tilemap.lz"
 
 Palette_1090f7:
-; unreferenced
+; unused
 	RGB 31, 31, 31
 	RGB  0,  0,  0
 

--- a/mobile/mobile_45.asm
+++ b/mobile/mobile_45.asm
@@ -61,7 +61,7 @@ String_114163: ; 114163
 ; 114165
 
 Jumptable_114165: ; 114165
-	dw Function114268
+	dw Stubbed_Function114268
 	dw Function114269
 	dw Function11433c
 	dw Function1143b7
@@ -159,7 +159,8 @@ Function11425c: ; 11425c
 
 ; 114268
 
-Function114268: mobile
+Stubbed_Function114268:
+	ret
 
 ; 114269
 

--- a/mobile/mobile_45.asm
+++ b/mobile/mobile_45.asm
@@ -7350,7 +7350,7 @@ INCBIN "data/mobile/ascii-sym.txt"
 
 ; everything from here to the end of the bank is related to the
 ; Mobile Stadium option from the continue/newgame menu.
-; XXX better function names
+; Needs better function names
 MobileStudium: ; 0x117a7f
 	ld a, [hInMenu]
 	push af

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -1672,7 +1672,7 @@ Function118ded: ; 118ded
 	push af
 	ld a, $1
 	ld [rSVBK], a
-	farcall Function11b93b
+	farcall Special_Function11b93b
 	pop af
 	ld [rSVBK], a
 
@@ -5729,7 +5729,7 @@ Text_ThisBattleRoomPleaseWait: ; 0x11ac1f
 	done
 ; 0x11ac3e
 
-Function11ac3e: ; 11ac3e
+Special_Function11ac3e: ; 11ac3e
 	call SpeechTextBox
 	call FadeToMenu
 	callfar ClearSpriteAnims2
@@ -7060,7 +7060,7 @@ Function11b3d9: ; 11b3d9
 	ret
 ; 11b444
 
-Function11b444: ; 11b444
+Special_Function11b444: ; 11b444
 ; special
 	call Mobile46_InitJumptable
 	call Mobile46_RunJumptable
@@ -7349,7 +7349,7 @@ Function11b5e7: ; 11b5e7
 	ret
 ; 11b5e8
 
-Function11b5e8: ; 11b5e8
+Special_Function11b5e8: ; 11b5e8
 	ld a, $0
 	call GetSRAMBank
 	ld hl, wRTC
@@ -7585,7 +7585,7 @@ Function11b6b4: ; 11b6b4
 	ret
 ; 11b7e5
 
-Function11b7e5: ; 11b7e5
+Special_Function11b7e5: ; 11b7e5
 	ld a, [$c60d] ; species
 	ld [wOTTrademonSpecies], a
 	ld [CurPartySpecies], a
@@ -7644,7 +7644,7 @@ Function11b7e5: ; 11b7e5
 	ret
 ; 11b879
 
-Function11b879: ; 11b879
+Special_Function11b879: ; 11b879
 	farcall BattleTower_CheckSaveFileExistsAndIsYours
 	ld a, [ScriptVar]
 	and a
@@ -7737,7 +7737,7 @@ Function11b879: ; 11b879
 	ret
 ; 11b920
 
-Function11b920: ; 11b920
+Special_Function11b920: ; 11b920
 	call Mobile46_InitJumptable
 	ld a, $5
 	call GetSRAMBank
@@ -7750,7 +7750,7 @@ Function11b920: ; 11b920
 	ret
 ; 11b93b
 
-Function11b93b: ; 11b93b
+Special_Function11b93b: ; 11b93b
 	ld a, $5
 	call GetSRAMBank
 	xor a
@@ -7894,7 +7894,7 @@ AddMobileMonToParty: ; 11b98f
 	ret
 ; 11ba38
 
-Function11ba38: ; 11ba38
+Special_Function11ba38: ; 11ba38
 	farcall CheckCurPartyMonFainted
 	ret c
 	xor a

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -1559,8 +1559,7 @@ IndexDownloadURL: ; 0x118ce5
 	db "http://gameboy.datacenter.ne.jp/cgb/download?name=/01/CGB-BXTJ/tamago/index.txt", 0
 
 
-Function118d35: ; 118d35
-; unreferenced
+Unreferenced_Function118d35: ; 118d35
 	ld hl, $d200
 	ld a, [wcd38]
 	and a
@@ -6957,8 +6956,7 @@ Function11b397: ; 11b397
 	jr .loop
 ; 11b3b6
 
-Function11b3b6: ; 11b3b6
-; unreferenced
+Unreferenced_Function11b3b6: ; 11b3b6
 .loop
 	ld a, [hl]
 	cp -1

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -487,7 +487,7 @@ BattleTowerRoomMenu_InitRAM: ; 1183cb
 	ld [hMobileReceive], a
 	ld [hMobile], a
 	ei
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	farcall Function115d99
 	farcall Function11615a
@@ -4461,7 +4461,7 @@ Function11a00e: ; 11a00e
 	call PushWindow
 	farcall Function11765d
 	farcall Function117ab4
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	call ExitMenu
 	farcall ReloadMapPart
@@ -4484,7 +4484,7 @@ Function11a0ca: ; 11a0ca
 	call PushWindow
 	farcall Function11765d
 	farcall Function17d3f6
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	call ExitMenu
 	farcall ReloadMapPart
@@ -5577,7 +5577,7 @@ Function11a9ce: ; 11a9ce
 	call ClearBGPalettes
 	call ReloadTilesetAndPalettes
 	call Call_ExitMenu
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	call ret_d90
 	farcall FinishExitMenu

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -6696,7 +6696,7 @@ Function11b242: ; 11b242
 	call PlaceString
 	xor a
 	ld [MonType], a
-	farcall GetGender
+	farcall Predef_GetGender
 	hlcoord 1, 4
 	ld a, [CurPartySpecies]
 	ld bc, wcd2f
@@ -7154,7 +7154,7 @@ Function11b483: ; 11b483
 	pop de
 	push de
 	ld b, OTPARTYMON
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	pop de
 	ld h, d
 	ld l, e
@@ -7573,7 +7573,7 @@ Function11b6b4: ; 11b6b4
 	ld hl, $c60d + MON_STAT_EXP - 1
 	ld de, $c60d + MON_MAXHP
 	ld b, $1
-	predef CalcPkmnStats
+	predef Predef_CalcPkmnStats
 	ld de, $c60d + MON_MAXHP
 	ld hl, $c60d + MON_HP
 	ld a, [de]

--- a/mobile/mobile_5b.asm
+++ b/mobile/mobile_5b.asm
@@ -1,5 +1,4 @@
-Function16c000: ; 16c000
-; unreferenced
+Unreferenced_Function16c000: ; 16c000
 	; Only for CGB
 	ld a, [hCGB]
 	and a

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -654,7 +654,7 @@ Function171c41: ; 171c41 (5c:5c41)
 	dec [hl]
 	ret nz
 	call ClearBGPalettes
-	farcall MobileFunc_106462
+	farcall Stubbed_Function106462
 	farcall Function106464
 	ld a, $2
 	ld [wc303], a

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -5246,7 +5246,7 @@ String_17fe63: ; 17fe63
 	next "せつめいしょを ごらんください"
 	db   "@"
 
-String_17fe9a: ; 17fe9a ; unreferenced
+String_17fe9a: ; 17fe9a ; unused
 	db   "ポケモンニュースが"
 	next "あたらしくなっているので"
 	next "レポートを おくれません"

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -412,7 +412,7 @@ Function17d1f1: ; 17d1f1
 	dec a
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
-	predef GetUnownLetter
+	predef Predef_GetUnownLetter
 	callfar UpdateUnownDex
 	ld a, [wFirstUnownSeen]
 	and a
@@ -1500,7 +1500,7 @@ Function17d93a: ; 17d93a
 	add hl, de
 	ld e, l
 	ld d, h
-	farcall HOF_AnimateFrontpic
+	farcall HOF_Predef_AnimateFrontpic
 	pop af
 	ld [rSVBK], a
 	call Function17e349
@@ -1532,12 +1532,12 @@ Function17d98b: ; 17d98b
 	ld d, a
 	push de
 	ld de, vTiles2
-	farcall GetTrainerPic
+	farcall Predef_GetTrainerPic
 	pop hl
 	decoord 0, 0
 	add hl, de
 	ld bc, $707
-	predef PlaceGraphic
+	predef Predef_PlaceGraphic
 	pop af
 	ld [rSVBK], a
 	call Function17e349
@@ -2339,7 +2339,7 @@ Function17ded9: ; 17ded9
 	ld [MonType], a
 	push hl
 	push bc
-	predef TryAddMonToParty
+	predef Predef_TryAddMonToParty
 	farcall SetCaughtData
 	pop bc
 	pop hl
@@ -2444,7 +2444,7 @@ Function17ded9: ; 17ded9
 	ld e, l
 	push hl
 	ld b, $0
-	farcall CalcPkmnStats
+	farcall Predef_CalcPkmnStats
 	ld a, [PartyCount]
 	dec a
 	ld hl, PartyMon1HP
@@ -2510,7 +2510,7 @@ Function17ded9: ; 17ded9
 	ld d, h
 	ld e, l
 	pop hl
-	predef FillPP
+	predef Predef_FillPP
 	pop hl
 	pop bc
 	jp asm_17e0ee
@@ -2533,7 +2533,7 @@ Function17e026: ; 17e026
 	push bc
 	push hl
 	farcall LoadEnemyMon
-	farcall SentPkmnIntoBox
+	farcall Predef_SendPkmnIntoBox
 	farcall SetBoxMonCaughtData
 	pop hl
 	pop bc
@@ -2624,7 +2624,7 @@ Function17e026: ; 17e026
 	push hl
 	ld hl, sBoxMon1Moves
 	ld de, sBoxMon1PP
-	predef FillPP
+	predef Predef_FillPP
 	call CloseSRAM
 	pop hl
 	pop bc

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -513,7 +513,7 @@ MenuData2_ChallengeExplanationCancel: ; 17d297
 	db "Cancel@"
 ; 17d2b6
 
-Function17d2b6: ; 17d2b6
+Special_Function17d2b6: ; 17d2b6
 	call Function17d2c0
 	farcall Function1181da
 	ret
@@ -528,7 +528,7 @@ Function17d2c0: ; 17d2c0
 	ret
 ; 17d2ce
 
-Function17d2ce: ; 17d2ce
+Special_Function17d2ce: ; 17d2ce
 	ld a, $5
 	call GetSRAMBank
 	ld a, [$aa72]
@@ -4619,7 +4619,7 @@ Function17f524: ; 17f524
 	jr .asm_17f536
 ; 17f53d
 
-BattleTowerMobileError: ; 17f53d
+Special_BattleTowerMobileError: ; 17f53d
 	call FadeToMenu
 	xor a
 	ld [wc303], a

--- a/mobile/mobile_menu.asm
+++ b/mobile/mobile_menu.asm
@@ -847,7 +847,7 @@ Function4a6ab: ; 4a6ab (12:66ab)
 	call ClearBGPalettes
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
-	farcall Function11c1ab
+	farcall Special_Function11c1ab
 	pop bc
 	call LoadFontsExtra
 	jp Function4a4c4

--- a/mobile/news/news.asm
+++ b/mobile/news/news.asm
@@ -1,9 +1,8 @@
 ; http://forums.glitchcity.info/index.php?topic=7509.msg206449#msg206449
 
-	db $cc, $6b, $1e ; XXX
+	db $cc, $6b, $1e ; unused
 
-Function1f4003: ; 1f4003
-; XXX
+Unreferenced_Function1f4003: ; 1f4003
 	ld a, $6
 	call GetSRAMBank
 	ld hl, .news_data
@@ -16,8 +15,7 @@ Function1f4003: ; 1f4003
 .news_data
 INCBIN "mobile/news/news_1.bin"
 
-Function1f4dbe: ; 1f4dbe
-; XXX
+Unreferenced_Function1f4dbe: ; 1f4dbe
 	ld a, $6
 	call GetSRAMBank
 	ld hl, .news_data

--- a/text/unused_gen_1_trainers.asm
+++ b/text/unused_gen_1_trainers.asm
@@ -1,5 +1,4 @@
-GetGen1TrainerClassName: ; 50a28
-; XXX
+Unreferenced_GetGen1TrainerClassName: ; 50a28
 	ld hl, .Strings
 	ld a, [TrainerClass]
 	dec a

--- a/tilesets/palette_maps.asm
+++ b/tilesets/palette_maps.asm
@@ -128,3 +128,10 @@ INCLUDE "tilesets/battle_tower_palette_map.asm"
 TilesetBattleTowerOutsidePalMap: ; 0x4cd95
 INCLUDE "tilesets/battle_tower_outside_palette_map.asm"
 ; 0x4ce05
+
+; unused
+; 0x4ce05
+rept 26
+	db $06
+endr
+; 0x4ce1f


### PR DESCRIPTION
Ready to merge. However, it's going to conflict somewhere with #456, so feel free to merge that one first and then I could look at merging and resolving conflicts. There *shouldn't* be too many though.

Addresses issue #453. Gets rid of the ``mobile`` string, consolidates unused content with ``Unreferenced_`` or ``Stubbed_`` label prefixes, or with an ``; unused`` comment. These are mostly consistent and should be easy to locate with a simple search, even though words like ``unused`` and ``dummy`` are still scattered in many labels and comments of unused content, particularly for constants, text and scripts.

As for ``predef`` and ``specials``, I added ``Predef_`` and ``Special_`` and a prefix in function labels (for consistency with most current specials), using also the word ``Dummy`` or ``Unused`` when appropriate. Unecessary bank 0 specials were not renamed and instead commented with ``; bank 0``.

Also took out leftover unused data from main.asm and changed some ``UnknownText_xxx`` that are unreferenced to ``UnusedText_xxx``.
  
  