### PR TITLE
anim_ret_command is an index in a table after all

### DIFF
--- a/macros/scripts/battle_anims.asm
+++ b/macros/scripts/battle_anims.asm
@@ -295,7 +295,7 @@ anim_call: MACRO
 	dw \1 ; address
 ENDM
 
-anim_ret_command EQU -1 ; $ff
+	enum anim_ret_command ; $ff
 anim_ret: MACRO
 	db anim_ret_command
 ENDM


### PR DESCRIPTION
For some reason I thought BattleAnimCmd_Ret was never used, due to how the
battle anim loop would be exited early from. It seems I was wrong.
Removing commands before anim_ret without it being part of the `enum`
seems to break things.