### PR TITLE
Note which labels are only needed for locating banks (relevant to issue #485)

### DIFF
--- a/data/moves/descriptions.asm
+++ b/data/moves/descriptions.asm
@@ -836,6 +836,7 @@ LovelyKissDescription:
 SkyAttackDescription:
 	db   "1st turn: Prepare"
 	next "2nd turn: Attack@"
+
 TransformDescription:
 	db   "The user assumes"
 	next "the foe's guise.@"

--- a/data/moves/effects.asm
+++ b/data/moves/effects.asm
@@ -1,4 +1,4 @@
-MoveEffects: ; 2732e
+MoveEffects: ; used only for BANK(MoveEffects)
 
 NormalHit:
 	checkobedience

--- a/data/pokemon/dex_entries.asm
+++ b/data/pokemon/dex_entries.asm
@@ -3,7 +3,6 @@ INCLUDE "constants.asm"
 
 SECTION "Pokedex Entries 001-064", ROMX
 
-PokedexEntries1::
 BulbasaurPokedexEntry::  INCLUDE "data/pokemon/dex_entries/bulbasaur.asm"
 IvysaurPokedexEntry::    INCLUDE "data/pokemon/dex_entries/ivysaur.asm"
 VenusaurPokedexEntry::   INCLUDE "data/pokemon/dex_entries/venusaur.asm"
@@ -72,7 +71,6 @@ KadabraPokedexEntry::    INCLUDE "data/pokemon/dex_entries/kadabra.asm"
 
 SECTION "Pokedex Entries 065-128", ROMX
 
-PokedexEntries2::
 AlakazamPokedexEntry::   INCLUDE "data/pokemon/dex_entries/alakazam.asm"
 MachopPokedexEntry::     INCLUDE "data/pokemon/dex_entries/machop.asm"
 MachokePokedexEntry::    INCLUDE "data/pokemon/dex_entries/machoke.asm"
@@ -141,7 +139,6 @@ TaurosPokedexEntry::     INCLUDE "data/pokemon/dex_entries/tauros.asm"
 
 SECTION "Pokedex Entries 129-192", ROMX
 
-PokedexEntries3::
 MagikarpPokedexEntry::   INCLUDE "data/pokemon/dex_entries/magikarp.asm"
 GyaradosPokedexEntry::   INCLUDE "data/pokemon/dex_entries/gyarados.asm"
 LaprasPokedexEntry::     INCLUDE "data/pokemon/dex_entries/lapras.asm"
@@ -210,7 +207,6 @@ SunfloraPokedexEntry::   INCLUDE "data/pokemon/dex_entries/sunflora.asm"
 
 SECTION "Pokedex Entries 193-251", ROMX
 
-PokedexEntries4::
 YanmaPokedexEntry::      INCLUDE "data/pokemon/dex_entries/yanma.asm"
 WooperPokedexEntry::     INCLUDE "data/pokemon/dex_entries/wooper.asm"
 QuagsirePokedexEntry::   INCLUDE "data/pokemon/dex_entries/quagsire.asm"

--- a/data/pokemon/egg_moves.asm
+++ b/data/pokemon/egg_moves.asm
@@ -11,11 +11,7 @@ SECTION "Egg Moves", ROMX
 ; Staryu's egg moves were removed in Crystal, because Staryu is genderless
 ; and can only breed with Ditto.
 
-
 INCLUDE "data/pokemon/egg_move_pointers.asm"
-
-
-EggMoves::
 
 BulbasaurEggMoves:
 	db LIGHT_SCREEN

--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -3,11 +3,6 @@ INCLUDE "constants.asm"
 
 SECTION "Evolutions and Attacks", ROMX
 
-
-INCLUDE "data/pokemon/evos_attacks_pointers.asm"
-
-
-EvosAttacks::
 ; Evos+attacks data structure:
 ; - Evolution methods:
 ;    * db EVOLVE_LEVEL, level, species
@@ -20,6 +15,7 @@ EvosAttacks::
 ;    * db level, move
 ; - db 0 ; no more level-up moves
 
+INCLUDE "data/pokemon/evos_attacks_pointers.asm"
 
 BulbasaurEvosAttacks:
 	db EVOLVE_LEVEL, 16, IVYSAUR

--- a/data/text/battle.asm
+++ b/data/text/battle.asm
@@ -1,4 +1,4 @@
-BattleText::
+BattleText:: ; used only for BANK(BattleText)
 
 BattleText_PlayerPickedUpPayDayMoney: ; 0x80730
 	text "<PLAYER> picked up"

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -49,7 +49,7 @@ These are known bugs and glitches in the original Pokémon Crystal game: code th
 - [Catching a Transformed Pokémon always catches a Ditto](#catching-a-transformed-pokémon-always-catches-a-ditto)
 - [Using a Park Ball in normal battles has a corrupt animation](#using-a-park-ball-in-normal-battles-has-a-corrupt-animation)
 - [`HELD_CATCH_CHANCE` has no effect](#held_catch_chance-has-no-effect)
-- [Only the first three `EvosAttacks` evolution entries can have Stone compatibility reported correctly](#only-the-first-three-evosattacks-evolution-entries-can-have-stone-compatibility-reported-correctly)
+- [Only the first three evolution entries can have Stone compatibility reported correctly](#only-the-first-three-evolution-entries-can-have-stone-compatibility-reported-correctly)
 - [`EVOLVE_STAT` can break Stone compatibility reporting](#evolve_stat-can-break-stone-compatibility-reporting)
 - [`ScriptCall` can overflow `wScriptStack` and crash](#scriptcall-can-overflow-wscriptstack-and-crash)
 - [`LoadSpriteGFX` does not limit the capacity of `UsedSprites`](#loadspritegfx-does-not-limit-the-capacity-of-usedsprites)
@@ -712,7 +712,7 @@ MoonBallMultiplier:
 ; No Pokémon evolve with Burn Heal,
 ; so Moon Balls always have a catch rate of 1×.
 	push bc
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	cp MOON_STONE_RED ; BURN_HEAL
 	pop bc
@@ -1360,7 +1360,7 @@ This is a bug with `PokeBallEffect` in [engine/items/item_effects.asm](/engine/i
 **Fix:** Uncomment `ld b, a`.
 
 
-## Only the first three `EvosAttacks` evolution entries can have Stone compatibility reported correctly
+## Only the first three evolution entries can have Stone compatibility reported correctly
 
 This is a bug with `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` in [engine/pokemon/party_menu.asm](/engine/pokemon/party_menu.asm):
 
@@ -1375,7 +1375,7 @@ This is a bug with `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` i
 	ld h, [hl]
 	ld l, a
 	ld de, wStringBuffer1
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	ld bc, 10
 	call FarCopyBytes
 ```

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -393,10 +393,10 @@ GetDexEntryPointer: ; 44333
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 ```
 
 `GetPokedexEntryBank` in [engine/items/item_effects.asm](/engine/items/item_effects.asm):
@@ -419,10 +419,10 @@ GetPokedexEntryBank:
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 ```
 
 And `PokedexShow_GetDexEntryBank` in [engine/pokegear/radio.asm](/engine/pokegear/radio.asm):
@@ -446,10 +446,10 @@ PokedexShow_GetDexEntryBank:
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 ```
 
 **Fix:** Use `dba` instead of `dw` in `PokedexDataPointerTable`, and modify the code that accesses it to match.

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1,4 +1,4 @@
-AIScoring: ; 38591
+AIScoring: ; used only for BANK(AIScoring)
 
 AI_Basic: ; 38591
 ; Don't do anything redundant:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1,5 +1,5 @@
 ; Core components of the battle engine.
-BattleCore:
+
 DoBattle: ; 3c000
 	xor a
 	ld [wBattleParticipantsNotFainted], a

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -7394,7 +7394,7 @@ PlayOpponentBattleAnim: ; 37e54
 
 
 CallBattleCore: ; 37e73
-	ld a, BANK(BattleCore)
+	ld a, BANK("Battle Core")
 	rst FarCall
 	ret
 
@@ -7467,7 +7467,7 @@ GetMoveData: ; 37ead
 	ld hl, Moves
 	ld bc, MOVE_LENGTH
 	call AddNTimes
-	ld a, Bank(Moves)
+	ld a, BANK(Moves)
 	jp FarCopyBytes
 
 ; 37ebb

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -977,7 +977,7 @@ BattleAnimCmd_RaiseSub: ; cc640 (33:4640)
 	xor a ; sScratch
 	call GetSRAMBank
 
-GetSubstitutePic: ; cc64c
+GetSubstitutePic: ; used only for BANK(GetSubstitutePic)
 
 	ld hl, sScratch
 	ld bc, (7 * 7) tiles

--- a/engine/events/catch_tutorial_input.asm
+++ b/engine/events/catch_tutorial_input.asm
@@ -15,7 +15,7 @@ _DudeAutoInput: ; 1de299
 	call StartAutoInput
 	ret
 
-DudeAutoInputs:
+DudeAutoInputs: ; used only for BANK(DudeAutoInputs)
 
 DudeAutoInput_A: ; 1de29f
 	db NO_INPUT, $50

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -767,10 +767,10 @@ GetPokedexEntryBank:
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 
 HeavyBallMultiplier:
 ; subtract 20 from catch rate if weight < 102.4 kg
@@ -907,7 +907,7 @@ MoonBallMultiplier:
 	pop bc
 
 	push bc
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	cp EVOLVE_ITEM
 	pop bc
@@ -921,7 +921,7 @@ MoonBallMultiplier:
 ; No Pokémon evolve with Burn Heal,
 ; so Moon Balls always have a catch rate of 1×.
 	push bc
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	cp MOON_STONE_RED ; BURN_HEAL
 	pop bc

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -611,7 +611,7 @@ Credits_TheEnd: ; 109c11 (42:5c11)
 
 CreditsBorderGFX:    INCBIN "gfx/credits/border.2bpp"
 
-CreditsMonsGFX:
+CreditsMonsGFX: ; used only for BANK(CreditsMonsGFX)
 CreditsPichuGFX:     INCBIN "gfx/credits/pichu.2bpp"
 CreditsSmoochumGFX:  INCBIN "gfx/credits/smoochum.2bpp"
 CreditsDittoGFX:     INCBIN "gfx/credits/ditto.2bpp"

--- a/engine/pokedex/pokedex_2.asm
+++ b/engine/pokedex/pokedex_2.asm
@@ -242,10 +242,10 @@ GetDexEntryPointer: ; 44333
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 
 GetDexEntryPagePointer: ; 44355
 	call GetDexEntryPointer ; b:de

--- a/engine/pokegear/radio.asm
+++ b/engine/pokegear/radio.asm
@@ -703,10 +703,10 @@ PokedexShow_GetDexEntryBank:
 	ret
 
 .PokedexEntryBanks:
-	db BANK(PokedexEntries1)
-	db BANK(PokedexEntries2)
-	db BANK(PokedexEntries3)
-	db BANK(PokedexEntries4)
+	db BANK("Pokedex Entries 001-064")
+	db BANK("Pokedex Entries 065-128")
+	db BANK("Pokedex Entries 129-192")
+	db BANK("Pokedex Entries 193-251")
 
 PokedexShow1:
 	call StartRadioStation

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -445,7 +445,7 @@ GetEggMove: ; 170e4
 	ld a, BANK(EggMovePointers)
 	call GetFarHalfword
 .loop
-	ld a, BANK(EggMoves)
+	ld a, BANK("Egg Moves")
 	call GetFarByte
 	cp -1
 	jr z, .reached_end
@@ -479,18 +479,18 @@ GetEggMove: ; 170e4
 	ld a, BANK(EvosAttacksPointers)
 	call GetFarHalfword
 .loop3
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	inc hl
 	and a
 	jr nz, .loop3
 .loop4
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	and a
 	jr z, .inherit_tmhm
 	inc hl
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
 	ld b, a
 	ld a, [de]

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -416,7 +416,7 @@ PlacePartyMonEvoStoneCompatibility: ; 5022f
 	ld h, [hl]
 	ld l, a
 	ld de, wStringBuffer1
-	ld a, BANK(EvosAttacks)
+	ld a, BANK("Evolutions and Attacks")
 	ld bc, 10
 	call FarCopyBytes
 	ld hl, wStringBuffer1

--- a/engine/printer/print_party.asm
+++ b/engine/printer/print_party.asm
@@ -103,7 +103,7 @@ PrintPage2: ; 1dc213
 	ret
 ; 1dc275
 
-GBPrinterStrings:
+GBPrinterStrings: ; used only for BANK(GBPrinterStrings)
 GBPrinterString_Null: db "@"
 GBPrinterString_CheckingLink: next " CHECKING LINK...@"
 GBPrinterString_Transmitting: next "  TRANSMITTING...@"

--- a/gfx/icons.asm
+++ b/gfx/icons.asm
@@ -1,4 +1,5 @@
-Icons:
+Icons: ; used only for BANK(Icons)
+
 NullIcon:
 PoliwagIcon:      INCBIN "gfx/icons/poliwag.2bpp" ; 0x8ec0d
 JigglypuffIcon:   INCBIN "gfx/icons/jigglypuff.2bpp" ; 0x8ec8d

--- a/gfx/pokemon/anims.asm
+++ b/gfx/pokemon/anims.asm
@@ -1,4 +1,5 @@
-PicAnimations:
+PicAnimations: ; used only for BANK(PicAnimations)
+
 BulbasaurAnimation:  INCLUDE "gfx/pokemon/bulbasaur/anim.asm"
 IvysaurAnimation:    INCLUDE "gfx/pokemon/ivysaur/anim.asm"
 VenusaurAnimation:   INCLUDE "gfx/pokemon/venusaur/anim.asm"

--- a/gfx/pokemon/johto_frames.asm
+++ b/gfx/pokemon/johto_frames.asm
@@ -1,4 +1,5 @@
-JohtoFrames:
+JohtoFrames: ; used only for BANK(JohtoFrames)
+
 ChikoritaFrames:  INCLUDE "gfx/pokemon/chikorita/frames.asm"
 BayleefFrames:    INCLUDE "gfx/pokemon/bayleef/frames.asm"
 MeganiumFrames:   INCLUDE "gfx/pokemon/meganium/frames.asm"

--- a/gfx/pokemon/kanto_frames.asm
+++ b/gfx/pokemon/kanto_frames.asm
@@ -1,4 +1,5 @@
-KantoFrames:
+KantoFrames: ; used only for BANK(KantoFrames)
+
 BulbasaurFrames:  INCLUDE "gfx/pokemon/bulbasaur/frames.asm"
 IvysaurFrames:    INCLUDE "gfx/pokemon/ivysaur/frames.asm"
 VenusaurFrames:   INCLUDE "gfx/pokemon/venusaur/frames.asm"

--- a/gfx/pokemon/unown_anims.asm
+++ b/gfx/pokemon/unown_anims.asm
@@ -1,4 +1,5 @@
-UnownAnimations:
+UnownAnimations: ; used only for BANK(UnownAnimations)
+
 UnownAAnimation: INCLUDE "gfx/pokemon/unown_a/anim.asm"
 UnownBAnimation: INCLUDE "gfx/pokemon/unown_b/anim.asm"
 UnownCAnimation: INCLUDE "gfx/pokemon/unown_c/anim.asm"

--- a/gfx/pokemon/unown_frames.asm
+++ b/gfx/pokemon/unown_frames.asm
@@ -1,4 +1,5 @@
-UnownsFrames:
+UnownsFrames: ; used only for BANK(UnownsFrames)
+
 UnownAFrames: INCLUDE "gfx/pokemon/unown_a/frames.asm"
 UnownBFrames: INCLUDE "gfx/pokemon/unown_b/frames.asm"
 UnownCFrames: INCLUDE "gfx/pokemon/unown_c/frames.asm"

--- a/wram.asm
+++ b/wram.asm
@@ -2361,7 +2361,7 @@ wDST:: ; d4c2
 ; bit 7: dst
 	db
 
-wGameTime::
+wGameTime:: ; used only for BANK(wGameTime)
 wGameTimeCap::     db ; d4c3
 wGameTimeHours::   dw ; d4c4
 wGameTimeMinutes:: db ; d4c6
@@ -2972,7 +2972,7 @@ w3_dffc:: ds 4
 SECTION "GBC Video", WRAMX
 
 ; eight 4-color palettes each
-wGBCPalettes::
+wGBCPalettes:: ; used only for BANK(wGBCPalettes)
 wBGPals1:: ds 8 palettes ; d000
 wOBPals1:: ds 8 palettes ; d040
 wBGPals2:: ds 8 palettes ; d080
@@ -2983,7 +2983,7 @@ wLYOverridesEnd:: ; d190
 
 	ds 1
 
-wMagnetTrain::
+wMagnetTrain:: ; used only for BANK(wMagnetTrain)
 wMagnetTrainDirection:: db
 wMagnetTrainInitPosition:: db
 wMagnetTrainHoldPosition:: db


### PR DESCRIPTION
Also standardize one "`Bank`" to "`BANK`".

If pokecrystal ever uses per-file objects each with their own section, like pokegold-spaceworld, some of these labels can be eliminated since `BANK("Section Name")` works.