### PR TITLE
Add Fix for Lock-On Bug

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -304,6 +304,7 @@ Fix:
 CheckHiddenOpponent: ; 37daa
 	ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	call GetBattleVar
+	ld a, [hl]
 	and 1 << SUBSTATUS_LOCK_ON
 	cp 1 << SUBSTATUS_LOCK_ON
 	ret z

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -302,17 +302,10 @@ Fix:
 
 ```asm
 CheckHiddenOpponent: ; 37daa
-	ld a, BATTLE_VARS_SUBSTATUS5_OPP
-	call GetBattleVar
-	ld a, [hl]
-	and 1 << SUBSTATUS_LOCK_ON
-	cp 1 << SUBSTATUS_LOCK_ON
-	ret z
-	ld a, BATTLE_VARS_SUBSTATUS3_OPP
-	call GetBattleVar
-	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
 	ret
 ```
+
+The code in `CheckHiddenOpponent` is completely redundant as `CheckHit` already does what this code is doing. Another option is to remove `CheckHiddenOpponent` completely, the calls to `CheckHiddenOpponent`, and the jump afterwards.
 
 ## Beat Up can desynchronize link battles
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -53,7 +53,6 @@ These are known bugs and glitches in the original Pokémon Crystal game: code th
 - [`TryObjectEvent` arbitrary code execution](#tryobjectevent-arbitrary-code-execution)
 - [`Special_CheckBugContestContestantFlag` can read beyond its data table](#special_checkbugcontestcontestantflag-can-read-beyond-its-data-table)
 - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
-- [Moves erroneously say they have missed when the opponent uses Protect or Detect](#moves-erroneously-say-they-have-missed-when-the-opponent-uses-protect-or-detect)
 
 
 ## Thick Club and Light Ball can decrease damage done with boosted (Special) Attack
@@ -1493,29 +1492,3 @@ ClearWRAM:: ; 25a
 ```
 
 **Fix:** Change `jr nc, .bank_loop` to `jr c, .bank_loop`.
-
-## Moves erroneously say they have missed when the opponent uses Protect or Detect
-
-In [battle/effect_commands.asm](battle/effect_commands.asm):
-
-```asm
-BattleCommand_CheckHit: ; 34d32
-; checkhit
-
-	call .DreamEater
-	jp z, .Miss
-
-	call .Protect
-	jp nz, .Miss
-```
-
-**Fix:** Change `jp nz, .Miss` to `jp nz, .Failed` and add
-
-```asm
-.Failed:
-    ld a, 1
-    ld [wEffectFailed], a
-    ret
-```
-
-at [line 1781](battle/effect_commands.asm#L1718).

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -295,7 +295,7 @@ CheckHiddenOpponent: ; 37daa
 ; Uncomment the lines below to fix.
 	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	; call GetBattleVar
-    ; bit SUBSTATUS_LOCK_ON, a
+    ; and 1 << SUBSTATUS_LOCK_ON
     ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -305,6 +305,7 @@ CheckHiddenOpponent: ; 37daa
 	ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	call GetBattleVar
 	and 1 << SUBSTATUS_LOCK_ON
+	cp 1 << SUBSTATUS_LOCK_ON
 	ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -53,6 +53,7 @@ These are known bugs and glitches in the original Pokémon Crystal game: code th
 - [`TryObjectEvent` arbitrary code execution](#tryobjectevent-arbitrary-code-execution)
 - [`Special_CheckBugContestContestantFlag` can read beyond its data table](#special_checkbugcontestcontestantflag-can-read-beyond-its-data-table)
 - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
+- [Moves erroneously say they have missed when the opponent uses Protect or Detect](#moves-erroneously-say-they-have-missed-when-the-opponent-uses-protect-or-detect)
 
 
 ## Thick Club and Light Ball can decrease damage done with boosted (Special) Attack
@@ -1486,3 +1487,29 @@ ClearWRAM:: ; 25a
 ```
 
 **Fix:** Change `jr nc, .bank_loop` to `jr c, .bank_loop`.
+
+## Moves erroneously say they have missed when the opponent uses Protect or Detect
+
+In [battle/effect_commands.asm](battle/effect_commands.asm):
+
+```asm
+BattleCommand_CheckHit: ; 34d32
+; checkhit
+
+	call .DreamEater
+	jp z, .Miss
+
+	call .Protect
+	jp nz, .Miss
+```
+
+**Fix:** Change `jp nz, .Miss` to `jp nz, .Failed` and add
+
+```asm
+.Failed:
+    ld a, 1
+    ld [wEffectFailed], a
+    ret
+```
+
+at [line 1781](battle/effect_commands.asm#L1718).

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -293,19 +293,25 @@ This is a bug with `CheckHiddenOpponent` in [engine/battle/effect_commands.asm](
 ```asm
 CheckHiddenOpponent: ; 37daa
 ; BUG: This routine should account for Lock-On and Mind Reader.
-; Uncomment the lines below to fix.
-	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
-	; call GetBattleVar
-    ; and 1 << SUBSTATUS_LOCK_ON
-    ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
 	ret
 ```
 
-**Fix:** Uncomment those 4 lines to fix.
+Fix:
 
+```asm
+CheckHiddenOpponent: ; 37daa
+	ld a, BATTLE_VARS_SUBSTATUS5_OPP
+	call GetBattleVar
+	and 1 << SUBSTATUS_LOCK_ON
+	ret z
+	ld a, BATTLE_VARS_SUBSTATUS3_OPP
+	call GetBattleVar
+	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
+	ret
+```
 
 ## Beat Up can desynchronize link battles
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -292,13 +292,18 @@ This is a bug with `CheckHiddenOpponent` in [engine/battle/effect_commands.asm](
 ```asm
 CheckHiddenOpponent: ; 37daa
 ; BUG: This routine should account for Lock-On and Mind Reader.
+; Uncomment the lines below to fix.
+	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
+	; call GetBattleVar
+    ; bit SUBSTATUS_LOCK_ON, a
+    ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
 	ret
 ```
 
-*To do:* Fix this bug.
+**Fix:** Uncomment those 4 lines to fix.
 
 
 ## Beat Up can desynchronize link battles

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -9711,7 +9711,7 @@ CheckHiddenOpponent: ; 37daa
 ; Uncomment the lines below to fix.
 	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	; call GetBattleVar
-    ; bit SUBSTATUS_LOCK_ON, a
+    ; and 1 << SUBSTATUS_LOCK_ON
     ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -9708,6 +9708,11 @@ BattleCommand_ThunderAccuracy: ; 37d94
 
 CheckHiddenOpponent: ; 37daa
 ; BUG: This routine should account for Lock-On and Mind Reader.
+; Uncomment the lines below to fix.
+	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
+	; call GetBattleVar
+    ; bit SUBSTATUS_LOCK_ON, a
+    ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -9708,11 +9708,6 @@ BattleCommand_ThunderAccuracy: ; 37d94
 
 CheckHiddenOpponent: ; 37daa
 ; BUG: This routine should account for Lock-On and Mind Reader.
-; Uncomment the lines below to fix.
-	; ld a, BATTLE_VARS_SUBSTATUS5_OPP
-	; call GetBattleVar
-    ; and 1 << SUBSTATUS_LOCK_ON
-    ; ret z
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND


### PR DESCRIPTION
These changes should fix the status move and secondary effects not working if the opponent is flying or digging but has been locked on.