### PR TITLE
Add tools/free_space.awk

### DIFF
--- a/tools/free_space.awk
+++ b/tools/free_space.awk
@@ -1,0 +1,13 @@
+#!/usr/bin/awk -f
+
+# Usage: tools/free_space.awk pokecrystal.map
+
+BEGIN {
+	total = free = 16384 * 128
+}
+/^  SECTION: \$[0-7]/ {
+	free -= strtonum("0x" substr($3, 3))
+}
+END {
+	printf "Free space: %d/%d (%.2f%%)\n", free, total, free * 100 / total
+}


### PR DESCRIPTION
    $ tools/free_space.awk pokecrystal.map
    Free space: 454935/2097152 (21.69%)

This could be automatically run and appended/prepended to the .map file, like how the .sym file is sorted in-place.

See previous discussion in #479.

---

In a tweet:

    awk 'BEGIN{t=f=2^21}/^  SECTION: \$[0-7]/{f-=strtonum("0x"substr($3,3))}END{printf"Free space: %d/%d (%.2f%%)",f,t,f*100/t}' pokecrystal.map