### PR TITLE
Replace hardcoded banks & addresses in non-mobile code

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -40,7 +40,7 @@ _MapSetup_Sound_Off:: ; e8000
 
 	ld hl, Channels ; start of channel data
 	ld de, ChannelsEnd - Channels ; length of area to clear (entire sound wram area)
-.clearchannels ; clear Channel1-$c2bf
+.clearchannels
 	xor a
 	ld [hli], a
 	dec de
@@ -2749,7 +2749,7 @@ PlayStereoSFX:: ; e8ca6
 	add hl, bc
 	ld [hl], a
 
-	ld hl, Channel1Field30 - Channel1 ; $c131 - Channel1
+	ld hl, Channel1Field30 - Channel1
 	add hl, bc
 	ld [hl], a
 
@@ -2760,11 +2760,11 @@ PlayStereoSFX:: ; e8ca6
 ; ch3-4
 	ld a, [wSFXDuration]
 
-	ld hl, Channel1Field2e - Channel1 ; $c12f - Channel1
+	ld hl, Channel1Field2e - Channel1
 	add hl, bc
 	ld [hl], a
 
-	ld hl, Channel1Field2f - Channel1 ; $c130 - Channel1
+	ld hl, Channel1Field2f - Channel1
 	add hl, bc
 	ld [hl], a
 

--- a/data/default_options.asm
+++ b/data/default_options.asm
@@ -11,8 +11,7 @@ DefaultOptions: ; 14f7c
 	db GBPRINTER_NORMAL
 ; Options2: menu account on
 	db 1 << MENU_ACCOUNT
-; $cfd2: ??
+	
 	db $00
-; $cfd3: ??
 	db $00
 ; 14f84

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -23,7 +23,7 @@ Predef_StartBattle: ; 8c20f
 .done
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, wBGPals1
@@ -44,7 +44,7 @@ Predef_StartBattle: ; 8c20f
 	ld [hLYOverrideEnd], a
 	ld [hSCY], a
 
-	ld a, $1
+	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
 	pop af
 	ld [hVBlank], a
@@ -116,7 +116,7 @@ LoadTrainerBattlePokeballTiles:
 ConvertTrainerBattlePokeballTilesTo2bpp: ; 8c2cf
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	push hl
 	ld hl, wDecompressScratch
@@ -647,7 +647,7 @@ StartTrainerBattle_LoadPokeBallGraphics: ; 8c5dc (23:45dc)
 .daytime
 	ld a, [rSVBK]
 	push af
-	ld a, $5 ; WRAM5 = palettes
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	call .copypals
 	push hl
@@ -729,7 +729,7 @@ PokeBallTransition:
 WipeLYOverrides: ; 8c6d8
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 
 	ld hl, LYOverrides

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -298,7 +298,7 @@ StartTrainerBattle_Flash: ; 8c3ab (23:43ab)
 
 StartTrainerBattle_SetUpForWavyOutro: ; 8c3e8 (23:43e8)
 	farcall Function5602
-	ld a, $5 ; BANK(LYOverrides)
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 
 	call StartTrainerBattle_NextScene
@@ -356,7 +356,7 @@ StartTrainerBattle_SineWave: ; 8c408 (23:4408)
 
 StartTrainerBattle_SetUpForSpinOutro: ; 8c43d (23:443d)
 	farcall Function5602
-	ld a, $5 ; BANK(LYOverrides)
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 	call StartTrainerBattle_NextScene
 	xor a
@@ -498,7 +498,7 @@ ENDM
 
 StartTrainerBattle_SetUpForRandomScatterOutro: ; 8c578 (23:4578)
 	farcall Function5602
-	ld a, $5 ; BANK(LYOverrides)
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 	call StartTrainerBattle_NextScene
 	ld a, $10

--- a/engine/battle/checkbattlescene.asm
+++ b/engine/battle/checkbattlescene.asm
@@ -21,7 +21,7 @@ CheckBattleScene: ; 4ea44
 
 	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
-	ld a, [$a60c]
+	ld a, [$a60c] ; address of MBC30 bank
 	ld c, a
 	call CloseSRAM
 

--- a/engine/battle/checkbattlescene.asm
+++ b/engine/battle/checkbattlescene.asm
@@ -1,7 +1,7 @@
 CheckBattleScene: ; 4ea44
 ; Return carry if battle scene is turned off.
 
-	ld a, 0
+	ld a, BANK(wLinkMode)
 	ld hl, wLinkMode
 	call GetFarWRAMByte
 	cp LINK_MOBILE
@@ -33,7 +33,7 @@ CheckBattleScene: ; 4ea44
 	ret
 
 .from_wram
-	ld a, $5
+	ld a, BANK(w5_dc00)
 	ld hl, w5_dc00
 	call GetFarWRAMByte
 	bit 0, a

--- a/engine/battle/checkbattlescene.asm
+++ b/engine/battle/checkbattlescene.asm
@@ -19,7 +19,7 @@ CheckBattleScene: ; 4ea44
 	and a
 	jr nz, .from_wram
 
-	ld a, $4
+	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld a, [$a60c]
 	ld c, a

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -9320,7 +9320,7 @@ InitBattleDisplay: ; 3fb6c
 .BlankBGMap: ; 3fbd6
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld hl, wDecompressScratch
@@ -9381,7 +9381,7 @@ GetTrainerBackpic: ; 3fbff
 CopyBackpic: ; 3fc30
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	ld hl, vTiles0
 	ld de, vTiles2 tile $31

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8440,7 +8440,7 @@ InitEnemy: ; 3f55e
 BackUpBGMap2: ; 3f568
 	ld a, [rSVBK]
 	push af
-	ld a, $6 ; BANK(wDecompressScratch)
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	ld hl, wDecompressScratch
 	ld bc, $40 tiles ; vBGMap3 - vBGMap2

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -232,7 +232,7 @@ BattleTurn: ; 3c12f
 ; 3c1bf
 
 MobileFn_3c1bf: mobile
-	ld a, $5
+	ld a, 5 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld hl, $a89b ; s5_a89b
 	inc [hl]

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -234,7 +234,7 @@ BattleTurn: ; 3c12f
 MobileFn_3c1bf: mobile
 	ld a, 5 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
-	ld hl, $a89b ; s5_a89b
+	ld hl, $a89b ; address of MBC30 bank
 	inc [hl]
 	jr nz, .finish
 	dec hl

--- a/engine/battle/sliding_intro.asm
+++ b/engine/battle/sliding_intro.asm
@@ -1,7 +1,7 @@
 BattleIntroSlidingPics: ; 4e980
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 	call .subfunction1
 	ld a, rSCX - $ff00

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -975,7 +975,7 @@ BattleAnimCmd_RaiseSub: ; cc640 (33:4640)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 
 GetSubstitutePic: ; cc64c
@@ -1049,7 +1049,7 @@ BattleAnimCmd_MinimizeOpp: ; cc6cf (33:46cf)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	call GetMinimizePic
 	call Request2bpp
@@ -1105,7 +1105,7 @@ BattleAnimCmd_Minimize: ; cc735 (33:4735)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	call GetMinimizePic
 	ld hl, vTiles0 tile $00

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -5,7 +5,7 @@ PlayBattleAnim: ; cc0d6
 	ld a, [rSVBK]
 	push af
 
-	ld a, 5
+	ld a, BANK(ActiveAnimObjects)
 	ld [rSVBK], a
 
 	call _PlayBattleAnim
@@ -163,7 +163,7 @@ BattleAnimRestoreHuds: ; cc1bb
 
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(CurBattleMon) ; alternatively: BANK(TempMon), BANK(PartyMon1), several others
 	ld [rSVBK], a
 
 	ld hl, UpdateBattleHuds
@@ -917,7 +917,7 @@ BattleAnimCmd_E7: ; cc5db (33:45db)
 BattleAnimCmd_Transform: ; cc5dc (33:45dc)
 	ld a, [rSVBK]
 	push af
-	ld a, 1
+	ld a, BANK(CurPartySpecies)
 	ld [rSVBK], a
 	ld a, [CurPartySpecies] ; CurPartySpecies
 	push af
@@ -973,7 +973,7 @@ BattleAnimCmd_RaiseSub: ; cc640 (33:4640)
 
 	ld a, [rSVBK]
 	push af
-	ld a, 1
+	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
 	xor a
 	call GetSRAMBank
@@ -1047,7 +1047,7 @@ GetSubstitutePic: ; cc64c
 BattleAnimCmd_MinimizeOpp: ; cc6cf (33:46cf)
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
 	xor a
 	call GetSRAMBank
@@ -1103,7 +1103,7 @@ INCBIN "gfx/battle/minimize.2bpp"
 BattleAnimCmd_Minimize: ; cc735 (33:4735)
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
 	xor a
 	call GetSRAMBank
@@ -1118,7 +1118,7 @@ BattleAnimCmd_Minimize: ; cc735 (33:4735)
 BattleAnimCmd_DropSub: ; cc750 (33:4750)
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(CurPartySpecies)
 	ld [rSVBK], a
 
 	ld a, [CurPartySpecies] ; CurPartySpecies
@@ -1143,7 +1143,7 @@ BattleAnimCmd_DropSub: ; cc750 (33:4750)
 BattleAnimCmd_BeatUp: ; cc776 (33:4776)
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(CurPartySpecies)
 	ld [rSVBK], a
 	ld a, [CurPartySpecies] ; CurPartySpecies
 	push af
@@ -1254,7 +1254,7 @@ endr
 
 	ld a, [rSVBK]
 	push af
-	ld a, 1
+	ld a, BANK(EnemyMon) ; BattleMon is in WRAM0, but EnemyMon is in WRAMX
 	ld [rSVBK], a
 
 	ld a, [hBattleTurn]
@@ -1262,14 +1262,14 @@ endr
 	jr nz, .enemy
 
 	ld a, $f0
-	ld [CryTracks], a ; CryTracks
-	ld a, [BattleMonSpecies] ; BattleMonSpecies
+	ld [CryTracks], a
+	ld a, [BattleMonSpecies]
 	jr .done_cry_tracks
 
 .enemy
 	ld a, $0f
-	ld [CryTracks], a ; CryTracks
-	ld a, [EnemyMonSpecies] ; EnemyMon
+	ld [CryTracks], a
+	ld a, [EnemyMonSpecies]
 
 .done_cry_tracks
 	push hl
@@ -1431,7 +1431,7 @@ BattleAnim_SetBGPals: ; cc91a
 	ret z
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, wBGPals2
 	ld de, wBGPals1
@@ -1459,7 +1459,7 @@ BattleAnim_SetOBPals: ; cc94b
 	ret z
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wOBPals1)
 	ld [rSVBK], a
 	ld hl, wOBPals2 palette PAL_BATTLE_OB_GRAY
 	ld de, wOBPals1 palette PAL_BATTLE_OB_GRAY

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -975,7 +975,7 @@ BattleAnimCmd_RaiseSub: ; cc640 (33:4640)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 
 GetSubstitutePic: ; cc64c
@@ -1049,7 +1049,7 @@ BattleAnimCmd_MinimizeOpp: ; cc6cf (33:46cf)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	call GetMinimizePic
 	call Request2bpp
@@ -1105,7 +1105,7 @@ BattleAnimCmd_Minimize: ; cc735 (33:4735)
 	push af
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	call GetMinimizePic
 	ld hl, vTiles0 tile $00

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -2578,7 +2578,7 @@ BGEffects_LoadBGPal0_OBPal1: ; c8e52 (32:4e52)
 	ld h, a
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld a, h
 	push bc
@@ -2605,7 +2605,7 @@ BGEffects_LoadBGPal1_OBPal0: ; c8e7f (32:4e7f)
 	ld h, a
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld a, h
 	push bc

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -428,9 +428,9 @@ GetBallAnimPal: ; cd249 (33:5249)
 	ld hl, BallColors
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(CurItem)
 	ld [rSVBK], a
-	ld a, [CurItem] ; CurItem
+	ld a, [CurItem]
 	ld e, a
 	pop af
 	ld [rSVBK], a

--- a/engine/battle_anims/getpokeballwobble.asm
+++ b/engine/battle_anims/getpokeballwobble.asm
@@ -8,7 +8,7 @@ GetPokeBallWobble: ; f971 (3:7971)
 	ld d, a
 	push de
 
-	ld a, 1 ; BANK(Buffer2)
+	ld a, BANK(Buffer2)
 	ld [rSVBK], a
 
 	ld a, [Buffer2]

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -2104,7 +2104,7 @@ MovePKMNWitoutMail_InsertMon: ; e31e7
 	ld hl, wBillsPC_BackupScrollPosition
 	add [hl]
 	ld [CurPartyMon], a
-	ld a, $1
+	ld a, BANK(sBox)
 	call GetSRAMBank
 	ld hl, sBoxSpecies
 	call CopySpeciesToTemp

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -1649,7 +1649,7 @@ CardFlip_InitAttrPals: ; e0c37 (38:4c37)
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, .palettes
 	ld de, wBGPals1

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -144,13 +144,13 @@ Function8b07:
 	ld hl, .BGPal
 	ld de, wBGPals1
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 
 	ld hl, .OBPal
 	ld de, wOBPals1
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 
 	call ApplyPals
@@ -359,7 +359,7 @@ ApplyHPBarPals:
 	ld bc, HPBarPals
 	add hl, bc
 	ld bc, 4
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	call FarCopyWRAM
 	ld a, $1
 	ld [hCGBPalUpdate], a
@@ -443,7 +443,7 @@ LoadMailPalettes:
 .cgb
 	ld de, wBGPals1
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call ApplyPals
 	call WipeAttrMap
@@ -460,7 +460,7 @@ Function95f0:
 	ld hl, .Palette
 	ld de, wBGPals1
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	call ApplyPals
 	call WipeAttrMap
@@ -611,7 +611,7 @@ ApplyPals:
 	ld hl, wBGPals1
 	ld de, wBGPals2
 	ld bc, 16 palettes
-	ld a, $5
+	ld a, BANK(wPals)
 	call FarCopyWRAM
 	ret
 
@@ -688,7 +688,7 @@ InitPartyMenuOBPals:
 	ld hl, PartyMenuOBPals
 	ld de, wOBPals1
 	ld bc, 2 palettes
-	ld a, $5
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	ret
 
@@ -761,7 +761,7 @@ Function9779: mobile
 	ld hl, BattleObjectPals
 	ld de, wOBPals1 palette 2
 	ld bc, 2 palettes
-	ld a, $5
+	ld a, BANK(wOBPals1)
 	call FarCopyWRAM
 	ret
 
@@ -1318,7 +1318,7 @@ endr
 .morn_day
 	ld de, wBGPals1 palette PAL_BG_ROOF + 2
 	ld bc, 4
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	ret
 

--- a/engine/color.asm
+++ b/engine/color.asm
@@ -394,7 +394,7 @@ LoadStatsScreenPals:
 	add hl, bc
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld a, [hli]
 	ld [wBGPals1 palette 0], a
@@ -504,7 +504,7 @@ GetPredefPal:
 LoadHLPaletteIntoDE:
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wOBPals1)
 	ld [rSVBK], a
 	ld c, $8
 .loop
@@ -520,7 +520,7 @@ LoadHLPaletteIntoDE:
 LoadPalette_White_Col1_Col2_Black:
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld a, LOW(palred 31 + palgreen 31 + palblue 31)
@@ -572,7 +572,7 @@ ResetBGPals:
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, wBGPals1
@@ -930,7 +930,7 @@ InitCGBPals::
 	jr nz, .obpals_loop
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, wBGPals1
 	call .LoadWhitePals
@@ -1251,7 +1251,7 @@ LoadMapPals:
 	; Switch to palettes WRAM bank
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, wBGPals1
 	ld b, 8

--- a/engine/credits.asm
+++ b/engine/credits.asm
@@ -13,7 +13,7 @@ Credits:: ; 109847
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wPals)
 	ld [rSVBK], a
 
 	call ClearBGPalettes

--- a/engine/crystal_colors.asm
+++ b/engine/crystal_colors.asm
@@ -241,7 +241,7 @@ Function49742: ; 49742
 	ld hl, .Palette_49757
 	ld de, wBGPals1
 	ld bc, 8 palettes
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	farcall ApplyPals
 	ret

--- a/engine/crystal_intro.asm
+++ b/engine/crystal_intro.asm
@@ -57,7 +57,7 @@ Copyright_GFPresents: ; e4579
 
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld hl, IntroLogoGFX
@@ -319,7 +319,7 @@ GameFreakLogoScene4: ; e4776 (39:4776)
 	add hl, de
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wOBPals2)
 	ld [rSVBK], a
 	ld a, [hli]
 	ld [wOBPals2 + 12], a
@@ -352,7 +352,7 @@ INCBIN "gfx/splash/logo2.1bpp"
 CrystalIntro: ; e48ac
 	ld a, [rSVBK]
 	push af
-	ld a, 5
+	ld a, BANK(wPals)
 	ld [rSVBK], a
 	ld a, [hInMenu]
 	push af
@@ -480,7 +480,7 @@ IntroScene1: ; e495b (39:495b)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_365ad
 	ld de, wBGPals1
@@ -553,7 +553,7 @@ IntroScene3: ; e49fd (39:49fd)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e5edd
 	ld de, wBGPals1
@@ -619,7 +619,7 @@ IntroScene5: ; e4a7a (39:4a7a)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_365ad
 	ld de, wBGPals1
@@ -725,7 +725,7 @@ IntroScene7: ; e4b3f (39:4b3f)
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, Palette_e5edd
@@ -884,7 +884,7 @@ IntroScene11: ; e4c86 (39:4c86)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_365ad
 	ld de, wBGPals1
@@ -1011,7 +1011,7 @@ IntroScene13: ; e4d6d (39:4d6d)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e5edd
 	ld de, wBGPals1
@@ -1120,7 +1120,7 @@ IntroScene15: ; e4e40 (39:4e40)
 	call Intro_LoadTilemap
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e77dd
 	ld de, wBGPals1
@@ -1194,7 +1194,7 @@ IntroScene17: ; e4ef5 (39:4ef5)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e6d6d
 	ld de, wBGPals1
@@ -1268,7 +1268,7 @@ IntroScene19: ; e4f7e (39:4f7e)
 	call Intro_LoadTilemap
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e77dd
 	ld de, wBGPals1
@@ -1438,7 +1438,7 @@ IntroScene26: ; e50bb (39:50bb)
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, Palette_e679d
 	ld de, wBGPals1
@@ -1526,7 +1526,7 @@ Intro_Scene24_ApplyPaletteFade: ; e5172 (39:5172)
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld de, wBGPals2
 	ld b, 8 ; number of BG pals
@@ -1617,7 +1617,7 @@ CrystalIntro_UnownFade: ; e5223 (39:5223)
 	ld b, $0
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
 	push hl
@@ -1722,7 +1722,7 @@ Intro_Scene20_AppearUnown: ; e5348 (39:5348)
 	ld c, a
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
 	push bc
@@ -1791,7 +1791,7 @@ endr
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
 	push hl
@@ -1846,7 +1846,7 @@ endr
 Intro_LoadTilemap: ; e541b (39:541b)
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld hl, wDecompressScratch
@@ -1946,7 +1946,7 @@ Intro_SetCGBPalUpdate: ; e549e (39:549e)
 Intro_ClearBGPals: ; e54a3 (39:54a3)
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 
 	ld hl, wBGPals2
@@ -1965,7 +1965,7 @@ Intro_ClearBGPals: ; e54a3 (39:54a3)
 Intro_DecompressRequest2bpp_128Tiles: ; e54c2 (39:54c2)
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	push de
@@ -1984,7 +1984,7 @@ Intro_DecompressRequest2bpp_128Tiles: ; e54c2 (39:54c2)
 Intro_DecompressRequest2bpp_255Tiles: ; e54de (39:54de)
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	push de
@@ -2003,7 +2003,7 @@ Intro_DecompressRequest2bpp_255Tiles: ; e54de (39:54de)
 Intro_DecompressRequest2bpp_64Tiles: ; e54fa (39:54fa)
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	push de
@@ -2022,7 +2022,7 @@ Intro_DecompressRequest2bpp_64Tiles: ; e54fa (39:54fa)
 Intro_ResetLYOverrides: ; e5516 (39:5516)
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 
 	ld hl, LYOverrides
@@ -2039,7 +2039,7 @@ Intro_ResetLYOverrides: ; e5516 (39:5516)
 Intro_PerspectiveScrollBG: ; e552f (39:552f)
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 	; Scroll the grass every frame.
 	; Scroll the trees every other frame and at half speed.

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -155,7 +155,7 @@ Function819a7: ; 819a7
 	ret z
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld hl, Palette_819f4
 	ld de, wBGPals2
@@ -436,7 +436,7 @@ Function81c33: ; 81c33
 	jr z, .asm_81c69
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld hl, wBGPals2
 	ld de, wc608
@@ -1145,7 +1145,7 @@ Function82203: ; 82203
 Function8220f: ; 8220f
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld a, [wcf64]
 	ld l, a
@@ -1198,7 +1198,7 @@ Function82236: ; 82236
 	call Function821d8
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld hl, wBGPals2
 	ld a, [wcf64]
@@ -1228,7 +1228,7 @@ Function82236: ; 82236
 Function822a3: ; 822a3
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld hl, wBGPals2
 	ld a, [wcf64]

--- a/engine/dma_transfer.asm
+++ b/engine/dma_transfer.asm
@@ -119,7 +119,7 @@ Mobile_ReloadMapPart: ; 104099
 .unreferenced_1040da
 	ld a, $1
 	ld [rVBK], a
-	ld a, $3
+	ld a, BANK(w3_d800)
 	ld [rSVBK], a
 	ld de, w3_d800
 	ld a, [hBGMapAddress + 1]

--- a/engine/dma_transfer.asm
+++ b/engine/dma_transfer.asm
@@ -143,7 +143,7 @@ Mobile_ReloadMapPart: ; 104099
 .unreferenced_104101
 	ld a, $1
 	ld [rVBK], a
-	ld a, $3
+	ld a, BANK(w3_d800)
 	ld [rSVBK], a
 	ld hl, w3_d800
 	call HDMATransferToWRAMBank3
@@ -221,7 +221,7 @@ CallInSafeGFXMode: ; 104177
 	ld [hMapAnims], a
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wScratchTileMap)
 	ld [rSVBK], a
 	ld a, [rVBK]
 	push af
@@ -472,7 +472,7 @@ _Get2bpp:: ; 104284
 	; switch to WRAM bank 6
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wScratchTileMap)
 	ld [rSVBK], a
 
 	push bc
@@ -542,7 +542,7 @@ _Get1bpp:: ; 1042b2
 .bankswitch ; 1042d6
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wScratchTileMap)
 	ld [rSVBK], a
 
 	push bc

--- a/engine/events/battle_tower.asm
+++ b/engine/events/battle_tower.asm
@@ -100,7 +100,7 @@ Function_LoadRandomBattleTowerPkmn: ; 1f8081
 .FindARandomBattleTowerPkmn:
 	; From Which LevelGroup are the Pkmn loaded
 	; a = 1..10
-	ld a, [wBTChoiceOfLvlGroup] ; [$d800]
+	ld a, [wBTChoiceOfLvlGroup]
 	dec a
 	ld hl, BattleTowerMons
 	ld bc, BattleTowerMons2 - BattleTowerMons1

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -198,7 +198,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 .go
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wOBPals2)
 	ld [rSVBK], a
 
 	ld hl, wOBPals2 palette PAL_OW_TREE

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -160,7 +160,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 	ld hl, .palettes
 	ld de, wOBPals2 palette PAL_OW_TREE
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wOBPals2)
 	call FarCopyWRAM
 	ld a, $1
 	ld [hCGBPalUpdate], a

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -16,7 +16,7 @@ Special_MagnetTrain: ; 8cc04
 	ld h, a
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wMagnetTrain)
 	ld [rSVBK], a
 
 	ld a, h
@@ -129,7 +129,7 @@ MagntTrain_LoadGFX_PlayMusic: ; 8ccc9
 	ld [hSCY], a
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(wPlayerGender)
 	ld [rSVBK], a
 	farcall GetPlayerIcon
 	pop af
@@ -325,7 +325,7 @@ MagnetTrain_Jumptable: ; 8cdf7
 	ld b, SPRITE_ANIM_INDEX_MAGNET_TRAIN_RED
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(wPlayerGender)
 	ld [rSVBK], a
 	ld a, [wPlayerGender]
 	bit 0, a
@@ -429,7 +429,7 @@ MagnetTrain_Jumptable_FirstRunThrough: ; 8ceae
 	call DelayFrame
 	ld a, [rSVBK]
 	push af
-	ld a, $1
+	ld a, BANK(wEnvironment)
 	ld [rSVBK], a
 	ld a, [TimeOfDayPal]
 	push af

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -26,7 +26,7 @@ LoadPoisonBGPals: ; cbcdd
 .cgb
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals2)
 	ld [rSVBK], a
 	ld hl, wBGPals2
 	ld c, 4 palettes

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -178,7 +178,7 @@ UnownPrinter: ; 16be4
 	hlcoord 1, 9
 	ld de, UnownDexVacantString
 	call PlaceString
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	ld hl, sScratch
 	ld bc, $31 tiles

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -154,7 +154,7 @@ UnownPrinter: ; 16be4
 .Load2bppToSRAM: ; 16cff
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld a, BANK(sScratch)

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -178,7 +178,7 @@ UnownPrinter: ; 16be4
 	hlcoord 1, 9
 	ld de, UnownDexVacantString
 	call PlaceString
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	ld hl, sScratch
 	ld bc, $31 tiles

--- a/engine/events/print_unown_2.asm
+++ b/engine/events/print_unown_2.asm
@@ -1,7 +1,7 @@
 RotateUnownFrontpic: ; e0000
 ; something to do with Unown printer
 	push de
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	ld hl, sScratch
 	ld bc, 0

--- a/engine/events/print_unown_2.asm
+++ b/engine/events/print_unown_2.asm
@@ -1,7 +1,7 @@
 RotateUnownFrontpic: ; e0000
 ; something to do with Unown printer
 	push de
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	ld hl, sScratch
 	ld bc, 0

--- a/engine/gbc_only.asm
+++ b/engine/gbc_only.asm
@@ -10,7 +10,7 @@ GBCOnlyScreen: ; 4ea82
 	call ClearTileMap
 
 	ld hl, GBCOnlyGFX
-	ld de, $d000
+	ld de, WRAM1_Begin
 	ld a, [rSVBK]
 	push af
 	ld a, 0
@@ -19,7 +19,7 @@ GBCOnlyScreen: ; 4ea82
 	pop af
 	ld [rSVBK], a
 
-	ld de, $d000
+	ld de, WRAM1_Begin
 	ld hl, vTiles2
 	lb bc, BANK(GBCOnlyGFX), $54
 	call Get2bpp

--- a/engine/gbc_only.asm
+++ b/engine/gbc_only.asm
@@ -10,7 +10,7 @@ GBCOnlyScreen: ; 4ea82
 	call ClearTileMap
 
 	ld hl, GBCOnlyGFX
-	ld de, WRAM1_Begin
+	ld de, wd000
 	ld a, [rSVBK]
 	push af
 	ld a, 0
@@ -19,7 +19,7 @@ GBCOnlyScreen: ; 4ea82
 	pop af
 	ld [rSVBK], a
 
-	ld de, WRAM1_Begin
+	ld de, wd000
 	ld hl, vTiles2
 	lb bc, BANK(GBCOnlyGFX), $54
 	call Get2bpp

--- a/engine/gbc_only.asm
+++ b/engine/gbc_only.asm
@@ -13,7 +13,7 @@ GBCOnlyScreen: ; 4ea82
 	ld de, wd000
 	ld a, [rSVBK]
 	push af
-	ld a, 0
+	ld a, 0 ; this is tantamount to selecting Bank 1
 	ld [rSVBK], a
 	call Decompress
 	pop af

--- a/engine/gbc_only.asm
+++ b/engine/gbc_only.asm
@@ -13,7 +13,7 @@ GBCOnlyScreen: ; 4ea82
 	ld de, wd000
 	ld a, [rSVBK]
 	push af
-	ld a, 0 ; this is tantamount to selecting Bank 1
+	ld a, 0 ; this has the same effect as selecting bank 1 (http://gbdev.gg8.se/files/docs/mirrors/pandocs.html#videodisplay)
 	ld [rSVBK], a
 	call Decompress
 	pop af

--- a/engine/init_gender.asm
+++ b/engine/init_gender.asm
@@ -90,7 +90,7 @@ LoadGenderScreenPal: ; 48e47 (12:4e47)
 	ld hl, .Palette
 	ld de, wBGPals1
 	ld bc, 1 palettes
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 	farcall ApplyPals
 	ret

--- a/engine/init_hof_credits.asm
+++ b/engine/init_hof_credits.asm
@@ -63,7 +63,7 @@ InitDisplayForRedCredits: ; 4e8c2
 ResetDisplayBetweenHallOfFameMons: ; 4e906
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	ld hl, wDecompressScratch
 	ld bc, wScratchAttrMap - wDecompressScratch

--- a/engine/init_map.asm
+++ b/engine/init_map.asm
@@ -79,7 +79,7 @@ LoadFonts_NoOAMUpdate:: ; 64bf
 HDMATransfer_FillBGMap0WithBlack: ; 64db
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld a, "<BLACK>" ; $60

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -1019,7 +1019,7 @@ CrystalIntroSequence: ; 620b
 StartTitleScreen: ; 6219
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	call .TitleScreen

--- a/engine/link.asm
+++ b/engine/link.asm
@@ -811,31 +811,24 @@ Link_PrepPartyData_Gen2: ; 28595
 	inc de
 	dec b
 	jr nz, .loop1
-	; de = $c806
 	ld hl, PlayerName
 	ld bc, NAME_LENGTH
 	call CopyBytes
-	; de = $c811
 	ld hl, PartyCount
 	ld bc, 1 + PARTY_LENGTH + 1
 	call CopyBytes
-	; de = $c819
 	ld hl, PlayerID
 	ld bc, 2
 	call CopyBytes
-	; de = $c81b
 	ld hl, PartyMon1Species
 	ld bc, PARTY_LENGTH * PARTYMON_STRUCT_LENGTH
 	call CopyBytes
-	; de = $c93b
 	ld hl, PartyMonOT
 	ld bc, PARTY_LENGTH * NAME_LENGTH
 	call CopyBytes
-	; de = $c97d
 	ld hl, PartyMonNicknames
 	ld bc, PARTY_LENGTH * PKMN_NAME_LENGTH
 	call CopyBytes
-	; de = $c9bf
 
 ; Okay, we did all that.  Now, are we in the trade center?
 	ld a, [wLinkMode]

--- a/engine/mail_2.asm
+++ b/engine/mail_2.asm
@@ -69,7 +69,7 @@ ReadAnyMail: ; b9237
 	ld h, d
 	ld l, e
 	push hl
-	ld a, $0
+	ld a, BANK(sPartyMail)
 	call GetSRAMBank
 	ld de, sPartyMon1MailAuthorID - sPartyMon1Mail
 	add hl, de

--- a/engine/menu.asm
+++ b/engine/menu.asm
@@ -586,7 +586,7 @@ Place2DMenuCursor: ; 24329
 _PushWindow:: ; 24374
 	ld a, [rSVBK]
 	push af
-	ld a, $7
+	ld a, BANK(wWindowStack)
 	ld [rSVBK], a
 
 	ld hl, wWindowStackPointer
@@ -691,7 +691,7 @@ _ExitMenu:: ; 243e8
 
 	ld a, [rSVBK]
 	push af
-	ld a, $7
+	ld a, BANK(wWindowStack)
 	ld [rSVBK], a
 
 	call GetWindowStackTop

--- a/engine/menu.asm
+++ b/engine/menu.asm
@@ -730,7 +730,7 @@ Function24423: ; 24423
 	ld a, [VramState]
 	bit 0, a
 	ret z
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	hlcoord 0, 0
 	ld de, sScratch
@@ -738,7 +738,7 @@ Function24423: ; 24423
 	call CopyBytes
 	call CloseSRAM
 	call OverworldTextModeSwitch
-	xor a
+	xor a ; effectively ld a, BANK(sScratch)
 	call GetSRAMBank
 	ld hl, sScratch
 	decoord 0, 0

--- a/engine/menu.asm
+++ b/engine/menu.asm
@@ -730,7 +730,7 @@ Function24423: ; 24423
 	ld a, [VramState]
 	bit 0, a
 	ret z
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	hlcoord 0, 0
 	ld de, sScratch
@@ -738,7 +738,7 @@ Function24423: ; 24423
 	call CopyBytes
 	call CloseSRAM
 	call OverworldTextModeSwitch
-	xor a ; effectively ld a, BANK(sScratch)
+	xor a ; sScratch
 	call GetSRAMBank
 	ld hl, sScratch
 	decoord 0, 0

--- a/engine/mon_stats.asm
+++ b/engine/mon_stats.asm
@@ -174,7 +174,7 @@ GetGender: ; 50bdd
 ; sBoxMon data is read directly from SRAM.
 	ld a, [MonType]
 	cp BOXMON
-	ld a, 1
+	ld a, BANK(sBox)
 	call z, GetSRAMBank
 
 ; Attack DV

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1561,7 +1561,7 @@ Function10578c: ; 10578c (41:578c)
 	ld a, [sCrystalData + 0]
 	ld [de], a
 	inc de
-	ld a, $4
+	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld hl, $a603
 	ld bc, $8

--- a/engine/mystery_gift.asm
+++ b/engine/mystery_gift.asm
@@ -1563,10 +1563,10 @@ Function10578c: ; 10578c (41:578c)
 	inc de
 	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
-	ld hl, $a603
+	ld hl, $a603 ; address of MBC30 bank
 	ld bc, $8
 	call CopyBytes
-	ld hl, $a007
+	ld hl, $a007 ; address of MBC30 bank
 	ld bc, $c
 	call CopyBytes
 	call CloseSRAM

--- a/engine/pack.asm
+++ b/engine/pack.asm
@@ -1710,7 +1710,7 @@ TextJump_YouCantUseItInABattle: ; 0x10b11
 	db "@"
 ; 0x10b16
 
-PackMenuGFX:
+PackMenuGFX::
 INCBIN "gfx/pack/pack_menu.2bpp"
 PackGFX:
 INCBIN "gfx/pack/pack.2bpp"

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -279,7 +279,7 @@ PokeAnim_StereoCry: ; d0196
 PokeAnim_DeinitFrames: ; d01a9
 	ld a, [rSVBK]
 	push af
-	ld a, $2
+	ld a, BANK(wPokeAnimCoord)
 	ld [rSVBK], a
 	call PokeAnim_PlaceGraphic
 	farcall HDMATransferTileMapToWRAMBank3
@@ -876,7 +876,7 @@ PokeAnim_PlaceGraphic: ; d04bd
 PokeAnim_SetVBank1: ; d0504
 	ld a, [rSVBK]
 	push af
-	ld a, $2
+	ld a, BANK(wPokeAnimCoord)
 	ld [rSVBK], a
 	xor a
 	ld [hBGMapMode], a

--- a/engine/pic_animation.asm
+++ b/engine/pic_animation.asm
@@ -335,12 +335,12 @@ PokeAnim_InitPicAttributes: ; d01d6
 	ld a, d
 	ld [wPokeAnimGraphicStartTile], a
 
-	ld a, $1
+	ld a, BANK(CurPartySpecies)
 	ld hl, CurPartySpecies
 	call GetFarWRAMByte
 	ld [wPokeAnimSpecies], a
 
-	ld a, $1
+	ld a, BANK(UnownLetter)
 	ld hl, UnownLetter
 	call GetFarWRAMByte
 	ld [wPokeAnimUnownLetter], a

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -2348,7 +2348,7 @@ Pokedex_BlackOutBG: ; 41401 (10:5401)
 ; Make BG palettes black so that the BG becomes all black.
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 	ld hl, wBGPals1
 	ld bc, 8 palettes

--- a/engine/routines/emptyallsrambanks.asm
+++ b/engine/routines/emptyallsrambanks.asm
@@ -1,11 +1,11 @@
 EmptyAllSRAMBanks: ; 4cf1f
-	ld a, $0
+	ld a, 0
 	call .EmptyBank
-	ld a, $1
+	ld a, 1
 	call .EmptyBank
-	ld a, $2
+	ld a, 2
 	call .EmptyBank
-	ld a, $3
+	ld a, 3
 	call .EmptyBank
 	ret
 

--- a/engine/rtc.asm
+++ b/engine/rtc.asm
@@ -146,7 +146,7 @@ Function140ae: ; 140ae
 	farcall ClearDailyTimers
 	farcall Function170923
 ; mobile
-	ld a, $5
+	ld a, 5 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld a, [$aa8c]
 	inc a

--- a/engine/rtc.asm
+++ b/engine/rtc.asm
@@ -148,12 +148,12 @@ Function140ae: ; 140ae
 ; mobile
 	ld a, 5 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
-	ld a, [$aa8c]
+	ld a, [$aa8c] ; address of MBC30 bank
 	inc a
-	ld [$aa8c], a
-	ld a, [$b2fa]
+	ld [$aa8c], a ; address of MBC30 bank
+	ld a, [$b2fa] ; address of MBC30 bank
 	inc a
-	ld [$b2fa], a
+	ld [$b2fa], a ; address of MBC30 bank
 	call CloseSRAM
 	ret
 

--- a/engine/save.asm
+++ b/engine/save.asm
@@ -418,7 +418,7 @@ EraseHallOfFame: ; 14d06
 Function14d18: ; 14d18
 ; XXX
 ; copy .Data to SRA4:a007
-	ld a, $4
+	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld hl, .Data
 	ld de, $a007
@@ -454,7 +454,7 @@ SaveData: ; 14d68
 
 Function14d6c: ; 14d6c
 ; XXX
-	ld a, $4
+	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld a, [$a60b]
 	ld b, $0
@@ -471,7 +471,7 @@ Function14d6c: ; 14d6c
 
 Function14d83: ; 14d83
 ; XXX
-	ld a, $4
+	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	xor a
 	ld [$a60c], a
@@ -482,7 +482,7 @@ Function14d83: ; 14d83
 
 Function14d93: ; 14d93
 ; XXX
-	ld a, $7
+	ld a, 7 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	xor a
 	ld [$a000], a

--- a/engine/save.asm
+++ b/engine/save.asm
@@ -421,7 +421,7 @@ Function14d18: ; 14d18
 	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	ld hl, .Data
-	ld de, $a007
+	ld de, $a007 ; address of MBC30 bank
 	ld bc, .DataEnd - .Data
 	call CopyBytes
 	jp CloseSRAM
@@ -456,7 +456,7 @@ Function14d6c: ; 14d6c
 ; XXX
 	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
-	ld a, [$a60b]
+	ld a, [$a60b] ; address of MBC30 bank
 	ld b, $0
 	and a
 	jr z, .ok
@@ -464,7 +464,7 @@ Function14d6c: ; 14d6c
 
 .ok
 	ld a, b
-	ld [$a60b], a
+	ld [$a60b], a ; address of MBC30 bank
 	call CloseSRAM
 	ret
 ; 14d83
@@ -474,8 +474,8 @@ Function14d83: ; 14d83
 	ld a, 4 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	xor a
-	ld [$a60c], a
-	ld [$a60d], a
+	ld [$a60c], a ; address of MBC30 bank
+	ld [$a60d], a ; address of MBC30 bank
 	call CloseSRAM
 	ret
 ; 14d93
@@ -485,7 +485,7 @@ Function14d93: ; 14d93
 	ld a, 7 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
 	call GetSRAMBank
 	xor a
-	ld [$a000], a
+	ld [$a000], a ; address of MBC30 bank
 	call CloseSRAM
 	ret
 ; 14da0
@@ -873,6 +873,11 @@ VerifyBackupChecksum: ; 1507c (5:507c)
 
 
 _SaveData: ; 1509a
+	; This is called within two scenarios:
+	;   a) ErasePreviousSave (the process of erasing the save from a previous game file)
+	;   b) unused mobile functionality
+	; It is not part of a regular save.
+	
 	ld a, BANK(sCrystalData)
 	call GetSRAMBank
 	ld hl, wCrystalData
@@ -880,7 +885,11 @@ _SaveData: ; 1509a
 	ld bc, wCrystalDataEnd - wCrystalData
 	call CopyBytes
 
-	; XXX SRAM bank 7
+	; This block originally had some mobile functionality, but since we're still in
+	; BANK(sCrystalData), it instead overwrites the sixteen EventFlags starting at 1:a603 with
+	; garbage from wd479. This isn't an issue, since ErasePreviousSave is followed by a regular
+	; save that unwrites the garbage.
+	
 	ld hl, wd479
 	ld a, [hli]
 	ld [$a60e + 0], a
@@ -897,8 +906,10 @@ _LoadData: ; 150b9
 	ld de, wCrystalData
 	ld bc, wCrystalDataEnd - wCrystalData
 	call CopyBytes
-
-	; XXX SRAM bank 7
+	
+	; This block originally had some mobile functionality to mirror _SaveData above, but instead it
+	; (harmlessly) writes the aforementioned EventFlags to the unused wd479.
+	
 	ld hl, wd479
 	ld a, [$a60e + 0]
 	ld [hli], a

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -47,8 +47,8 @@ _TimeOfDayPals:: ; 8c011
 ; save wram bank
 	ld a, [rSVBK]
 	ld b, a
-; wram bank 5
-	ld a, $5
+	
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 ; push palette
@@ -78,8 +78,8 @@ _TimeOfDayPals:: ; 8c011
 ; save wram bank
 	ld a, [rSVBK]
 	ld d, a
-; wram bank 5
-	ld a, 5
+	
+	ld a, BANK(wOBPals1)
 	ld [rSVBK], a
 
 ; pop palette
@@ -173,7 +173,7 @@ Special_FadeBlackQuickly: ; 8c0b6
 FillWhiteBGColor: ; 8c0c1
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, wBGPals1

--- a/engine/title.asm
+++ b/engine/title.asm
@@ -162,7 +162,7 @@ _TitleScreen: ; 10ed67
 
 	ld a, [rSVBK]
 	push af
-	ld a, 5 ; BANK(LYOverrides)
+	ld a, BANK(LYOverrides)
 	ld [rSVBK], a
 
 ; Make alternating lines come in from opposite sides

--- a/engine/title.asm
+++ b/engine/title.asm
@@ -139,7 +139,7 @@ _TitleScreen: ; 10ed67
 	ld a, [rSVBK]
 	push af
 ; WRAM bank 5
-	ld a, 5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 ; Update palette colors

--- a/engine/unused_title.asm
+++ b/engine/unused_title.asm
@@ -63,7 +63,7 @@ UnusedTitleScreen: ; 10c000
 
 	ld a, [rSVBK]
 	push af
-	ld a, $5
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, UnusedTitleBG_Palettes

--- a/gfx/load_pics.asm
+++ b/gfx/load_pics.asm
@@ -206,7 +206,7 @@ GetMonBackpic: ; 5116c
 	ld c, a
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	push de
 
@@ -327,7 +327,7 @@ GetTrainerPic: ; 5120d
 	call AddNTimes
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 	push de
 	ld a, BANK(TrainerPicPointers)
@@ -358,7 +358,7 @@ DecompressPredef: ; 5125d
 
 	ld a, [rSVBK]
 	push af
-	ld a, 6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	push de

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -16,7 +16,7 @@ GameTimer:: ; 209e
 
 	ld a, [rSVBK]
 	push af
-	ld a, 1
+	ld a, BANK(GameTime)
 	ld [rSVBK], a
 
 	call UpdateGameTimer

--- a/home/init.asm
+++ b/home/init.asm
@@ -96,7 +96,7 @@ Init:: ; 17d
 	ld [hCGB], a
 
 	call ClearWRAM
-	ld a, 1
+	ld a, BANK(wd000)
 	ld [rSVBK], a
 	call ClearVRAM
 	call ClearSprites

--- a/home/init.asm
+++ b/home/init.asm
@@ -55,7 +55,7 @@ Init:: ; 17d
 	ld [rOBP1], a
 	ld [rTMA], a
 	ld [rTAC], a
-	ld [$d000], a
+	ld [WRAM1_Begin], a
 
 	ld a, %100 ; Start timer at 4096Hz
 	ld [rTAC], a

--- a/home/map.asm
+++ b/home/map.asm
@@ -1401,7 +1401,7 @@ LoadTilesetGFX:: ; 2821
 
 	ld a, [rSVBK]
 	push af
-	ld a, $6
+	ld a, BANK(wDecompressScratch)
 	ld [rSVBK], a
 
 	ld a, e

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -499,7 +499,7 @@ ClearWindowData:: ; 1fbf
 
 	ld a, [rSVBK]
 	push af
-	ld a, $7
+	ld a, BANK(wWindowStack)
 	ld [rSVBK], a
 
 	xor a

--- a/home/names.asm
+++ b/home/names.asm
@@ -7,7 +7,7 @@ NamesPointers:: ; 33ab
 	dbw 0, PartyMonOT
 	dbw 0, OTPartyMonOT
 	dba TrainerClassNames
-	dbw $4, PackMenuGFX + 60
+	dbw BANK(PackMenuGFX), PackMenuGFX + 60
 ; 33c3
 
 GetName:: ; 33c3

--- a/home/names.asm
+++ b/home/names.asm
@@ -7,7 +7,7 @@ NamesPointers:: ; 33ab
 	dbw 0, PartyMonOT
 	dbw 0, OTPartyMonOT
 	dba TrainerClassNames
-	dbw $4, $4b52 ; within PackMenuGFX
+	dbw $4, PackMenuGFX + 60
 ; 33c3
 
 GetName:: ; 33c3

--- a/home/video.asm
+++ b/home/video.asm
@@ -466,7 +466,7 @@ AnimateTileset:: ; 17d3
 
 	ld a, [rSVBK]
 	push af
-	ld a, 1
+	ld a, BANK(TilesetAnim)
 	ld [rSVBK], a
 
 	ld a, [rVBK]

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -7223,7 +7223,7 @@ Function11b483: ; 11b483
 	jr .loop8
 
 .okay4
-	ld a, $0 ; BANK(sPartyMail)
+	ld a, BANK(sPartyMail)
 	call GetSRAMBank
 	ld a, MAIL_STRUCT_LENGTH
 .loop9

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -44,7 +44,7 @@ Function17c000: ; 17c000
 	ld a, [rSVBK]
 	push af
 
-	ld a, 5 ; BANK(wBGPals1)
+	ld a, BANK(wBGPals1)
 	ld [rSVBK], a
 
 	ld hl, HaveWantPals

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -3042,10 +3042,10 @@ inc_crash_check_pointer_farcall: MACRO
 	push af
 	ld a, $1
 	ld [rSVBK], a
-REPT _NARG
+rept _NARG
 	farcall \1
-SHIFT
-ENDR
+	shift
+endr
 	pop af
 	ld [rSVBK], a
 	ret

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -620,8 +620,8 @@ Function17d314: ; 17d314
 Function17d370: ; 17d370
 	xor a
 	ld [wcd77], a
-	ld [wcd78], a
-	ld [wcd79], a
+	ld [wMobileCrashCheckPointer], a
+	ld [wMobileCrashCheckPointer + 1], a
 	dec a
 	ld [wcd6c], a
 	call ClearBGPalettes
@@ -958,9 +958,9 @@ Function17d5c4:
 	ld h, a
 	add hl, bc
 	ld a, l
-	ld [wcd78], a
+	ld [wMobileCrashCheckPointer], a
 	ld a, h
-	ld [wcd79], a
+	ld [wMobileCrashCheckPointer + 1], a
 	ld a, $3
 	ld [wcd77], a
 	ret
@@ -1122,9 +1122,9 @@ Function17d6fd: ; 17d6fd
 	ld a, [wcd77]
 	bit 7, a
 	jr nz, asm_17d721
-	ld a, [wcd78]
+	ld a, [wMobileCrashCheckPointer]
 	ld l, a
-	ld a, [wcd79]
+	ld a, [wMobileCrashCheckPointer + 1]
 	ld h, a
 	ld a, [hl]
 	cp $ff
@@ -1193,11 +1193,11 @@ Jumptable17d72a: ; 17d72a
 	dw Function17e27f
 	dw Function17e293
 	dw Function17e2a7
-	dw Function17e367
-	dw Function17e37e
-	dw Function17e395
-	dw Function17e3ac
-	dw Function17e3c3
+	dw IncCrashCheckPointer_SaveGameData
+	dw IncCrashCheckPointer_SaveAfterLinkTrade
+	dw IncCrashCheckPointer_SaveBox
+	dw IncCrashCheckPointer_SaveChecksum
+	dw IncCrashCheckPointer_SaveTrainerRankingsChecksum
 	dw Function17e3e0
 	dw Function17e3f0
 	dw Function17e409
@@ -1208,12 +1208,12 @@ Function17d78c: ; 17d78c
 ; 17d78d
 
 Function17d78d: ; 17d78d
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld a, $6
 	call GetSRAMBank
 	ld hl, $a006
@@ -1229,40 +1229,40 @@ Function17d78d: ; 17d78d
 ; 17d7b4
 
 Function17d7b4: ; 17d7b4
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld d, $0
 	call PlayMusic2
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17d7c2
 
 Function17d7c2: ; 17d7c2
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld d, $0
 	call PlaySFX
 	call WaitSFX
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17d7d3
 
 Function17d7d3: ; 17d7d3
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	dec a
 	ld e, a
 	ld d, $0
 	call PlayCryHeader
 	call WaitSFX
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17d7e5
 
 Function17d7e5: ; 17d7e5
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld [wcd4f], a
 	ld a, [hli]
@@ -1283,12 +1283,12 @@ Function17d7e5: ; 17d7e5
 	ld [wcd53], a
 	ld de, wcd4f
 	call Function17e691
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17d818
 
 Function17d818: ; 17d818
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld c, a
 	ld a, [hli]
@@ -1297,7 +1297,7 @@ Function17d818: ; 17d818
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	call Function17e447
 	ld e, l
 	ld d, h
@@ -1308,7 +1308,7 @@ Function17d818: ; 17d818
 ; 17d833
 
 Function17d833: ; 17d833
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1317,7 +1317,7 @@ Function17d833: ; 17d833
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	push de
 	push bc
 	call Function17e32b
@@ -1336,7 +1336,7 @@ Function17d833: ; 17d833
 ; 17d85d
 
 Function17d85d: ; 17d85d
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1406,7 +1406,7 @@ Function17d85d: ; 17d85d
 	jr .asm_17d878
 
 .asm_17d8c7
-	call Function17e41e
+	call HlToCrashCheckPointer
 	push bc
 	ld a, $3
 	ld [rSVBK], a
@@ -1437,13 +1437,13 @@ Function17d85d: ; 17d85d
 ; 17d902
 
 Function17d902: ; 17d902
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
 	ld d, a
 	push de
-	call Function17e41e
+	call HlToCrashCheckPointer
 	call Function17e32b
 	pop de
 	ld hl, wBGPals1
@@ -1472,11 +1472,11 @@ Function17d902: ; 17d902
 ; 17d93a
 
 Function17d93a: ; 17d93a
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $5
 	call CopyBytes
-	call Function17e41e
+	call HlToCrashCheckPointer
 	call Function17e32b
 	ld a, [rSVBK]
 	push af
@@ -1508,11 +1508,11 @@ Function17d93a: ; 17d93a
 ; 17d98b
 
 Function17d98b: ; 17d98b
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $4
 	call CopyBytes
-	call Function17e41e
+	call HlToCrashCheckPointer
 	call Function17e32b
 	ld a, [rSVBK]
 	push af
@@ -1545,11 +1545,11 @@ Function17d98b: ; 17d98b
 ; 17d9e3
 
 Function17d9e3: ; 17d9e3
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $7
 	call CopyBytes
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld a, [$c70b]
 	push af
 	cp $c0
@@ -1591,11 +1591,11 @@ Function17d9e3: ; 17d9e3
 ; 17da31
 
 Function17da31: ; 17da31
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $4
 	call CopyBytes
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld a, [$c709]
 	push af
 	cp $c0
@@ -1681,7 +1681,7 @@ Function17da9c: ; 17da9c
 	call Function17e55b
 	call Function17e5af
 .asm_17daba
-	jp Function17e415
+	jp IncCrashCheckPointer
 
 .asm_17dabd
 	ld a, [wcd2f]
@@ -1723,7 +1723,7 @@ Function17dadc: ; 17dadc
 	call Function17e5af
 
 .asm_17db0e
-	jp Function17e415
+	jp IncCrashCheckPointer
 
 .asm_17db11
 	ld hl, wcd24
@@ -1758,7 +1758,7 @@ Function17db2d: ; 17db2d
 	call Function17e5af
 
 .asm_17db53
-	jp Function17e415
+	jp IncCrashCheckPointer
 ; 17db56
 
 Function17db56: ; 17db56
@@ -1776,7 +1776,7 @@ Function17db56: ; 17db56
 	call Function17e5af
 
 .asm_17db74
-	jp Function17e415
+	jp IncCrashCheckPointer
 ; 17db77
 
 Function17db77: ; 17db77
@@ -1808,7 +1808,7 @@ Function17db77: ; 17db77
 	call Function17e5af
 
 .asm_17dbae
-	jp Function17e415
+	jp IncCrashCheckPointer
 ; 17dbb1
 
 Function17dbb1: ; 17dbb1
@@ -1878,11 +1878,11 @@ Function17dbe9: ; 17dbe9
 	call Function17e451
 	call Function17e55b
 	call Function17e5af
-	jp Function17e415
+	jp IncCrashCheckPointer
 ; 17dc1f
 
 Function17dc1f: ; 17dc1f
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c688
 	ld bc, $6
 	call CopyBytes
@@ -1950,15 +1950,15 @@ MenuData2_17dc96:
 ; 17dc9f
 
 Function17dc9f: ; 17dc9f
-	call Function17e415
-	call Function17e41e
+	call IncCrashCheckPointer
+	call HlToCrashCheckPointer
 	call RotateFourPalettesLeft
 	ret
 ; 17dca9
 
 Function17dca9: ; 17dca9
-	call Function17e415
-	call Function17e41e
+	call IncCrashCheckPointer
+	call HlToCrashCheckPointer
 
 Function17dcaf:
 	ld a, $5
@@ -1983,7 +1983,7 @@ Function17dcaf:
 ; 17dccf
 
 Function17dccf: ; 17dccf
-	call Function17e415
+	call IncCrashCheckPointer
 	push hl
 	ld a, [wcd4b]
 	ld l, a
@@ -1999,11 +1999,11 @@ Function17dccf: ; 17dccf
 	ld a, [hl]
 	ld b, a
 	call Function17e43d
-	call Function17e41e
+	call HlToCrashCheckPointer
 .asm_17dced
-	ld a, [wcd78]
+	ld a, [wMobileCrashCheckPointer]
 	ld l, a
-	ld a, [wcd79]
+	ld a, [wMobileCrashCheckPointer + 1]
 	ld h, a
 	ld a, [hl]
 	cp $ff
@@ -2021,7 +2021,7 @@ Function17dccf: ; 17dccf
 
 .asm_17dd0d
 	pop hl
-	jp Function17e41e
+	jp HlToCrashCheckPointer
 
 .asm_17dd11
 	pop hl
@@ -2029,7 +2029,7 @@ Function17dccf: ; 17dccf
 ; 17dd13
 
 Function17dd13: ; 17dd13
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld c, a
 	ld a, [hli]
@@ -2038,7 +2038,7 @@ Function17dd13: ; 17dd13
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	call Function17e447
 	push hl
 	hlcoord 0, 0
@@ -2051,7 +2051,7 @@ Function17dd13: ; 17dd13
 ; 17dd30
 
 Function17dd30: ; 17dd30
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -2061,7 +2061,7 @@ Function17dd30: ; 17dd30
 	ld b, $0
 	ld a, [hli]
 	push af
-	call Function17e41e
+	call HlToCrashCheckPointer
 	pop af
 	hlcoord 0, 0
 	add hl, de
@@ -2070,7 +2070,7 @@ Function17dd30: ; 17dd30
 ; 17dd49
 
 Function17dd49: ; 17dd49
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $a
 	call CopyBytes
@@ -2151,7 +2151,7 @@ Function17dd49: ; 17dd49
 ; 17ddcd
 
 Function17ddcd: ; 17ddcd
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $8
 	call CopyBytes
@@ -2213,7 +2213,7 @@ Function17ddcd: ; 17ddcd
 ; 17de32
 
 Function17de32: ; 17de32
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $9
 	call CopyBytes
@@ -2272,7 +2272,7 @@ Function17de32: ; 17de32
 ; 17de91
 
 Function17de91: ; 17de91
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $7
 	call CopyBytes
@@ -2315,7 +2315,7 @@ Function17de91: ; 17de91
 ; 17ded9
 
 Function17ded9: ; 17ded9
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $1f
 	call CopyBytes
@@ -2656,7 +2656,7 @@ asm_17e0ee
 ; 17e0fd
 
 Function17e0fd: ; 17e0fd
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $6
 	call CopyBytes
@@ -2690,7 +2690,7 @@ Function17e0fd: ; 17e0fd
 ; 17e133
 
 Function17e133: ; 17e133
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $5
 	call CopyBytes
@@ -2721,7 +2721,7 @@ Function17e133: ; 17e133
 ; 17e165
 
 Function17e165: ; 17e165
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $5
 	call CopyBytes
@@ -2758,7 +2758,7 @@ Function17e165: ; 17e165
 ; 17e1a1
 
 Function17e1a1: ; 17e1a1
-	call Function17e415
+	call IncCrashCheckPointer
 	ld de, $c708
 	ld bc, $d
 	call CopyBytes
@@ -2867,19 +2867,19 @@ Function17e1a1: ; 17e1a1
 ; 17e254
 
 Function17e254: ; 17e254
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
 	ld d, a
 	ld a, [hli]
 	ld [de], a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17e261
 
 Function17e261: ; 17e261
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -2888,12 +2888,12 @@ Function17e261: ; 17e261
 	add [hl]
 	ld [de], a
 	inc hl
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17e270
 
 Function17e270: ; 17e270
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -2902,12 +2902,12 @@ Function17e270: ; 17e270
 	sub [hl]
 	ld [de], a
 	inc hl
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ret
 ; 17e27f
 
 Function17e27f: ; 17e27f
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -2916,7 +2916,7 @@ Function17e27f: ; 17e27f
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld l, c
 	ld h, b
 	ld a, [de]
@@ -2926,7 +2926,7 @@ Function17e27f: ; 17e27f
 ; 17e293
 
 Function17e293: ; 17e293
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -2935,7 +2935,7 @@ Function17e293: ; 17e293
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld l, c
 	ld h, b
 	ld a, [de]
@@ -2945,8 +2945,8 @@ Function17e293: ; 17e293
 ; 17e2a7
 
 Function17e2a7: ; 17e2a7
-	call Function17e415
-	call Function17e41e
+	call IncCrashCheckPointer
+	call HlToCrashCheckPointer
 	call Function17e32b
 	xor a
 	ld [wcf66], a
@@ -3035,77 +3035,46 @@ Function17e349: ; 17e349
 	ret
 ; 17e367
 
-Function17e367: ; 17e367
-	call Function17e415
-	call Function17e41e
+inc_crash_check_pointer_farcall: MACRO
+	call IncCrashCheckPointer
+	call HlToCrashCheckPointer ; redundant
 	ld a, [rSVBK]
 	push af
 	ld a, $1
 	ld [rSVBK], a
-	farcall SaveGameData_
+REPT _NARG
+	farcall \1
+SHIFT
+ENDR
 	pop af
 	ld [rSVBK], a
 	ret
+ENDM
+
+IncCrashCheckPointer_SaveGameData: ; 17e367
+	inc_crash_check_pointer_farcall SaveGameData_
 ; 17e37e
 
-Function17e37e: ; 17e37e
-	call Function17e415
-	call Function17e41e
-	ld a, [rSVBK]
-	push af
-	ld a, $1
-	ld [rSVBK], a
-	farcall SaveAfterLinkTrade
-	pop af
-	ld [rSVBK], a
-	ret
-; 17e395
+IncCrashCheckPointer_SaveAfterLinkTrade: ; 17e37e
+	inc_crash_check_pointer_farcall SaveAfterLinkTrade
 
-Function17e395: ; 17e395
-	call Function17e415
-	call Function17e41e
-	ld a, [rSVBK]
-	push af
-	ld a, $1
-	ld [rSVBK], a
-	farcall SaveBox
-	pop af
-	ld [rSVBK], a
-	ret
+IncCrashCheckPointer_SaveBox: ; 17e395
+	inc_crash_check_pointer_farcall SaveBox
 ; 17e3ac
 
-Function17e3ac: ; 17e3ac
-	call Function17e415
-	call Function17e41e
-	ld a, [rSVBK]
-	push af
-	ld a, $1
-	ld [rSVBK], a
-	farcall SaveChecksum
-	pop af
-	ld [rSVBK], a
-	ret
+IncCrashCheckPointer_SaveChecksum: ; 17e3ac
+	inc_crash_check_pointer_farcall SaveChecksum
 ; 17e3c3
 
-Function17e3c3: ; 17e3c3
-	call Function17e415
-	call Function17e41e
-	ld a, [rSVBK]
-	push af
-	ld a, $1
-	ld [rSVBK], a
-	farcall UpdateTrainerRankingsChecksum2
-	farcall BackupMobileEventIndex
-	pop af
-	ld [rSVBK], a
-	ret
+IncCrashCheckPointer_SaveTrainerRankingsChecksum: ; 17e3c3
+	inc_crash_check_pointer_farcall UpdateTrainerRankingsChecksum2, BackupMobileEventIndex
 ; 17e3e0
 
 Function17e3e0: ; 17e3e0
-	call Function17e415
+	call IncCrashCheckPointer
 	ld a, [hli]
 	ld c, a
-	call Function17e41e
+	call HlToCrashCheckPointer
 	ld a, $1
 	ld [hBGMapMode], a
 	call DelayFrames
@@ -3113,8 +3082,8 @@ Function17e3e0: ; 17e3e0
 ; 17e3f0
 
 Function17e3f0: ; 17e3f0
-	call Function17e415
-	call Function17e41e
+	call IncCrashCheckPointer
+	call HlToCrashCheckPointer
 .asm_17e3f6
 	call JoyTextDelay
 	ld hl, hJoyPressed
@@ -3137,20 +3106,20 @@ Function17e409: ; 17e409
 Function17e40f: ; 17e40f
 	ld de, wBGPals1
 	add hl, de
-	jr Function17e41e
+	jr HlToCrashCheckPointer
 
-Function17e415:
-	ld a, [wcd78]
+IncCrashCheckPointer:
+	ld a, [wMobileCrashCheckPointer]
 	ld l, a
-	ld a, [wcd79]
+	ld a, [wMobileCrashCheckPointer + 1]
 	ld h, a
 	inc hl
 
-Function17e41e:
+HlToCrashCheckPointer:
 	ld a, l
-	ld [wcd78], a
+	ld [wMobileCrashCheckPointer], a
 	ld a, h
-	ld [wcd79], a
+	ld [wMobileCrashCheckPointer + 1], a
 	ret
 ; 17e427
 

--- a/mobile/print_opp_message.asm
+++ b/mobile/print_opp_message.asm
@@ -10,7 +10,7 @@ Mobile_PrintOpponentBattleMessage: ; 4ea0a
 	call AddNTimes
 	ld de, wMobileOpponentBattleMessage
 	ld bc, $c
-	ld a, $5 ; BANK(w5_MobileOpponentBattleMessages)
+	ld a, BANK(w5_MobileOpponentBattleMessages)
 	call FarCopyWRAM
 
 	ld a, [rSVBK]

--- a/wram.asm
+++ b/wram.asm
@@ -1202,8 +1202,7 @@ wcd74:: ds 1
 wOTMonSelection:: ds 2 ; ds 3
 wcd77:: ds 1
 
-wcd78:: ds 1
-wcd79:: ds 1
+wMobileCrashCheckPointer:: dw
 wcd7a:: ds 2
 wcd7c:: ds 3
 wcd7f:: ds 1

--- a/wram.asm
+++ b/wram.asm
@@ -2278,6 +2278,7 @@ StartSecond:: db ; d4b9
 wRTC:: ds 8 ; d4ba
 wDST:: db ; d4c2
 
+GameTime::
 GameTimeCap::     db ; d4c3
 GameTimeHours::   dw ; d4c4
 GameTimeMinutes:: db ; d4c6
@@ -2879,6 +2880,7 @@ w3_dffc:: ds 4
 SECTION "GBC Video", WRAMX
 
 ; eight 4-color palettes each
+wPals::
 wBGPals1:: ds 8 palettes ; d000
 wOBPals1:: ds 8 palettes ; d040
 wBGPals2:: ds 8 palettes ; d080
@@ -2889,6 +2891,7 @@ LYOverridesEnd:: ; d190
 
 	ds 1
 
+wMagnetTrain::
 wMagnetTrainDirection:: db
 wMagnetTrainInitPosition:: db
 wMagnetTrainHoldPosition:: db


### PR DESCRIPTION
Addresses [#413](https://github.com/pret/pokecrystal/issues/413).

"Replace" is defined here as replacing constant numbers with `BANK` functions (in the case of banks) or labels (in the case of addresses), *except* where the use of a bank or address appears unnecessary and therefore can't be clearly labeled (such cases should be explicitly commented, though).

"Non-mobile code" is defined here as all code outside `mobile/*.asm`, `lib/mobile/main.asm` , and `home/mobile.asm`. (There are still thousands of hardcoded banks & addresses in mobile code.)

- ~~Replace hardcoded ROM banks.~~ (Possibly unneeded?)
- [x] Replace hardcoded SRAM banks.
- [x] Replace hardcoded WRAM banks.
- [x] Replace hardcoded ROM addresses.
- [x] Replace hardcoded SRAM addresses.
- [x] Replace hardcoded WRAM addresses.
- ~~Replace hardcoded VRAM banks & addresses.~~ (This isn't advisable while VRAM is still [vaguely and incompletely labeled](https://github.com/pret/pokecrystal/issues/466)).

([fb825a8](https://github.com/pret/pokecrystal/commit/fb825a800e44c0795225949658b58a0522a9c998) is irrelevant and a relic I committed before I knew the scope of this PR. But I left it in since it just makes one minor improvement to mobile code.)
  
  
  