### PR TITLE
Don’t use GNU extensions when calling sed

### DIFF
--- a/tools/sort_symfile.sh
+++ b/tools/sort_symfile.sh
@@ -8,6 +8,6 @@ sed \
     -e "s/^00:[C-D]/4_WRAM0@&/g" \
     -e "s/^..:[D-D]/5_WRAMX@&/g" \
     $1 \
-| sort -o $TEMP_FILE
-sed -e "s/^.*@//g" $TEMP_FILE > $1
-rm $TEMP_FILE
+| sort \
+| sed -e "s/^.*@//g" > $TEMP_FILE
+mv $TEMP_FILE $1


### PR DESCRIPTION
Apparently, GNU `sed` has a few extensions that aren’t supported by the version of BSD `sed` that currently comes with Macs.

This would cause `sort_symfile.sh` to fail on macOS, causing the build to appear to fail at the last minute.

Admittedly, I’m not very familiar with `sed`, but this seems to do the trick on both macOS and Ubuntu. I'm open to slicker solutions, if anyone more experienced wants to give this a shot.

- The input file must be last in the arguments list.
- The `-i` option, allowing the same file for input and output, doesn’t appear to be supported. Instead, I’m writing the output to a temporary file, and replacing the original file with that temporary file.
- Apparently `\w` isn’t supported, so I’m simply using `.` instead, as it appears to match “0_ROM0@” etc. just as well.