### PR TITLE
Add meaningful aliases for wd265

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -2422,7 +2422,7 @@ _PlayCry::
 	add hl, bc
 	ld a, [wCryLength]
 	ld [hli], a
-	ld a, [wCryLength+1]
+	ld a, [wCryLength + 1]
 	ld [hl], a
 .start
 	call StartChannel

--- a/constants/battle_constants.asm
+++ b/constants/battle_constants.asm
@@ -63,8 +63,8 @@ MOVE_LENGTH EQU const_value
 	const STAT_SATK
 NUM_EXP_STATS EQU const_value + -1
 	const STAT_SDEF
-NUM_STATS EQU const_value +- 1
-STAT_SPC EQU STAT_SATK
+NUM_STATS EQU const_value + -1
+NUM_BATTLE_STATS EQU NUM_STATS + -1 ; don't count HP
 
 ; stat formula constants
 STAT_MIN_NORMAL EQU 5
@@ -243,6 +243,12 @@ SUBSTATUS_CURLED EQU 0
 	const BATTLEACTION_D
 	const BATTLEACTION_E
 	const BATTLEACTION_FORFEIT
+
+; wBattlePlayerAction
+	const_def
+	const BATTLEPLAYERACTION_USEMOVE
+	const BATTLEPLAYERACTION_USEITEM
+	const BATTLEPLAYERACTION_SWITCH
 
 ; wBattleResult
 	const_def

--- a/constants/icon_constants.asm
+++ b/constants/icon_constants.asm
@@ -39,3 +39,13 @@
 	const ICON_SLOWPOKE
 	const ICON_SUDOWOODO
 	const ICON_BIGMON
+
+; LoadMenuMonIcon.Jumptable indexes (see engine/gfx/mon_icons.asm)
+	const_def
+	const MONICON_PARTYMENU
+	const MONICON_NAMINGSCREEN
+	const MONICON_MOVES
+	const MONICON_TRADE
+	const MONICON_MOBILE1
+	const MONICON_MOBILE2
+	const MONICON_UNUSED

--- a/data/text/battle.asm
+++ b/data/text/battle.asm
@@ -87,7 +87,7 @@ SandstormHitsText:
 PerishCountText:
 	text "<USER>'s"
 	line "PERISH count is @"
-	deciram wd265, 1, 1
+	deciram wDeciramBuffer, 1, 1
 	text "!"
 	prompt
 
@@ -669,7 +669,7 @@ SpiteEffectText:
 	text_from_ram wStringBuffer1
 	text " was"
 	cont "reduced by @"
-	deciram wd265, 1, 1
+	deciram wDeciramBuffer, 1, 1
 	text "!"
 	prompt
 
@@ -1029,7 +1029,7 @@ SafeguardProtectText:
 
 MagnitudeText:
 	text "Magnitude @"
-	deciram wd265, 1, 1
+	deciram wDeciramBuffer, 1, 1
 	text "!"
 	prompt
 

--- a/data/text/common_1.asm
+++ b/data/text/common_1.asm
@@ -41,7 +41,7 @@ UnknownText_0x1bc0a2::
 	text_from_ram wStringBuffer1
 	text_start
 	line "recovered @"
-	deciram wd1f3, 2, 3
+	deciram wCurHPAnimDeltaHP, 2, 3
 	text "HP!"
 	done
 
@@ -1155,7 +1155,7 @@ Text_BreedingIsNotPossible::
 UnknownText_0x1bd0d8::
 	text "The compatibility"
 	line "is @"
-	deciram wd265, 1, 3
+	deciram wDeciramBuffer, 1, 3
 	text "."
 	cont "Should they breed?"
 	done

--- a/data/text/common_1.asm
+++ b/data/text/common_1.asm
@@ -1155,7 +1155,7 @@ Text_BreedingIsNotPossible::
 UnknownText_0x1bd0d8::
 	text "The compatibility"
 	line "is @"
-	deciram wBreedingCompatibility , 1, 3
+	deciram wBreedingCompatibility, 1, 3
 	text "."
 	cont "Should they breed?"
 	done

--- a/data/text/common_1.asm
+++ b/data/text/common_1.asm
@@ -1155,7 +1155,7 @@ Text_BreedingIsNotPossible::
 UnknownText_0x1bd0d8::
 	text "The compatibility"
 	line "is @"
-	deciram wDeciramBuffer, 1, 3
+	deciram wBreedingCompatibility , 1, 3
 	text "."
 	cont "Should they breed?"
 	done

--- a/data/text/common_2.asm
+++ b/data/text/common_2.asm
@@ -262,7 +262,7 @@ UnknownText_0x1c0531::
 	text_from_ram wc850
 	text "'s CARD was"
 	line "listed as no.@"
-	deciram wd265, 1, 2
+	deciram wDeciramBuffer, 1, 2
 	text "."
 	prompt
 

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -153,43 +153,43 @@ Don't enforce `org $4000` in pokecrystal.link.
 Modify `GetFrontpicPointer`:
 
 ```diff
-	ld a, [wCurPartySpecies]
-	cp UNOWN
-	jr z, .unown
-	ld a, [wCurPartySpecies]
+ 	ld a, [wCurPartySpecies]
+ 	cp UNOWN
+ 	jr z, .unown
+ 	ld a, [wCurPartySpecies]
 +	ld hl, PokemonPicPointers
-	ld d, BANK(PokemonPicPointers)
-	jr .ok
+ 	ld d, BANK(PokemonPicPointers)
+ 	jr .ok
 
-.unown
-	ld a, [wUnownLetter]
+ .unown
+ 	ld a, [wUnownLetter]
 +	ld hl, UnownPicPointers
-	ld d, BANK(UnownPicPointers)
+ 	ld d, BANK(UnownPicPointers)
 
-.ok
+ .ok
 -	ld hl, PokemonPicPointers ; UnownPicPointers
-	dec a
-	ld bc, 6
-	call AddNTimes
+ 	dec a
+ 	ld bc, 6
+ 	call AddNTimes
 ```
 
 And `GetMonBackpic`:
 
-```asm
+```diff
 -	; These are assumed to be at the same address in their respective banks.
 -	ld hl, PokemonPicPointers ; UnownPicPointers
-	ld a, b
+ 	ld a, b
 +	ld hl, PokemonPicPointers
-	ld d, BANK(PokemonPicPointers)
-	cp UNOWN
-	jr nz, .ok
-	ld a, c
+ 	ld d, BANK(PokemonPicPointers)
+ 	cp UNOWN
+ 	jr nz, .ok
+ 	ld a, c
 +	ld hl, UnownPicPointers
-	ld d, BANK(UnownPicPointers)
-.ok
-	dec a
-	ld bc, 6
-	call AddNTimes
+ 	ld d, BANK(UnownPicPointers)
+ .ok
+ 	dec a
+ 	ld bc, 6
+ 	call AddNTimes
 ```
 
 
@@ -273,12 +273,12 @@ Modify `Pokedex_LoadAnyFootprint`:
 
 ```diff
 -	push hl
-	ld e, l
-	ld d, h
-	ld hl, vTiles2 tile $62
+ 	ld e, l
+ 	ld d, h
+ 	ld hl, vTiles2 tile $62
 -	lb bc, BANK(Footprints), 2
 +	lb bc, BANK(Footprints), 4
-	call Request1bpp
+ 	call Request1bpp
 -	pop hl
 -
 -	; Whoever was editing footprints forgot to fix their
@@ -359,9 +359,9 @@ Move `ITEM_C3` and `ITEM_DC` above all the TMs in every table of item data.
 Modify engine/items/items.asm:
 
 ```diff
-GetTMHMNumber::
-; Return the number of a TM/HM by item id c.
-	ld a, c
+ GetTMHMNumber::
+ ; Return the number of a TM/HM by item id c.
+ 	ld a, c
 -; Skip any dummy items.
 -	cp ITEM_C3 ; TM04-05
 -	jr c, .done
@@ -371,14 +371,14 @@ GetTMHMNumber::
 -.skip
 -	dec a
 -.done
-	sub TM01
-	inc a
-	ld c, a
-	ret
+ 	sub TM01
+ 	inc a
+ 	ld c, a
+ 	ret
 
-GetNumberedTMHM:
-; Return the item id of a TM/HM by number c.
-	ld a, c
+ GetNumberedTMHM:
+ ; Return the item id of a TM/HM by number c.
+ 	ld a, c
 -; Skip any gaps.
 -	cp ITEM_C3 - (TM01 - 1)
 -	jr c, .done
@@ -389,10 +389,10 @@ GetNumberedTMHM:
 -.skip_one
 -	inc a
 -.done
-	add TM01
-	dec a
-	ld c, a
-	ret
+ 	add TM01
+ 	dec a
+ 	ld c, a
+ 	ret
 ```
 
 

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -818,7 +818,7 @@ PrintText_UsedItemOn_AND_AIUpdateHUD:
 
 PrintText_UsedItemOn:
 	ld a, [wCurEnemyItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, wStringBuffer1
 	ld de, wMonOrItemNameBuffer

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -171,10 +171,10 @@ AI_Types:
 	pop bc
 	pop hl
 
-	ld a, [wd265]
+	ld a, [wTypeMatchup]
 	and a
 	jr z, .immune
-	cp 10 ; 1.0
+	cp EFFECTIVE
 	jr z, .checkmove
 	jr c, .noteffective
 
@@ -415,8 +415,8 @@ AI_Smart_LeechHit:
 	pop hl
 
 ; 60% chance to discourage this move if not very effective.
-	ld a, [wd265]
-	cp 10 ; 1.0
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	jr c, .asm_38815
 
 ; Do nothing if effectiveness is neutral.
@@ -491,8 +491,8 @@ AI_Smart_LockOn:
 	push hl
 	push bc
 	farcall BattleCheckTypeMatchup
-	ld a, [wd265]
-	cp $a
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	pop bc
 	pop hl
 	jr c, .asm_3884f
@@ -1292,8 +1292,8 @@ AI_Smart_Mimic:
 	ld [hBattleTurn], a
 	callfar BattleCheckTypeMatchup
 
-	ld a, [wd265]
-	cp $a
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	pop hl
 	jr c, .asm_38bef
 	jr z, .asm_38bd4
@@ -1408,8 +1408,8 @@ AI_Smart_Encore:
 	predef CheckTypeMatchup
 
 	pop hl
-	ld a, [wd265]
-	cp $a
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	jr nc, .asm_38c68
 
 	and a
@@ -1679,8 +1679,8 @@ AI_Smart_Conversion2:
 
 	callfar BattleCheckTypeMatchup
 
-	ld a, [wd265]
-	cp $a
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	pop hl
 	jr c, .asm_38dc9
 	ret z
@@ -2293,8 +2293,8 @@ AI_Smart_HiddenPower:
 	pop hl
 
 ; Discourage Hidden Power if not very effective.
-	ld a, [wd265]
-	cp 10
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE
 	jr c, .bad
 
 ; Discourage Hidden Power if its base power	is lower than 50.
@@ -2303,8 +2303,8 @@ AI_Smart_HiddenPower:
 	jr c, .bad
 
 ; Encourage Hidden Power if super-effective.
-	ld a, [wd265]
-	cp 11
+	ld a, [wTypeMatchup]
+	cp EFFECTIVE + 1
 	jr nc, .good
 
 ; Encourage Hidden Power if its base power is 70.
@@ -3125,7 +3125,7 @@ AI_Status:
 	pop bc
 	pop hl
 
-	ld a, [wd265]
+	ld a, [wTypeMatchup]
 	and a
 	jr nz, .checkmove
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5989,7 +5989,7 @@ LoadEnemyMon:
 ; Used for Ho-Oh, Lugia and Snorlax encounters
 	ld a, [wBattleType]
 	cp BATTLETYPE_FORCEITEM
-	ld a, [wBaseItems]
+	ld a, [wBaseItem1]
 	jr z, .UpdateItem
 
 ; Failing that, it's all up to chance
@@ -6007,9 +6007,9 @@ LoadEnemyMon:
 ; From there, an 8% chance for Item2
 	call BattleRandom
 	cp 8 percent ; 8% of 25% = 2% Item2
-	ld a, [wBaseItems]
+	ld a, [wBaseItem1]
 	jr nc, .UpdateItem
-	ld a, [wBaseItems+1]
+	ld a, [wBaseItem2]
 
 .UpdateItem:
 	ld [wEnemyMonItem], a

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -2,7 +2,7 @@ DoPlayerTurn:
 	call SetPlayerTurn
 
 	ld a, [wBattlePlayerAction]
-	and a
+	and a ; BATTLEPLAYERACTION_USEMOVE?
 	ret nz
 
 	jr DoTurn
@@ -1248,7 +1248,7 @@ BattleCommand_Stab:
 .go
 	ld a, BATTLE_VARS_MOVE_TYPE
 	call GetBattleVarAddr
-	ld [wTypeMatchup], a
+	ld [wCurType], a
 
 	push hl
 	push de
@@ -1264,7 +1264,7 @@ BattleCommand_Stab:
 	pop bc
 	pop de
 
-	ld a, [wTypeMatchup]
+	ld a, [wCurType]
 	cp b
 	jr z, .stab
 	cp c

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -3583,7 +3583,7 @@ UpdateMoveData:
 
 	ld a, BATTLE_VARS_MOVE
 	call GetBattleVar
-	ld [wCurMove], a
+	ld [wCurSpecies], a
 	ld [wNamedObjectIndexBuffer], a
 
 	dec a

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -53,13 +53,13 @@ DoWeatherModifiers:
 	ld de, WeatherTypeModifiers
 	ld a, [wBattleWeather]
 	ld b, a
-	ld a, [wd265] ; move type
+	ld a, [wCurType]
 	ld c, a
 
 .CheckWeatherType:
 	ld a, [de]
 	inc de
-	cp $ff
+	cp -1
 	jr z, .done_weather_types
 
 	cp b
@@ -84,7 +84,7 @@ DoWeatherModifiers:
 .CheckWeatherMove:
 	ld a, [de]
 	inc de
-	cp $ff
+	cp -1
 	jr z, .done
 
 	cp b
@@ -116,7 +116,7 @@ DoWeatherModifiers:
 
 	ld a, 10
 	ld [hDivisor], a
-	ld b, $4
+	ld b, 4
 	call Divide
 
 	ld a, [hQuotient + 0]
@@ -176,7 +176,7 @@ DoBadgeTypeBoosts:
 	rr c
 	jr nc, .NextBadge
 
-	ld a, [wd265] ; move type
+	ld a, [wCurType]
 	cp [hl]
 	jr z, .ApplyBoost
 

--- a/engine/battle/move_effects/baton_pass.asm
+++ b/engine/battle/move_effects/baton_pass.asm
@@ -68,8 +68,8 @@ BattleCommand_BatonPass:
 	call CallBattleCore
 	ld hl, ResetBattleParticipants
 	call CallBattleCore
-	ld a, 1
-	ld [wTypeMatchup], a
+	ld a, TRUE
+	ld [wApplyStatLevelMultipliersToEnemy], a
 	ld hl, ApplyStatLevelMultiplierOnAllStats
 	call CallBattleCore
 
@@ -83,7 +83,7 @@ BatonPass_LinkPlayerSwitch:
 	and a
 	ret z
 
-	ld a, 1
+	ld a, BATTLEPLAYERACTION_USEITEM
 	ld [wBattlePlayerAction], a
 
 	call LoadStandardMenuHeader
@@ -91,7 +91,7 @@ BatonPass_LinkPlayerSwitch:
 	call CallBattleCore
 	call CloseWindow
 
-	xor a
+	xor a ; BATTLEPLAYERACTION_USEMOVE
 	ld [wBattlePlayerAction], a
 	ret
 

--- a/engine/battle/move_effects/magnitude.asm
+++ b/engine/battle/move_effects/magnitude.asm
@@ -18,7 +18,7 @@ BattleCommand_GetMagnitude:
 	push de
 	inc hl
 	ld a, [hl]
-	ld [wTypeMatchup], a
+	ld [wDeciramBuffer], a
 	call BattleCommand_MoveDelay
 	ld hl, MagnitudeText
 	call StdBattleTextBox

--- a/engine/battle/move_effects/mirror_move.asm
+++ b/engine/battle/move_effects/mirror_move.asm
@@ -24,7 +24,7 @@ BattleCommand_MirrorMove:
 .use
 	ld a, b
 	ld [hl], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 
 	push af
 	ld a, BATTLE_VARS_MOVE_ANIM

--- a/engine/battle/move_effects/sketch.asm
+++ b/engine/battle/move_effects/sketch.asm
@@ -34,7 +34,7 @@ BattleCommand_Sketch:
 .get_last_move
 	ld a, BATTLE_VARS_LAST_COUNTER_MOVE_OPP
 	call GetBattleVar
-	ld [wTypeMatchup], a
+	ld [wNamedObjectIndexBuffer], a
 	ld b, a
 ; Fail if move is invalid or is Struggle.
 	and a

--- a/engine/battle/move_effects/spite.asm
+++ b/engine/battle/move_effects/spite.asm
@@ -24,7 +24,7 @@ BattleCommand_Spite:
 	ld a, [hli]
 	cp b
 	jr nz, .loop
-	ld [wTypeMatchup], a
+	ld [wNamedObjectIndexBuffer], a
 	dec hl
 	ld b, 0
 	push bc
@@ -78,7 +78,7 @@ BattleCommand_Spite:
 	call AnimateCurrentMove
 	pop de
 	ld a, d
-	ld [wTypeMatchup], a
+	ld [wDeciramBuffer], a
 	ld hl, SpiteEffectText
 	jp StdBattleTextBox
 

--- a/engine/battle/move_effects/thief.asm
+++ b/engine/battle/move_effects/thief.asm
@@ -21,7 +21,7 @@ BattleCommand_Thief:
 
 ; Can't steal mail.
 
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld d, a
 	farcall ItemIsMail
 	ret c
@@ -45,7 +45,7 @@ BattleCommand_Thief:
 	ld [de], a
 
 	call .playeritem
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [hl], a
 	ld [de], a
 	jr .stole
@@ -68,7 +68,7 @@ BattleCommand_Thief:
 
 ; Can't steal mail!
 
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld d, a
 	farcall ItemIsMail
 	ret c
@@ -86,7 +86,7 @@ BattleCommand_Thief:
 	ld [de], a
 
 	call .enemyitem
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [hl], a
 	ld [de], a
 

--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -157,21 +157,21 @@ DrawEnemyHUDBorder:
 .tiles_end
 
 PlaceHUDBorderTiles:
-	ld a, [wTrainerHUDTiles+0]
+	ld a, [wTrainerHUDTiles + 0]
 	ld [hl], a
 	ld bc, SCREEN_WIDTH
 	add hl, bc
-	ld a, [wTrainerHUDTiles+1]
+	ld a, [wTrainerHUDTiles + 1]
 	ld [hl], a
 	ld b, 8
 .loop
 	add hl, de
-	ld a, [wTrainerHUDTiles+3]
+	ld a, [wTrainerHUDTiles + 3]
 	ld [hl], a
 	dec b
 	jr nz, .loop
 	add hl, de
-	ld a, [wTrainerHUDTiles+2]
+	ld a, [wTrainerHUDTiles + 2]
 	ld [hl], a
 	ret
 

--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -101,7 +101,7 @@ StageBallTilesData:
 DrawPlayerHUDBorder:
 	ld hl, .tiles
 	ld de, wTrainerHUDTiles
-	ld bc, 4
+	ld bc, .tiles_end - .tiles
 	call CopyBytes
 	hlcoord 18, 10
 	ld de, -1 ; start on right
@@ -112,11 +112,12 @@ DrawPlayerHUDBorder:
 	db $77 ; bottom right
 	db $6f ; bottom left
 	db $76 ; bottom side
+.tiles_end
 
 DrawPlayerPartyIconHUDBorder:
 	ld hl, .tiles
 	ld de, wTrainerHUDTiles
-	ld bc, 4
+	ld bc, .tiles_end - .tiles
 	call CopyBytes
 	hlcoord 18, 10
 	ld de, -1 ; start on right
@@ -127,11 +128,12 @@ DrawPlayerPartyIconHUDBorder:
 	db $5c ; bottom right
 	db $6f ; bottom left
 	db $76 ; bottom side
+.tiles_end
 
 DrawEnemyHUDBorder:
 	ld hl, .tiles
 	ld de, wTrainerHUDTiles
-	ld bc, 4
+	ld bc, .tiles_end - .tiles
 	call CopyBytes
 	hlcoord 1, 2
 	ld de, 1 ; start on left
@@ -152,23 +154,24 @@ DrawEnemyHUDBorder:
 	db $74 ; bottom left
 	db $78 ; bottom right
 	db $76 ; bottom side
+.tiles_end
 
 PlaceHUDBorderTiles:
-	ld a, [wTrainerHUDTiles]
+	ld a, [wTrainerHUDTiles+0]
 	ld [hl], a
 	ld bc, SCREEN_WIDTH
 	add hl, bc
-	ld a, [wStartFlypoint]
+	ld a, [wTrainerHUDTiles+1]
 	ld [hl], a
-	ld b, $8
+	ld b, 8
 .loop
 	add hl, de
-	ld a, [wMovementBuffer]
+	ld a, [wTrainerHUDTiles+3]
 	ld [hl], a
 	dec b
 	jr nz, .loop
 	add hl, de
-	ld a, [wEndFlypoint]
+	ld a, [wTrainerHUDTiles+2]
 	ld [hl], a
 	ret
 
@@ -181,7 +184,7 @@ LinkBattle_TrainerHuds:
 	ld a, 10 * 8
 	ld [hli], a
 	ld [hl], 8 * 8
-	ld a, $8
+	ld a, 8
 	ld [wPlaceBallsDirection], a
 	ld hl, wVirtualOAMSprite00
 	call LoadTrainerHudOAM

--- a/engine/battle/used_move_text.asm
+++ b/engine/battle/used_move_text.asm
@@ -26,7 +26,7 @@ UsedMoveText:
 
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVar
-	ld [wd265], a
+	ld [wMoveGrammar], a
 
 	push hl
 	farcall CheckUserIsCharging
@@ -34,13 +34,12 @@ UsedMoveText:
 	jr nz, .grammar
 
 	; update last move
-	ld a, [wd265]
+	ld a, [wMoveGrammar]
 	ld [hl], a
 	ld [de], a
 
 .grammar
-	call GetMoveGrammar
-; wd265 now contains MoveGrammar
+	call GetMoveGrammar ; convert move id to grammar index
 
 ; everything except 'instead' made redundant in localization
 
@@ -51,7 +50,7 @@ UsedMoveText:
 	ret nz
 
 	; check move grammar
-	ld a, [wd265]
+	ld a, [wMoveGrammar]
 	cp $3
 	ld hl, UsedMove2Text
 	ret c
@@ -89,14 +88,14 @@ MoveNameText:
 	ld hl, .endusedmovetexts
 
 ; get move id
-	ld a, [wd265]
+	ld a, [wMoveGrammar]
 
 ; 2-byte pointer
 	add a
 
 ; seek
 	push bc
-	ld b, $0
+	ld b, 0
 	ld c, a
 	add hl, bc
 	pop bc
@@ -132,13 +131,13 @@ EndUsedMove5Text:
 	db "@"
 
 GetMoveGrammar:
-; store move grammar type in wd265
+; store move grammar type in wMoveGrammar
 
 	push bc
-; c = move id
-	ld a, [wd265]
-	ld c, a
-	ld b, $0
+; wMoveGrammar contains move id
+	ld a, [wMoveGrammar]
+	ld c, a ; move id
+	ld b, 0 ; grammar index
 
 ; read grammar table
 	ld hl, MoveGrammar
@@ -158,9 +157,9 @@ GetMoveGrammar:
 	jr .loop
 
 .end
-; wd265 now contains move grammar
+; wMoveGrammar now contains move grammar
 	ld a, b
-	ld [wd265], a
+	ld [wMoveGrammar], a
 
 ; we're done
 	pop bc

--- a/engine/events/bug_contest/caught_mon.asm
+++ b/engine/events/bug_contest/caught_mon.asm
@@ -2,7 +2,7 @@ BugContest_SetCaughtContestMon:
 	ld a, [wContestMon]
 	and a
 	jr z, .firstcatch
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	farcall DisplayAlreadyCaughtText
 	farcall DisplayCaughtContestMonStats
 	lb bc, 14, 7
@@ -12,7 +12,7 @@ BugContest_SetCaughtContestMon:
 .firstcatch
 	call .generatestats
 	ld a, [wTempEnemyMonSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, .caughttext
 	call PrintText

--- a/engine/events/bug_contest/display_stats.asm
+++ b/engine/events/bug_contest/display_stats.asm
@@ -36,7 +36,7 @@ DisplayCaughtContestMonStats:
 	call PlaceString
 
 	ld a, [wContestMon]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld de, wStringBuffer1
 	hlcoord 1, 2

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -558,7 +558,7 @@ DayCare_InitBreeding:
 	bit DAYCAREMAN_HAS_MON_F, a
 	ret z
 	callfar CheckBreedmonCompatibility
-	ld a, [wd265]
+	ld a, [wBreedingCompatibility]
 	and a
 	ret z
 	inc a

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -407,7 +407,7 @@ FlyFunction_InitGFX:
 	ld d, 0
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempIconSpecies], a
 	ld e, FIELDMOVE_FLY
 	farcall FlyFunction_GetMonIcon
 	xor a

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -462,7 +462,7 @@ DisplayHOFMon:
 	call TextBox
 	ld a, [wTempMonSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd265], a
+	ld [wDeciramBuffer], a
 	ld hl, wTempMonDVs
 	predef GetUnownLetter
 	xor a
@@ -477,7 +477,7 @@ DisplayHOFMon:
 	ld [hli], a
 	ld [hl], "<DOT>"
 	hlcoord 3, 13
-	ld de, wd265
+	ld de, wDeciramBuffer
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNum
 	call GetBasePokemonName

--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -11,7 +11,7 @@ GetFirstPokemonHappiness:
 	jr .loop
 
 .done
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld a, [hl]
 	ld [wScriptVar], a
 	call GetPokemonName
@@ -19,9 +19,9 @@ GetFirstPokemonHappiness:
 
 CheckFirstMonIsEgg:
 	ld a, [wPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	cp EGG
-	ld a, 1
+	ld a, TRUE
 	jr z, .egg
 	xor a
 
@@ -196,15 +196,15 @@ DayCareStep::
 	call Random
 	ld [hl], a
 	callfar CheckBreedmonCompatibility
-	ld a, [wd265]
+	ld a, [wBreedingCompatibility]
 	cp 230
 	ld b, 32 percent - 1
 	jr nc, .okay
-	ld a, [wd265]
+	ld a, [wBreedingCompatibility]
 	cp 170
 	ld b, 16 percent
 	jr nc, .okay
-	ld a, [wd265]
+	ld a, [wBreedingCompatibility]
 	cp 110
 	ld b, 12 percent
 	jr nc, .okay

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -127,14 +127,14 @@ CheckForLuckyNumberWinners:
 	ld hl, wBuffer1
 	lb bc, PRINTNUM_LEADINGZEROS | 2, 5
 	call PrintNum
-	ld hl, wLuckyNumberDigit1Buffer
+	ld hl, wLuckyNumberDigitsBuffer
 	ld de, wLuckyIDNumber
 	lb bc, PRINTNUM_LEADINGZEROS | 2, 5
 	call PrintNum
 	ld b, 5
 	ld c, 0
-	ld hl, wLuckyNumberDigit5Buffer
-	ld de, wBuffer5
+	ld hl, wLuckyNumberDigitsBuffer + 4
+	ld de, wBuffer1 + 4
 .loop
 	ld a, [de]
 	cp [hl]

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -1,7 +1,7 @@
 CheckForLuckyNumberWinners:
 	xor a
 	ld [wScriptVar], a
-	ld [wFoundMatchingIDInParty], a
+	ld [wTempByteValue], a
 	ld a, [wPartyCount]
 	and a
 	ret z
@@ -34,8 +34,8 @@ CheckForLuckyNumberWinners:
 	jr z, .SkipOpenBoxMon
 	call .CompareLuckyNumberToMonID
 	jr nc, .SkipOpenBoxMon
-	ld a, 1
-	ld [wFoundMatchingIDInParty], a
+	ld a, TRUE
+	ld [wTempByteValue], a
 
 .SkipOpenBoxMon:
 	push bc
@@ -81,8 +81,8 @@ CheckForLuckyNumberWinners:
 
 	call .CompareLuckyNumberToMonID ; sets wScriptVar and wCurPartySpecies appropriately
 	jr nc, .SkipBoxMon
-	ld a, 1
-	ld [wFoundMatchingIDInParty], a
+	ld a, TRUE
+	ld [wTempByteValue], a
 
 .SkipBoxMon:
 	push bc
@@ -104,7 +104,7 @@ CheckForLuckyNumberWinners:
 	and a
 	ret z ; found nothing
 	farcall StubbedTrainerRankings_LuckyNumberShow
-	ld a, [wFoundMatchingIDInParty]
+	ld a, [wTempByteValue]
 	and a
 	push af
 	ld a, [wCurPartySpecies]

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -185,7 +185,7 @@ CalcMagikarpLength:
 
 	ld hl, MagikarpLengths
 	ld a, 2
-	ld [wd265], a
+	ld [wTempByteValue], a
 
 .read
 	ld a, [hli]
@@ -214,7 +214,7 @@ CalcMagikarpLength:
 	ld [hMultiplicand + 1], a
 	ld a, 100
 	ld [hMultiplicand + 2], a
-	ld a, [wd265]
+	ld a, [wTempByteValue]
 	ld [hMultiplier], a
 	call Multiply
 	ld b, 0
@@ -228,9 +228,9 @@ CalcMagikarpLength:
 
 .next
 	inc hl ; align to next triplet
-	ld a, [wd265]
+	ld a, [wTempByteValue]
 	inc a
-	ld [wd265], a
+	ld [wTempByteValue], a
 	cp 16
 	jr c, .read
 

--- a/engine/events/move_deleter.asm
+++ b/engine/events/move_deleter.asm
@@ -27,8 +27,8 @@ MoveDeletion:
 	jr c, .declined
 	ld a, [wMenuCursorY]
 	push af
-	ld a, [wCurSpecies]
-	ld [wd265], a
+	ld a, [wCurMove]
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	ld hl, .ConfirmDeleteText
 	call PrintText

--- a/engine/events/move_deleter.asm
+++ b/engine/events/move_deleter.asm
@@ -27,7 +27,7 @@ MoveDeletion:
 	jr c, .declined
 	ld a, [wMenuCursorY]
 	push af
-	ld a, [wCurMove]
+	ld a, [wCurSpecies]
 	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	ld hl, .ConfirmDeleteText

--- a/engine/events/move_tutor.asm
+++ b/engine/events/move_tutor.asm
@@ -8,7 +8,7 @@ MoveTutor:
 	xor a
 	ld [wItemAttributeParamBuffer], a
 	call .GetMoveTutorMove
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	call CopyName1

--- a/engine/events/name_rater.asm
+++ b/engine/events/name_rater.asm
@@ -29,7 +29,7 @@ _NameRater:
 	xor a ; PARTYMON
 	ld [wMonType], a
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wCurSpecies], a
 	call GetBaseData
 	ld b, 0

--- a/engine/events/npc_trade.asm
+++ b/engine/events/npc_trade.asm
@@ -301,7 +301,7 @@ Trade_GetAttributeOfLastPartymon:
 
 GetTradeMonName:
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetBasePokemonName
 	ld hl, wStringBuffer1
 	pop de

--- a/engine/events/specials.asm
+++ b/engine/events/specials.asm
@@ -34,7 +34,7 @@ GameCornerPrizeMonCheckDex:
 	call SetSeenAndCaughtMon
 	call FadeToMenu
 	ld a, [wScriptVar]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	farcall NewPokedexEntry
 	call ExitAllMenus
 	ret
@@ -153,7 +153,7 @@ GetMysteryGiftItem:
 	ld [sMysteryGiftItem], a
 	call CloseSRAM
 	ld a, [wCurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, .ReceiveItemText
 	call PrintText

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -34,13 +34,14 @@ LoadMenuMonIcon:
 	jp hl
 
 .Jumptable:
-	dw PartyMenu_InitAnimatedMonIcon ; party menu
-	dw NamingScreen_InitAnimatedMonIcon ; naming screen
-	dw MoveList_InitAnimatedMonIcon ; moves (?)
-	dw Trade_LoadMonIconGFX ; trade
-	dw Mobile_InitAnimatedMonIcon ; mobile
-	dw Mobile_InitPartyMenuBGPal71 ; mobile
-	dw .GetPartyMenuMonIcon ; unused
+; entries correspond to MONICON_* constants
+	dw PartyMenu_InitAnimatedMonIcon    ; MONICON_PARTYMENU
+	dw NamingScreen_InitAnimatedMonIcon ; MONICON_NAMINGSCREEN
+	dw MoveList_InitAnimatedMonIcon     ; MONICON_MOVES
+	dw Trade_LoadMonIconGFX             ; MONICON_TRADE
+	dw Mobile_InitAnimatedMonIcon       ; MONICON_MOBILE1
+	dw Mobile_InitPartyMenuBGPal71      ; MONICON_MOBILE2
+	dw .GetPartyMenuMonIcon             ; MONICON_UNUSED
 
 .GetPartyMenuMonIcon:
 	call InitPartyMenuIcon
@@ -65,14 +66,14 @@ LoadMenuMonIcon:
 	pop bc
 	pop hl
 	jr c, .not_mail
-	ld a, $6
+	ld a, $06
 	jr .got_tile
 .not_mail
-	ld a, $5
-	; jr .got_tile
+	ld a, $05
+	; fallthrough
 
 .no_item
-	ld a, $4
+	ld a, $04
 .got_tile
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
@@ -156,7 +157,7 @@ InitPartyMenuIcon:
 	ld a, [hObjectStructIndexBuffer]
 	ld hl, wPartySpecies
 	ld e, a
-	ld d, $0
+	ld d, 0
 	add hl, de
 	ld a, [hl]
 	call ReadMonMenuIcon
@@ -214,7 +215,7 @@ SetPartyMonIconAnimSpeed:
 	db $80 ; HP_RED
 
 NamingScreen_InitAnimatedMonIcon:
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	xor a
@@ -228,7 +229,7 @@ NamingScreen_InitAnimatedMonIcon:
 	ret
 
 MoveList_InitAnimatedMonIcon:
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	xor a
@@ -243,7 +244,7 @@ MoveList_InitAnimatedMonIcon:
 	ret
 
 Trade_LoadMonIconGFX:
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	ld a, $62
@@ -254,7 +255,7 @@ Trade_LoadMonIconGFX:
 GetSpeciesIcon:
 ; Load species icon into VRAM at tile a
 	push de
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	pop de
@@ -264,7 +265,7 @@ GetSpeciesIcon:
 
 FlyFunction_GetMonIcon:
 	push de
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	pop de
@@ -274,7 +275,7 @@ FlyFunction_GetMonIcon:
 
 Unreferenced_GetMonIcon2:
 	push de
-	ld a, [wd265]
+	ld a, [wTempIconSpecies]
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	pop de

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -1,6 +1,6 @@
 _DoItemEffect::
 	ld a, [wCurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	call CopyName1
 	ld a, 1
@@ -489,7 +489,7 @@ PokeBallEffect:
 	ld a, [wEnemyMonSpecies]
 	ld [wWildMon], a
 	ld [wCurPartySpecies], a
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ld a, [wBattleType]
 	cp BATTLETYPE_TUTORIAL
 	jp z, .FinishTutorial
@@ -501,13 +501,13 @@ PokeBallEffect:
 
 	call ClearSprites
 
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 
 	ld a, c
 	push af
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call SetSeenAndCaughtMon
 	pop af
@@ -523,7 +523,7 @@ PokeBallEffect:
 	call ClearSprites
 
 	ld a, [wEnemyMonSpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	predef NewPokedexEntry
 
 .skip_pokedex
@@ -566,7 +566,7 @@ PokeBallEffect:
 	call PrintText
 
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	call YesNoBox
@@ -626,7 +626,7 @@ PokeBallEffect:
 	call PrintText
 
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	call YesNoBox
@@ -1276,7 +1276,7 @@ Table_eeeb:
 RareCandy_StatBooster_GetParameters:
 	ld a, [wCurPartySpecies]
 	ld [wCurSpecies], a
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ld a, MON_LEVEL
 	call GetPartyParamLocation
 	ld a, [hl]
@@ -1368,7 +1368,7 @@ RareCandyEffect:
 	xor a ; PARTYMON
 	ld [wMonType], a
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	predef LearnLevelMoves
 
 	xor a
@@ -2344,7 +2344,7 @@ RestorePPEffect:
 
 	push hl
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	pop hl
@@ -2373,8 +2373,8 @@ RestorePPEffect:
 	ld a, [hl]
 	add PP_UP_ONE
 	ld [hl], a
-	ld a, $1
-	ld [wd265], a
+	ld a, TRUE
+	ld [wUsePPUp], a
 	call ApplyPPUp
 	call Play_SFX_FULL_HEAL
 
@@ -2492,7 +2492,7 @@ RestorePP:
 	ld hl, wPartyMon1PP
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call GetMthMoveOfNthPartymon
-	ld a, [wd265]
+	ld a, [wTempPP]
 	ld b, a
 	ld a, [hl]
 	and PP_MASK
@@ -2765,8 +2765,8 @@ ApplyPPUp:
 	ld a, b
 	cp NUM_MOVES + 1
 	ret z
-	ld a, [wd265]
-	dec a
+	ld a, [wUsePPUp]
+	dec a ; FALSE?
 	jr nz, .use
 	ld a, [wMenuCursorY]
 	inc a
@@ -2822,7 +2822,7 @@ ComputeMaxPP:
 .okay
 	add b
 	ld b, a
-	ld a, [wd265]
+	ld a, [wTempPP]
 	dec a
 	jr z, .NoPPUp
 	dec c
@@ -2857,7 +2857,7 @@ RestoreAllPP:
 	ld a, [de]
 	and PP_UP_MASK
 	ld b, a
-	ld a, [wd265]
+	ld a, [wTempPP]
 	add b
 	ld [de], a
 	inc de
@@ -2933,12 +2933,12 @@ GetMaxPPOfMove:
 	ld hl, wStringBuffer1 + 1
 	ld [hl], a
 	xor a
-	ld [wd265], a
+	ld [wTempPP], a
 	ld a, b ; this gets lost anyway
 	call ComputeMaxPP
 	ld a, [hl]
 	and PP_MASK
-	ld [wd265], a
+	ld [wTempPP], a
 
 	pop af
 	ld [wStringBuffer1 + 1], a

--- a/engine/items/print_item_description.asm
+++ b/engine/items/print_item_description.asm
@@ -9,7 +9,7 @@ PrintItemDescription:
 	push de
 	farcall GetTMHMItemMove
 	pop hl
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	ld [wCurSpecies], a
 	predef PrintMoveDesc
 	ret

--- a/engine/items/tmhm.asm
+++ b/engine/items/tmhm.asm
@@ -381,7 +381,7 @@ TMHM_DisplayPocketItems:
 	ld [wTempTMHM], a
 .okay
 	predef GetTMHMMove
-	ld a, [wTempTMHM]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	pop hl

--- a/engine/items/tmhm.asm
+++ b/engine/items/tmhm.asm
@@ -33,7 +33,7 @@ ConvertCurItemIntoCurTMHM:
 	ld c, a
 	callfar GetTMHMNumber
 	ld a, c
-	ld [wCurTMHM], a
+	ld [wTempTMHM], a
 	ret
 
 GetTMHMItemMove:
@@ -50,7 +50,7 @@ AskTeachTMHM:
 	cp TM01
 	jr c, .NotTMHM
 	call GetTMHMItemMove
-	ld a, [wCurTMHM]
+	ld a, [wTempTMHM]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	call CopyName1
@@ -251,9 +251,9 @@ TMHM_ShowTMMoveDescription:
 	ld a, [wCurItem]
 	cp NUM_TMS + NUM_HMS + 1
 	jr nc, TMHM_JoypadLoop
-	ld [wd265], a
+	ld [wTempTMHM], a
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	ld [wCurSpecies], a
 	hlcoord 1, 14
 	call PrintMoveDesc
@@ -261,14 +261,14 @@ TMHM_ShowTMMoveDescription:
 
 TMHM_ChooseTMorHM:
 	call TMHM_PlaySFX_ReadText2
-	call CountTMsHMs ; This stores the count to wd265.
+	call CountTMsHMs ; This stores the count to wTempTMHM.
 	ld a, [wMenuCursorY]
 	dec a
 	ld b, a
 	ld a, [wTMHMPocketScrollPosition]
 	add b
 	ld b, a
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	cp b
 	jr z, _TMHM_ExitPack ; our cursor was hovering over CANCEL
 TMHM_CheckHoveringOverCancel:
@@ -354,16 +354,16 @@ TMHM_DisplayPocketItems:
 	jr z, .loop2
 	ld b, a
 	ld a, c
-	ld [wd265], a
+	ld [wTempTMHM], a
 	push hl
 	push de
 	push bc
 	call TMHMPocket_GetCurrentLineCoord
 	push hl
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	cp NUM_TMS + 1
 	jr nc, .HM
-	ld de, wd265
+	ld de, wTempTMHM
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 2
 	call PrintNum
 	jr .okay
@@ -371,17 +371,17 @@ TMHM_DisplayPocketItems:
 .HM:
 	push af
 	sub NUM_TMS
-	ld [wd265], a
+	ld [wTempTMHM], a
 	ld [hl], "H"
 	inc hl
-	ld de, wd265
+	ld de, wTempTMHM
 	lb bc, PRINTNUM_RIGHTALIGN | 1, 2
 	call PrintNum
 	pop af
-	ld [wd265], a
+	ld [wTempTMHM], a
 .okay
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	pop hl
@@ -403,8 +403,8 @@ TMHM_DisplayPocketItems:
 	pop bc
 	push bc
 	ld a, b
-	ld [wd265], a
-	ld de, wd265
+	ld [wTempTMHM], a
+	ld de, wTempTMHM
 	lb bc, 1, 2
 	call PrintNum
 .hm2
@@ -445,7 +445,7 @@ Unreferenced_Function2ca95:
 	ld bc, 3
 	add hl, bc
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	push hl
@@ -508,7 +508,7 @@ Unreferenced_Function2cadf:
 	db "@"
 
 .CheckHaveRoomForTMHM:
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	dec a
 	ld hl, wTMsHMs
 	ld b, 0
@@ -523,7 +523,7 @@ Unreferenced_Function2cadf:
 
 ConsumeTM:
 	call ConvertCurItemIntoCurTMHM
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	dec a
 	ld hl, wTMsHMs
 	ld b, 0
@@ -555,7 +555,7 @@ CountTMsHMs:
 	dec c
 	jr nz, .loop
 	ld a, b
-	ld [wd265], a
+	ld [wTempTMHM], a
 	ret
 
 PrintMoveDesc:

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -33,14 +33,14 @@ CanLearnTMHMMove:
 	ret
 
 GetTMHMMove:
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	dec a
 	ld hl, TMHMMoves
 	ld b, 0
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempTMHM], a
 	ret
 
 INCLUDE "data/moves/tmhm_moves.asm"

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -149,13 +149,13 @@ Gen2ToGen1LinkComms:
 	ld a, [hli]
 	cp -1
 	jr z, .done_party
-	ld [wd265], a
+	ld [wTempSpecies], a
 	push hl
 	push de
 	callfar ConvertMon_1to2
 	pop de
 	pop hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [de], a
 	inc de
 	jr .party_loop
@@ -651,13 +651,13 @@ Link_PrepPartyData_Gen1:
 	ld a, [hli]
 	cp -1
 	jr z, .done_party
-	ld [wd265], a
+	ld [wTempSpecies], a
 	push hl
 	push de
 	callfar ConvertMon_2to1
 	pop de
 	pop hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [de], a
 	inc de
 	jr .loop2
@@ -692,11 +692,11 @@ Link_PrepPartyData_Gen1:
 	push de
 	push bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	callfar ConvertMon_2to1
 	pop bc
 	pop de
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [de], a
 	inc de
 	ld hl, MON_HP
@@ -976,11 +976,11 @@ Function2868a:
 	inc de
 	push bc
 	push de
-	ld [wd265], a
+	ld [wTempSpecies], a
 	callfar ConvertMon_1to2
 	pop de
 	pop bc
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [bc], a
 	ld [wCurSpecies], a
 	ld hl, MON_HP
@@ -1461,7 +1461,7 @@ Function28926:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	hlcoord 0, 12
 	ld b, 4
@@ -1619,7 +1619,7 @@ LinkTrade:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	ld de, wd004
@@ -1631,7 +1631,7 @@ LinkTrade:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, UnknownText_0x28eb8
 	bccoord 1, 14
@@ -2047,14 +2047,14 @@ CheckTimeCapsuleCompatibility:
 	jr .done
 
 .mon_too_new
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld a, $1
 	jr .done
 
 .move_too_new
 	push bc
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	pop bc
@@ -2079,7 +2079,7 @@ Function29c67:
 	ld hl, wPartyCount
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ret
 
@@ -2146,13 +2146,13 @@ WaitForOtherPlayerToExit:
 SetBitsForLinkTradeRequest:
 	ld a, LINK_TRADECENTER - 1
 	ld [wPlayerLinkAction], a
-	ld [wd265], a
+	ld [wChosenCableClubRoom], a
 	ret
 
 SetBitsForBattleRequest:
 	ld a, LINK_COLOSSEUM - 1
 	ld [wPlayerLinkAction], a
-	ld [wd265], a
+	ld [wChosenCableClubRoom], a
 	ret
 
 SetBitsForTimeCapsuleRequest:
@@ -2166,7 +2166,7 @@ SetBitsForTimeCapsuleRequest:
 	ld [rSC], a
 	xor a ; LINK_TIMECAPSULE - 1
 	ld [wPlayerLinkAction], a
-	ld [wd265], a
+	ld [wChosenCableClubRoom], a
 	ret
 
 WaitForLinkedFriend:
@@ -2373,7 +2373,7 @@ Link_CheckCommunicationError:
 	ret
 
 TryQuickSave:
-	ld a, [wd265]
+	ld a, [wChosenCableClubRoom]
 	push af
 	farcall Link_SaveGame
 	ld a, TRUE
@@ -2384,11 +2384,11 @@ TryQuickSave:
 	ld c, 30
 	call DelayFrames
 	pop af
-	ld [wd265], a
+	ld [wChosenCableClubRoom], a
 	ret
 
 CheckBothSelectedSameRoom:
-	ld a, [wd265]
+	ld a, [wChosenCableClubRoom]
 	call Link_EnsureSync
 	push af
 	call LinkDataReceived
@@ -2396,10 +2396,10 @@ CheckBothSelectedSameRoom:
 	call LinkDataReceived
 	pop af
 	ld b, a
-	ld a, [wd265]
+	ld a, [wChosenCableClubRoom]
 	cp b
 	jr nz, .fail
-	ld a, [wd265]
+	ld a, [wChosenCableClubRoom]
 	inc a
 	ld [wLinkMode], a
 	xor a

--- a/engine/link/mystery_gift.asm
+++ b/engine/link/mystery_gift.asm
@@ -1430,7 +1430,7 @@ Function105688:
 	ld de, wMysteryGiftTrainerData
 	farcall Function8ac70
 	ld a, c
-	ld [wd265], a
+	ld [wDeciramBuffer], a
 	ld hl, Text_CardNotRegistered
 	jr c, PrintTextAndExit_JP
 	ld hl, Text_ListedCardAsNumber

--- a/engine/link/mystery_gift_2.asm
+++ b/engine/link/mystery_gift_2.asm
@@ -24,7 +24,7 @@ PrepMysteryGiftDataToSend:
 	call CountSetBits
 	pop de
 	pop bc
-	ld a, [wd265]
+	ld a, [wNumSetBits]
 	ld [de], a
 	inc de ; wc80f
 	call CloseSRAM

--- a/engine/link/time_capsule.asm
+++ b/engine/link/time_capsule.asm
@@ -122,7 +122,7 @@ PlaceTradePartnerNamesAndParty:
 	ld a, [de]
 	cp -1
 	ret z
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	push bc
 	push hl
 	push de

--- a/engine/link/time_capsule_2.asm
+++ b/engine/link/time_capsule_2.asm
@@ -1,8 +1,10 @@
 ConvertMon_2to1:
-; Takes the Gen-2 Pokemon number stored in wd265, finds it in the Pokered_MonIndices table, and returns its index in wd265.
+; Takes the Gen 2 Pokemon number stored in wTempSpecies,
+; finds it in the Pokered_MonIndices table,
+; and returns its index in wTempSpecies.
 	push bc
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld b, a
 	ld c, 0
 	ld hl, Pokered_MonIndices
@@ -12,23 +14,24 @@ ConvertMon_2to1:
 	cp b
 	jr nz, .loop
 	ld a, c
-	ld [wd265], a
+	ld [wTempSpecies], a
 	pop hl
 	pop bc
 	ret
 
 ConvertMon_1to2:
-; Takes the Gen-1 Pokemon number stored in wd265 and returns the corresponding value from Pokered_MonIndices in wd265.
+; Takes the Gen 1 Pokemon number stored in wTempSpecies
+; and returns the corresponding value from Pokered_MonIndices in wTempSpecies.
 	push bc
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	ld hl, Pokered_MonIndices
 	ld b, 0
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	pop hl
 	pop bc
 	ret

--- a/engine/menus/debug.asm
+++ b/engine/menus/debug.asm
@@ -311,9 +311,9 @@ Function81adb:
 	ld a, [wcf66]
 	inc a
 	ld [wCurPartySpecies], a
-	ld [wd265], a
+	ld [wDeciramBuffer], a
 	hlcoord 0, 1
-	ld de, wd265
+	ld de, wDeciramBuffer
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNum
 	ld a, [wd002]
@@ -353,7 +353,7 @@ Function81adb:
 	jr .asm_81ba9
 
 .asm_81b7a
-	ld a, [wd265]
+	ld a, [wDeciramBuffer]
 	ld [wTrainerClass], a
 	callfar GetTrainerAttributes
 	ld de, wStringBuffer1
@@ -738,9 +738,9 @@ Function81df4:
 	call Function81e5e
 	ld a, [wd004]
 	inc a
-	ld [wd265], a
+	ld [wTempTMHM], a
 	predef GetTMHMMove
-	ld a, [wd265]
+	ld a, [wTempTMHM]
 	ld [wPutativeTMHMMove], a
 	call GetMoveName
 	hlcoord 10, 12

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -593,7 +593,7 @@ Continue_DisplayBadgeCount:
 	ld b, 2
 	call CountSetBits
 	pop hl
-	ld de, wd265
+	ld de, wNumSetBits
 	lb bc, 1, 2
 	jp PrintNum
 
@@ -610,7 +610,7 @@ else
 endc
 	call CountSetBits
 	pop hl
-	ld de, wd265
+	ld de, wNumSetBits
 	lb bc, 1, 3
 	jp PrintNum
 

--- a/engine/menus/menu_2.asm
+++ b/engine/menus/menu_2.asm
@@ -170,7 +170,7 @@ StartMenu_PrintBugContestStatus:
 	and a
 	ld de, .None
 	jr z, .no_contest_mon
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 .no_contest_mon

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -84,13 +84,13 @@ NamingScreen:
 
 .Pokemon:
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempIconSpecies], a
 	ld hl, LoadMenuMonIcon
 	ld a, BANK(LoadMenuMonIcon)
-	ld e, $1
-	rst FarCall ;  ; indirect jump to LoadMenuMonIcon (8e83f (23:683f))
+	ld e, MONICON_NAMINGSCREEN
+	rst FarCall
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	hlcoord 5, 2
 	call PlaceString

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -133,12 +133,12 @@ StartMoveMonWOMail_SaveGame:
 	ret
 
 PauseGameLogic:
-	ld a, $1
+	ld a, TRUE
 	ld [wGameLogicPaused], a
 	ret
 
 ResumeGameLogic:
-	xor a
+	xor a ; FALSE
 	ld [wGameLogicPaused], a
 	ret
 
@@ -230,13 +230,13 @@ _SavingDontTurnOffThePower:
 SavedTheGame:
 	call _SaveGameData
 	; wait 32 frames
-	ld c, $20
+	ld c, 32
 	call DelayFrames
 	; copy the original text speed setting to the stack
 	ld a, [wOptions]
 	push af
-	; set text speed super slow
-	ld a, 3
+	; set text speed to medium
+	ld a, TEXT_DELAY_MED
 	ld [wOptions], a
 	; <PLAYER> saved the game!
 	ld hl, Text_PlayerSavedTheGame
@@ -248,7 +248,7 @@ SavedTheGame:
 	call WaitPlaySFX
 	call WaitSFX
 	; wait 30 frames
-	ld c, $1e
+	ld c, 30
 	call DelayFrames
 	ret
 
@@ -332,8 +332,8 @@ SavingDontTurnOffThePower:
 	; Save the text speed setting to the stack
 	ld a, [wOptions]
 	push af
-	; Set the text speed to super slow
-	ld a, $3
+	; Set the text speed to medium
+	ld a, TEXT_DELAY_MED
 	ld [wOptions], a
 	; SAVING... DON'T TURN OFF THE POWER.
 	ld hl, Text_SavingDontTurnOffThePower
@@ -342,7 +342,7 @@ SavingDontTurnOffThePower:
 	pop af
 	ld [wOptions], a
 	; Wait for 16 frames
-	ld c, $10
+	ld c, 16
 	call DelayFrames
 	ret
 

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -639,7 +639,7 @@ CantUseItemText:
 
 PartyMonItemName:
 	ld a, [wCurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	call CopyName1
 	ret
@@ -842,17 +842,17 @@ TryGiveItemToPartymon:
 	ret
 
 .already_holding_item
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld hl, SwitchAlreadyHoldingText
 	call StartMenuYesNo
 	jr c, .abort
 
 	call GiveItemToPokemon
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	push af
 	ld a, [wCurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	pop af
 	ld [wCurItem], a
 	call ReceiveItemFromPokemon
@@ -860,13 +860,13 @@ TryGiveItemToPartymon:
 
 	ld hl, TookAndMadeHoldText
 	call MenuTextBoxBackup
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [wCurItem], a
 	call GivePartyItem
 	ret
 
 .bag_full
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [wCurItem], a
 	call ReceiveItemFromPokemon
 	ld hl, ItemStorageIsFullText
@@ -901,7 +901,7 @@ TakePartyItem:
 	farcall ItemIsMail
 	call GetPartyItemLocation
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [hl], NO_ITEM
 	call GetItemName
 	ld hl, TookFromText
@@ -1654,8 +1654,8 @@ SetUpMoveScreenBG:
 	ld hl, wPartySpecies
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
-	ld e, $2
+	ld [wTempIconSpecies], a
+	ld e, MONICON_MOVES
 	farcall LoadMenuMonIcon
 	hlcoord 0, 1
 	ld b, 9
@@ -1755,8 +1755,8 @@ PlaceMoveData:
 	hlcoord 16, 12
 	cp 2
 	jr c, .no_power
-	ld [wd265], a
-	ld de, wd265
+	ld [wDeciramBuffer], a
+	ld de, wDeciramBuffer
 	lb bc, 1, 3
 	call PrintNum
 	jr .description

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -1724,7 +1724,7 @@ PrepareToPlaceMoveData:
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	ld [wCurMove], a
+	ld [wCurSpecies], a
 	hlcoord 1, 12
 	lb bc, 5, 18
 	jp ClearBox
@@ -1741,11 +1741,11 @@ PlaceMoveData:
 	hlcoord 12, 12
 	ld de, String_MoveAtk
 	call PlaceString
-	ld a, [wCurMove]
+	ld a, [wCurSpecies]
 	ld b, a
 	hlcoord 2, 12
 	predef PrintMoveType
-	ld a, [wCurMove]
+	ld a, [wCurSpecies]
 	dec a
 	ld hl, Moves + MOVE_POWER
 	ld bc, MOVE_LENGTH

--- a/engine/menus/trainer_card.asm
+++ b/engine/menus/trainer_card.asm
@@ -276,7 +276,7 @@ TrainerCard_Page1_PrintDexCaught_GameTime:
 	ld hl, wPokedexCaught
 	ld b, wEndPokedexCaught - wPokedexCaught
 	call CountSetBits
-	ld de, wd265
+	ld de, wNumSetBits
 	hlcoord 15, 10
 	lb bc, 1, 3
 	call PrintNum

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -377,7 +377,7 @@ ParseCredits:
 	push de
 	ld a, [wCreditsPos]
 	ld e, a
-	ld a, [wCreditsPos+1]
+	ld a, [wCreditsPos + 1]
 	ld d, a
 	ld hl, CreditsScript
 	add hl, de
@@ -386,7 +386,7 @@ ParseCredits:
 	ld a, e
 	ld [wCreditsPos], a
 	ld a, d
-	ld [wCreditsPos+1], a
+	ld [wCreditsPos + 1], a
 	ld a, [hl]
 	pop de
 	pop hl

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -317,7 +317,7 @@ TradeAnim_TubeToOT1:
 	ld a, TRADEANIM_RIGHT_ARROW
 	call TradeAnim_PlaceTrademonStatsOnTubeAnim
 	ld a, [wLinkTradeSendmonSpecies]
-	ld [wd265], a
+	ld [wTempIconSpecies], a
 	xor a
 	depixel 5, 11, 4, 0
 	ld b, $0
@@ -327,7 +327,7 @@ TradeAnim_TubeToPlayer1:
 	ld a, TRADEANIM_LEFT_ARROW
 	call TradeAnim_PlaceTrademonStatsOnTubeAnim
 	ld a, [wLinkTradeGetmonSpecies]
-	ld [wd265], a
+	ld [wTempIconSpecies], a
 	ld a, TRADEANIMSTATE_2
 	depixel 9, 18, 4, 4
 	ld b, $4
@@ -820,7 +820,7 @@ TradeAnim_GetFrontpic:
 
 TradeAnim_GetNickname:
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	pop de
@@ -1373,7 +1373,7 @@ LoadTradeBallAndCableGFX:
 
 LoadTradeBubbleGFX:
 	call DelayFrame
-	ld e, $3
+	ld e, MONICON_TRADE
 	callfar LoadMenuMonIcon
 	ld de, TradeBubbleGFX
 	ld hl, vTiles0 tile $72

--- a/engine/overworld/decorations.asm
+++ b/engine/overworld/decorations.asm
@@ -559,7 +559,7 @@ GetDecoName:
 
 .getpokename
 	push bc
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop bc
 	jr .copy

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -972,16 +972,17 @@ DoPlayerEvent:
 	ret
 
 PlayerEventScriptPointers:
-	dba Invalid_0x96c2d          ; 0
-	dba SeenByTrainerScript      ; 1
-	dba TalkToTrainerScript      ; 2
-	dba FindItemInBallScript     ; 3
-	dba EdgeWarpScript           ; 4
-	dba WarpToNewMapScript       ; 5
-	dba FallIntoMapScript        ; 6
-	dba Script_OverworldWhiteout ; 7
-	dba HatchEggScript           ; 8
-	dba ChangeDirectionScript    ; 9
+; entries correspond to PLAYEREVENT_* constants
+	dba Invalid_0x96c2d          ; PLAYEREVENT_NONE
+	dba SeenByTrainerScript      ; PLAYEREVENT_SEENBYTRAINER
+	dba TalkToTrainerScript      ; PLAYEREVENT_TALKTOTRAINER
+	dba FindItemInBallScript     ; PLAYEREVENT_ITEMBALL
+	dba EdgeWarpScript           ; PLAYEREVENT_CONNECTION
+	dba WarpToNewMapScript       ; PLAYEREVENT_WARP
+	dba FallIntoMapScript        ; PLAYEREVENT_FALL
+	dba Script_OverworldWhiteout ; PLAYEREVENT_WHITEOUT
+	dba HatchEggScript           ; PLAYEREVENT_HATCH
+	dba ChangeDirectionScript    ; PLAYEREVENT_JOYCHANGEFACING
 	dba Invalid_0x96c2d          ; 10
 
 Invalid_0x96c2d:

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -983,7 +983,7 @@ PlayerEventScriptPointers:
 	dba Script_OverworldWhiteout ; PLAYEREVENT_WHITEOUT
 	dba HatchEggScript           ; PLAYEREVENT_HATCH
 	dba ChangeDirectionScript    ; PLAYEREVENT_JOYCHANGEFACING
-	dba Invalid_0x96c2d          ; 10
+	dba Invalid_0x96c2d          ; (NUM_PLAYER_EVENTS)
 
 Invalid_0x96c2d:
 	end

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -623,7 +623,7 @@ INCLUDE "data/items/pocket_names.asm"
 
 CurItemName:
 	ld a, [wCurItem]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ret
 
@@ -1863,7 +1863,7 @@ Script_pokenamemem:
 	jr nz, .gotit
 	ld a, [wScriptVar]
 .gotit
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld de, wStringBuffer1
 
@@ -1890,7 +1890,7 @@ Script_itemtotext:
 	jr nz, .ok
 	ld a, [wScriptVar]
 .ok
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ld de, wStringBuffer1
 	jr ConvertMemToText

--- a/engine/overworld/variables.asm
+++ b/engine/overworld/variables.asm
@@ -72,7 +72,7 @@ _GetVarAction::
 	ld hl, wPokedexCaught
 	ld b, wEndPokedexCaught - wPokedexCaught
 	call CountSetBits
-	ld a, [wd265]
+	ld a, [wNumSetBits]
 	jp .loadstringbuffer2
 
 .CountSeenMons:
@@ -80,7 +80,7 @@ _GetVarAction::
 	ld hl, wPokedexSeen
 	ld b, wEndPokedexSeen - wPokedexSeen
 	call CountSetBits
-	ld a, [wd265]
+	ld a, [wNumSetBits]
 	jp .loadstringbuffer2
 
 .CountBadges:
@@ -88,7 +88,7 @@ _GetVarAction::
 	ld hl, wBadges
 	ld b, 2
 	call CountSetBits
-	ld a, [wd265]
+	ld a, [wNumSetBits]
 	jp .loadstringbuffer2
 
 .PlayerFacing:

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -1492,7 +1492,7 @@ Pokedex_PrintListing:
 .loop
 	push af
 	ld a, [de]
-	ld [wTempSpecies], a
+	ld [wTempSpecies], a ; also sets wNamedObjectIndexBuffer
 	push de
 	push hl
 	call .PrintEntry

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -465,7 +465,7 @@ DexEntryScreen_MenuActionJumptable:
 
 .Cry:
 	call Pokedex_GetSelectedMon
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	call GetCryIndex
 	ld e, c
 	ld d, b
@@ -1088,7 +1088,7 @@ Pokedex_DrawMainScreenBG:
 	ld hl, wPokedexSeen
 	ld b, wEndPokedexSeen - wPokedexSeen
 	call CountSetBits
-	ld de, wd265
+	ld de, wNumSetBits
 	hlcoord 5, 12
 	lb bc, 1, 3
 	call PrintNum
@@ -1098,7 +1098,7 @@ Pokedex_DrawMainScreenBG:
 	ld hl, wPokedexCaught
 	ld b, wEndPokedexCaught - wPokedexCaught
 	call CountSetBits
-	ld de, wd265
+	ld de, wNumSetBits
 	hlcoord 5, 15
 	lb bc, 1, 3
 	call PrintNum
@@ -1492,7 +1492,7 @@ Pokedex_PrintListing:
 .loop
 	push af
 	ld a, [de]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	push de
 	push hl
 	call .PrintEntry
@@ -1531,7 +1531,7 @@ Pokedex_PrintNumberIfOldMode:
 	push hl
 	ld de, -SCREEN_WIDTH
 	add hl, de
-	ld de, wd265
+	ld de, wTempSpecies
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNum
 	pop hl
@@ -1585,13 +1585,13 @@ Pokedex_GetSelectedMon:
 	ld hl, wPokedexOrder
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ret
 
 Pokedex_CheckCaught:
 	push de
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 	pop hl
@@ -1601,7 +1601,7 @@ Pokedex_CheckCaught:
 Pokedex_CheckSeen:
 	push de
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckSeenMon
 	pop hl
@@ -1654,7 +1654,7 @@ Pokedex_OrderMonsByMode:
 	ld e, d
 .loopfindend
 	ld a, [hld]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	call Pokedex_CheckSeen
 	jr nz, .foundend
 	dec d
@@ -1674,10 +1674,10 @@ Pokedex_ABCMode:
 .loop1abc
 	push bc
 	ld a, [de]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	call Pokedex_CheckSeen
 	jr z, .skipabc
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [hli], a
 	ld a, [wDexListingEnd]
 	inc a
@@ -1898,7 +1898,7 @@ Pokedex_SearchForMons:
 	ld a, [hl]
 	and a
 	jr z, .next_mon
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ld [wCurSpecies], a
 	call Pokedex_CheckCaught
 	jr z, .next_mon
@@ -1917,7 +1917,7 @@ Pokedex_SearchForMons:
 	jr nz, .next_mon
 
 .match_found
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [de], a
 	inc de
 	ld a, [wDexSearchResultCount]
@@ -2354,7 +2354,7 @@ Pokedex_LoadSelectedMonTiles:
 	jr z, .QuestionMark
 	ld a, [wFirstUnownSeen]
 	ld [wUnownLetter], a
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurPartySpecies], a
 	call GetBaseData
 	ld de, vTiles2
@@ -2378,7 +2378,7 @@ Pokedex_LoadCurrentFootprint:
 	call Pokedex_GetSelectedMon
 
 Pokedex_LoadAnyFootprint:
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	and %11111000
 	srl a
@@ -2386,7 +2386,7 @@ Pokedex_LoadAnyFootprint:
 	srl a
 	ld e, 0
 	ld d, a
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	and %111
 	swap a ; * $10
@@ -2524,7 +2524,7 @@ _NewPokedexEntry:
 	call LoadFontsExtra
 	call Pokedex_LoadGFX
 	call Pokedex_LoadAnyFootprint
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurPartySpecies], a
 	call Pokedex_DrawDexEntryScreenBG
 	call Pokedex_DrawFootprint

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -2138,40 +2138,40 @@ Pokedex_PutScrollbarOAM:
 	ld hl, wDexListingScrollOffset
 	add [hl]
 	cp e
-	jr z, .asm_4133f
-	ld hl, $0
-	ld bc, $79
+	jr z, .max
+	ld hl, 0
+	ld bc, 121 ; max y - min y
 	call AddNTimes
 	ld e, l
 	ld d, h
-	ld b, $0
+	ld b, 0
 	ld a, d
 	or e
-	jr z, .asm_41341
+	jr z, .done
 	ld a, [wDexListingEnd]
 	ld c, a
-.asm_41333
+.loop
 	ld a, e
 	sub c
 	ld e, a
 	ld a, d
-	sbc $0
+	sbc 0
 	ld d, a
-	jr c, .asm_41341
+	jr c, .done
 	inc b
-	jr .asm_41333
-.asm_4133f
-	ld b, $79
-.asm_41341
-	ld a, $14
+	jr .loop
+.max
+	ld b, 121 ; max y - min y
+.done
+	ld a, 20 ; min y
 	add b
 	pop hl
 	ld [hli], a
-	ld a, $a1
+	ld a, 161 ; x
 	ld [hli], a
-	ld a, $f
+	ld a, $0f ; tile id
 	ld [hli], a
-	ld [hl], $0
+	ld [hl], 0 ; attributes
 	ret
 
 Pokedex_InitArrowCursor:

--- a/engine/pokedex/pokedex_2.asm
+++ b/engine/pokedex/pokedex_2.asm
@@ -80,7 +80,7 @@ DisplayDexEntry:
 	call GetPokemonName
 	hlcoord 9, 3
 	call PlaceString ; mon species
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld b, a
 	call GetDexEntryPointer
 	ld a, b
@@ -96,11 +96,11 @@ DisplayDexEntry:
 	ld [hli], a
 	ld a, $5d ; .
 	ld [hli], a
-	ld de, wd265
+	ld de, wTempSpecies
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNum
 ; Check to see if we caught it.  Get out of here if we haven't.
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 	pop hl

--- a/engine/pokegear/pokegear.asm
+++ b/engine/pokegear/pokegear.asm
@@ -1287,12 +1287,12 @@ PokegearPhoneContactSubmenu:
 	cp 12
 	jr c, .am
 	sub 12
-	ld [wd265], a
+	ld [wTempByteValue], a
 	scf
 	ret
 
 .am
-	ld [wd265], a
+	ld [wTempByteValue], a
 	and a
 	ret
 
@@ -2741,7 +2741,7 @@ TownMapMon:
 	ld d, $0
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempIconSpecies], a
 ; Get FlyMon icon
 	ld e, $08 ; starting tile in VRAM
 	farcall GetSpeciesIcon

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -1035,7 +1035,7 @@ PCMonInfo:
 	cp -1
 	ret z
 
-	ld [wd265], a
+	ld [wTempSpecies], a
 	hlcoord 1, 4
 	xor a
 	ld b, 7
@@ -1057,7 +1057,7 @@ PCMonInfo:
 	jr nz, .row
 
 	call BillsPC_LoadMonStats
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurPartySpecies], a
 	ld [wCurSpecies], a
 	ld hl, wTempMonDVs
@@ -1068,7 +1068,7 @@ PCMonInfo:
 	xor a
 	ld [wBillsPC_MonHasMail], a
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	cp EGG
 	ret z
 
@@ -1676,9 +1676,9 @@ StatsScreenDPad:
 	and a
 	jr z, .did_nothing
 	call BillsPC_GetSelectedPokemonSpecies
-	ld [wd265], a
+	ld [wTempSpecies], a
 	call BillsPC_LoadMonStats
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurPartySpecies], a
 	ld [wCurSpecies], a
 	ld hl, wTempMonDVs
@@ -1893,7 +1893,7 @@ ReleasePKMN_ByePKMN:
 .skip_cry
 
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	call GetPokemonName
 	hlcoord 1, 16
 	ld de, PCString_ReleasedPKMN
@@ -2314,9 +2314,9 @@ BillsPC_PrintBoxCountAndCapacity:
 	ld de, .Pokemon
 	call PlaceString
 	call GetBoxCount
-	ld [wd265], a
+	ld [wDeciramBuffer], a
 	hlcoord 13, 11
-	ld de, wd265
+	ld de, wDeciramBuffer
 	lb bc, 1, 2
 	call PrintNum
 	ld de, .out_of_20

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -81,7 +81,7 @@ CheckBreedmonCompatibility:
 
 .done
 	ld a, c
-	ld [wd265], a
+	ld [wBreedingCompatibility], a
 	ret
 
 .CheckDVs:
@@ -250,7 +250,7 @@ HatchEggs:
 	ld a, [wCurPartySpecies]
 	dec de
 	ld [de], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wCurSpecies], a
 	call GetPokemonName
 	xor a
@@ -676,7 +676,7 @@ EggHatch_DoAnimFrame:
 	ret
 
 EggHatch_AnimationSequence:
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld [wJumptableIndex], a
 	ld a, [wCurSpecies]
 	push af
@@ -910,7 +910,7 @@ DayCareMonCompatibilityText:
 	call CopyBytes
 	call CheckBreedmonCompatibility
 	pop bc
-	ld a, [wd265]
+	ld a, [wBreedingCompatibility]
 	ld hl, .AllAlone
 	cp -1
 	jr z, .done

--- a/engine/pokemon/caught_data.asm
+++ b/engine/pokemon/caught_data.asm
@@ -38,7 +38,7 @@ CheckPartyFullAfterContest:
 	ld hl, wPlayerName
 	call CopyBytes
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	ld de, wMonOrItemNameBuffer
@@ -105,7 +105,7 @@ CheckPartyFullAfterContest:
 	call CopyBytes
 	callfar InsertPokemonIntoBox
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call GiveANickname_YesNo
 	ld hl, wStringBuffer1

--- a/engine/pokemon/correct_party_errors.asm
+++ b/engine/pokemon/correct_party_errors.asm
@@ -123,7 +123,7 @@ Unreferenced_CorrectPartyErrors:
 	cp EGG
 	ld hl, .TAMAGO
 	jr z, .got_nickname
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 .got_nickname

--- a/engine/pokemon/evolve.asm
+++ b/engine/pokemon/evolve.asm
@@ -236,7 +236,7 @@ EvolveAfterBattle_MasterLoop:
 	ld [wCurSpecies], a
 	ld [wTempMonSpecies], a
 	ld [wEvolutionNewSpecies], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	push hl
@@ -293,15 +293,15 @@ EvolveAfterBattle_MasterLoop:
 	call CopyBytes
 
 	ld a, [wCurSpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	xor a
 	ld [wMonType], a
 	call LearnLevelMoves
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call SetSeenAndCaughtMon
 
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	cp UNOWN
 	jr nz, .skip_unown
 
@@ -348,7 +348,7 @@ UpdateSpeciesNameIfNotNicknamed:
 	ld a, [wCurSpecies]
 	push af
 	ld a, [wBaseDexNo]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop af
 	ld [wCurSpecies], a
@@ -369,7 +369,7 @@ UpdateSpeciesNameIfNotNicknamed:
 	call AddNTimes
 	push hl
 	ld a, [wCurSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	pop de
@@ -415,7 +415,7 @@ Text_WhatEvolving:
 	db "@"
 
 LearnLevelMoves:
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurPartySpecies], a
 	dec a
 	ld b, 0
@@ -466,7 +466,7 @@ LearnLevelMoves:
 .learn
 	ld a, d
 	ld [wPutativeTMHMMove], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	call CopyName1
 	predef LearnMove
@@ -475,7 +475,7 @@ LearnLevelMoves:
 
 .done
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ret
 
 FillMoves:

--- a/engine/pokemon/learn.asm
+++ b/engine/pokemon/learn.asm
@@ -36,7 +36,7 @@ LearnMove:
 
 	push hl
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 
 	ld b, a
 	ld a, [wBattleMode]

--- a/engine/pokemon/mail.asm
+++ b/engine/pokemon/mail.asm
@@ -149,7 +149,7 @@ CheckPokeMail::
 
 ; Compare the mail message, byte for byte, with the expected message.
 	ld a, MAIL_MSG_LENGTH
-	ld [wd265], a
+	ld [wTempByteValue], a
 .loop
 	ld a, [de]
 	ld c, a
@@ -162,9 +162,9 @@ CheckPokeMail::
 	jr nz, .close_sram_return
 	inc hl
 	inc de
-	ld a, [wd265]
+	ld a, [wTempByteValue]
 	dec a
-	ld [wd265], a
+	ld [wTempByteValue], a
 	jr nz, .loop
 
 .done

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -100,7 +100,7 @@ GetMonMenuString:
 	jr z, .NotMove
 	inc hl
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	ret
 

--- a/engine/pokemon/mon_stats.asm
+++ b/engine/pokemon/mon_stats.asm
@@ -295,7 +295,7 @@ ListMovePP:
 	call PrintNum
 	ld a, "/"
 	ld [hli], a
-	ld de, wd265
+	ld de, wTempPP
 	lb bc, 1, 2
 	call PrintNum
 	pop hl

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -52,7 +52,7 @@ TryAddMonToParty:
 	and a
 	jr nz, .skipnickname
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wPartyMonNicknames
 	ld a, [hMoveMon]
@@ -185,11 +185,11 @@ endr
 
 .registerpokedex
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	dec a
 	push de
 	call CheckCaughtMon
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call SetSeenAndCaughtMon
 	pop de
@@ -750,7 +750,7 @@ RestorePPofDepositedPokemon:
 	farcall GetMaxPPOfMove
 	pop de
 	pop hl
-	ld a, [wd265]
+	ld a, [wTempPP]
 	ld b, a
 	ld a, [de]
 	and %11000000
@@ -970,7 +970,7 @@ SendMonIntoBox:
 	call CopyBytes
 
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 
 	ld de, sBoxMonNicknames
@@ -1669,7 +1669,7 @@ GivePoke::
 
 .done
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wTempEnemyMonSpecies], a
 	call GetPokemonName
 	ld hl, wStringBuffer1

--- a/engine/pokemon/move_mon_wo_mail.asm
+++ b/engine/pokemon/move_mon_wo_mail.asm
@@ -5,21 +5,21 @@ InsertPokemonIntoBox:
 	call InsertSpeciesIntoBoxOrParty
 	ld a, [sBoxCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, sBoxMonNicknames
 	ld bc, MON_NAME_LENGTH
 	ld de, wBufferMonNick
 	call InsertDataIntoBoxOrParty
 	ld a, [sBoxCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, sBoxMonOT
 	ld bc, NAME_LENGTH
 	ld de, wBufferMonOT
 	call InsertDataIntoBoxOrParty
 	ld a, [sBoxCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, sBoxMons
 	ld bc, BOXMON_STRUCT_LENGTH
 	ld de, wBufferMon
@@ -42,21 +42,21 @@ InsertPokemonIntoParty:
 	call InsertSpeciesIntoBoxOrParty
 	ld a, [wPartyCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, wPartyMonNicknames
 	ld bc, MON_NAME_LENGTH
 	ld de, wBufferMonNick
 	call InsertDataIntoBoxOrParty
 	ld a, [wPartyCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, wPartyMonOT
 	ld bc, NAME_LENGTH
 	ld de, wBufferMonOT
 	call InsertDataIntoBoxOrParty
 	ld a, [wPartyCount]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	ld hl, wPartyMons
 	ld bc, PARTYMON_STRUCT_LENGTH
 	ld de, wBufferMon
@@ -85,7 +85,7 @@ InsertDataIntoBoxOrParty:
 	push de
 	push hl
 	push bc
-	ld a, [wd265]
+	ld a, [wNextBoxOrPartyIndex]
 	dec a
 	call AddNTimes
 	push hl
@@ -95,7 +95,7 @@ InsertDataIntoBoxOrParty:
 	pop hl
 .loop
 	push bc
-	ld a, [wd265]
+	ld a, [wNextBoxOrPartyIndex]
 	ld b, a
 	ld a, [wCurPartyMon]
 	cp b
@@ -116,9 +116,9 @@ InsertDataIntoBoxOrParty:
 	sbc b
 	ld h, a
 	pop de
-	ld a, [wd265]
+	ld a, [wNextBoxOrPartyIndex]
 	dec a
-	ld [wd265], a
+	ld [wNextBoxOrPartyIndex], a
 	jr .loop
 
 .insert

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -596,7 +596,7 @@ InitPartyMenuGFX:
 	push hl
 	ld hl, LoadMenuMonIcon
 	ld a, BANK(LoadMenuMonIcon)
-	ld e, $0
+	ld e, MONICON_PARTYMENU
 	rst FarCall
 	ld a, [hObjectStructIndexBuffer]
 	inc a

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -377,7 +377,7 @@ StatsScreen_InitUpperHalf:
 	xor a
 	ld [hBGMapMode], a
 	ld a, [wBaseDexNo]
-	ld [wd265], a
+	ld [wDeciramBuffer], a
 	ld [wCurSpecies], a
 	hlcoord 8, 0
 	ld [hl], "№"
@@ -386,7 +386,7 @@ StatsScreen_InitUpperHalf:
 	inc hl
 	hlcoord 10, 0
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
-	ld de, wd265
+	ld de, wDeciramBuffer
 	call PrintNum
 	hlcoord 14, 0
 	call PrintLevel
@@ -401,7 +401,7 @@ StatsScreen_InitUpperHalf:
 	ld a, "/"
 	ld [hli], a
 	ld a, [wBaseDexNo]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call PlaceString
 	call StatsScreen_PlaceHorizontalDivider
@@ -483,7 +483,7 @@ StatsScreen_PlaceShinyIcon:
 
 StatsScreen_LoadGFX:
 	ld a, [wBaseDexNo]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ld [wCurSpecies], a
 	xor a
 	ld [hBGMapMode], a
@@ -708,7 +708,7 @@ StatsScreen_LoadGFX:
 	ld b, a
 	farcall TimeCapsule_ReplaceTeruSama
 	ld a, b
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	ret
 

--- a/engine/pokemon/switchpartymons.asm
+++ b/engine/pokemon/switchpartymons.asm
@@ -1,5 +1,5 @@
 _SwitchPartyMons:
-	ld a, [wd0e3]
+	ld a, [wSwitchMon]
 	dec a
 	ld [wBuffer3], a
 	ld b, a

--- a/engine/pokemon/types.asm
+++ b/engine/pokemon/types.asm
@@ -74,9 +74,9 @@ PrintType:
 	jp PlaceString
 
 GetTypeName:
-; Copy the name of type [wd265] to wStringBuffer1.
+; Copy the name of type [wNamedObjectIndexBuffer] to wStringBuffer1.
 
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld hl, TypeNames
 	ld e, a
 	ld d, 0

--- a/engine/printer/print_party.asm
+++ b/engine/printer/print_party.asm
@@ -26,11 +26,11 @@ PrintPage1:
 	hlcoord 2, 11, wPrinterTileMapBuffer
 	lb bc, 5, 18
 	call ClearBox
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 	push af
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld b, a
 	ld c, 1 ; get page 1
 	farcall GetDexEntryPagePointer
@@ -75,11 +75,11 @@ PrintPage2:
 	ld bc, SCREEN_WIDTH
 	ld a, $32
 	call ByteFill
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 	push af
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld b, a
 	ld c, 2 ; get page 2
 	farcall GetDexEntryPagePointer
@@ -170,7 +170,7 @@ PrintPartyMonPage1:
 	lb bc, 2, 3
 	call PrintNum
 	ld a, [wCurPartySpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wCurSpecies], a
 	ld hl, wPartyMonNicknames
 	call Function1dc50e
@@ -186,7 +186,7 @@ PrintPartyMonPage1:
 	inc hl
 	ld [hl], "."
 	inc hl
-	ld de, wd265
+	ld de, wNamedObjectIndexBuffer
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNum
 	hlcoord 1, 9
@@ -297,7 +297,7 @@ Function1dc51a:
 	and a
 	jr z, .no_move
 
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetMoveName
 	jr .got_string
 

--- a/engine/printer/printer.asm
+++ b/engine/printer/printer.asm
@@ -725,7 +725,7 @@ Printer_PrintBoxListSegment:
 	ld a, [de]
 	cp $ff
 	jp z, .finish
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	ld [wCurPartySpecies], a
 
 	push bc

--- a/engine/rtc/timeset.asm
+++ b/engine/rtc/timeset.asm
@@ -694,8 +694,8 @@ PrintHour:
 	inc hl
 	pop bc
 	call AdjustHourForAMorPM
-	ld [wd265], a
-	ld de, wd265
+	ld [wDeciramBuffer], a
+	ld de, wDeciramBuffer
 	call PrintTwoDigitNumberRightAlign
 	ret
 

--- a/home.asm
+++ b/home.asm
@@ -169,7 +169,7 @@ INCLUDE "home/hp_pals.asm"
 
 CountSetBits::
 ; Count the number of set bits in b bytes starting from hl.
-; Return in a, c and [wd265].
+; Return in a, c and [wNumSetBits].
 	ld c, 0
 .next
 	ld a, [hli]
@@ -188,7 +188,7 @@ CountSetBits::
 	jr nz, .next
 
 	ld a, c
-	ld [wd265], a
+	ld [wNumSetBits], a
 	ret
 
 GetWeekday::

--- a/home/joypad.asm
+++ b/home/joypad.asm
@@ -213,7 +213,7 @@ GetJoypad::
 	ld a, l
 	ld [wAutoInputAddress], a
 	ld a, h
-	ld [wAutoInputAddress+1], a
+	ld [wAutoInputAddress + 1], a
 	jr .finishauto
 
 .stopauto
@@ -235,7 +235,7 @@ StartAutoInput::
 	ld a, l
 	ld [wAutoInputAddress], a
 	ld a, h
-	ld [wAutoInputAddress+1], a
+	ld [wAutoInputAddress + 1], a
 ; Start reading the stream immediately.
 	xor a
 	ld [wAutoInputLength], a
@@ -254,7 +254,7 @@ StopAutoInput::
 	xor a
 	ld [wAutoInputBank], a
 	ld [wAutoInputAddress], a
-	ld [wAutoInputAddress+1], a
+	ld [wAutoInputAddress + 1], a
 	ld [wAutoInputLength], a
 ; Back to normal input.
 	ld [wInputType], a

--- a/home/names.asm
+++ b/home/names.asm
@@ -23,7 +23,7 @@ GetName::
 	jr nz, .NotPokeName
 
 	ld a, [wCurSpecies]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, MON_NAME_LENGTH
 	add hl, de
@@ -110,7 +110,7 @@ GetBasePokemonName::
 	ret
 
 GetPokemonName::
-; Get Pokemon name wd265.
+; Get Pokemon name for wNamedObjectIndexBuffer.
 
 	ld a, [hROMBank]
 	push af
@@ -119,7 +119,7 @@ GetPokemonName::
 	rst Bankswitch
 
 ; Each name is ten characters
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	dec a
 	ld d, 0
 	ld e, a
@@ -147,11 +147,11 @@ GetPokemonName::
 	ret
 
 GetItemName::
-; Get item name wd265.
+; Get item name for wNamedObjectIndexBuffer.
 
 	push hl
 	push bc
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 
 	cp TM01
 	jr nc, .TM
@@ -170,12 +170,12 @@ GetItemName::
 	ret
 
 GetTMHMName::
-; Get TM/HM name by item id wd265.
+; Get TM/HM name for item wNamedObjectIndexBuffer.
 
 	push hl
 	push de
 	push bc
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	push af
 
 ; TM/HM prefix
@@ -197,7 +197,7 @@ GetTMHMName::
 
 ; TM/HM number
 	push de
-	ld a, [wd265]
+	ld a, [wNamedObjectIndexBuffer]
 	ld c, a
 	callfar GetTMHMNumber
 	pop de
@@ -235,7 +235,7 @@ GetTMHMName::
 	ld [de], a
 
 	pop af
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	pop bc
 	pop de
 	pop hl

--- a/home/names.asm
+++ b/home/names.asm
@@ -2,10 +2,10 @@ NamesPointers::
 ; entries correspond to GetName constants (see constants/text_constants.asm)
 	dba PokemonNames        ; MON_NAME (not used; jumps to GetPokemonName)
 	dba MoveNames           ; MOVE_NAME
-	dbw 0, NULL             ; DUMMY_NAME
+	dba NULL                ; DUMMY_NAME
 	dba ItemNames           ; ITEM_NAME
-	dbw 0, wPartyMonOT       ; PARTY_OT_NAME
-	dbw 0, wOTPartyMonOT     ; ENEMY_OT_NAME
+	dbw 0, wPartyMonOT      ; PARTY_OT_NAME
+	dbw 0, wOTPartyMonOT    ; ENEMY_OT_NAME
 	dba TrainerClassNames   ; TRAINER_NAME
 	dbw 4, MoveDescriptions ; MOVE_DESC_NAME_BROKEN (wrong bank)
 

--- a/home/predef.asm
+++ b/home/predef.asm
@@ -39,7 +39,7 @@ Predef::
 	ld a, h
 	ld [wPredefTemp], a
 	ld a, l
-	ld [wPredefTemp+1], a
+	ld [wPredefTemp + 1], a
 
 	pop hl
 	ld a, h

--- a/home/print_level.asm
+++ b/home/print_level.asm
@@ -22,7 +22,7 @@ PrintLevel_Force3Digits::
 	ld c, 3
 
 Print8BitNumRightAlign::
-	ld [wd265], a
-	ld de, wd265
+	ld [wDeciramBuffer], a
+	ld de, wDeciramBuffer
 	ld b, PRINTNUM_RIGHTALIGN | 1
 	jp PrintNum

--- a/maps/BattleTowerBattleRoom.asm
+++ b/maps/BattleTowerBattleRoom.asm
@@ -34,7 +34,7 @@ Script_BattleRoomLoop:
 	special FadeOutPalettes
 	reloadmap
 	ifnotequal $0, Script_FailedBattleTowerChallenge
-	copybytetovar wNrOfBeatenBattleTowerTrainers ; wcf64
+	copybytetovar wNrOfBeatenBattleTowerTrainers
 	ifequal BATTLETOWER_STREAK_LENGTH, Script_BeatenAllTrainers
 	applymovement BATTLETOWERBATTLEROOM_YOUNGSTER, MovementData_BattleTowerBattleRoomOpponentWalksOut
 	warpsound

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -261,7 +261,7 @@ CopyMobileEZChatToC608:
 
 .get_name
 	ld a, e
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	ld bc, MON_NAME_LENGTH - 1

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -268,7 +268,7 @@ Function4a9d7:
 	call GetNick
 	ld h, d
 	ld l, e
-	ld de, wEndFlypoint
+	ld de, wd006
 	ld bc, 6
 	call CopyBytes
 	ld a, [wd003]

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -428,7 +428,7 @@ Function4aad3:
 .loop
 	push bc
 	push hl
-	ld e, 0
+	ld e, MONICON_PARTYMENU
 	farcall LoadMenuMonIcon
 	ld a, [hObjectStructIndexBuffer]
 	inc a

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -1549,7 +1549,7 @@ _LinkBattleSendReceiveAction:
 
 .StageForSend:
 	ld a, [wBattlePlayerAction]
-	and a
+	and a ; BATTLEPLAYERACTION_USEMOVE?
 	jr nz, .switch
 	ld a, [wCurPlayerMove]
 	ld b, BATTLEACTION_E
@@ -6383,7 +6383,7 @@ Function102d48:
 	ld hl, wPartyCount
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	cp EGG
 	jr z, .asm_102d6d
 	dec a
@@ -6396,7 +6396,7 @@ Function102d48:
 	ld [hl], BASE_HAPPINESS
 
 .asm_102d6d
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	cp UNOWN
 	jr nz, .asm_102d98
 	ld a, [wcd4c]
@@ -6529,7 +6529,7 @@ Function102e4f:
 	ld a, [de]
 	cp $ff
 	ret z
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	push bc
 	push hl
 	push de
@@ -6557,7 +6557,7 @@ Function102ea8:
 	ld hl, wPartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	ld de, wStringBuffer2
@@ -6570,7 +6570,7 @@ Function102ea8:
 	ld hl, wOTPartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, UnknownText_0x102ee2
 	call PrintTextBoxText
@@ -6639,7 +6639,7 @@ Function102f85:
 	ld hl, wOTPartySpecies
 	add hl, bc
 	ld a, [hl]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	call Function102dc3
 	ld de, String_102fb2
@@ -7518,11 +7518,11 @@ UnknownText_0x10377b:
 	db "@"
 
 Function103780:
-	ld a, [wd265]
+	ld a, [wChosenCableClubRoom]
 	push af
 	call Function10378c
 	pop af
-	ld [wd265], a
+	ld [wChosenCableClubRoom], a
 	ret
 
 Function10378c:

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -318,7 +318,7 @@ Function108229:
 
 MobileTradeAnim_InitSpeciesName:
 	push de
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	pop de

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -3967,7 +3967,7 @@ BattleTower_UbersCheck:
 .uber_under_70
 	pop af
 	ld a, [de]
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wStringBuffer1
 	ld de, wcd49
@@ -5624,11 +5624,11 @@ Function11ad1b:
 	ld [wCurIconTile], a
 	ld hl, LoadMenuMonIcon
 	ld a, BANK(LoadMenuMonIcon)
-	ld e, $4
+	ld e, MONICON_MOBILE1
 	rst FarCall
 	ld hl, LoadMenuMonIcon
 	ld a, BANK(LoadMenuMonIcon)
-	ld e, $5
+	ld e, MONICON_MOBILE2
 	rst FarCall
 	ld hl, $c6d0
 	ld bc, $0115
@@ -6127,7 +6127,7 @@ Function11b099:
 .loop
 	push af
 	ld a, [de]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	push de
 	push hl
 	call .PlaceMonNameOrPlaceholderString
@@ -6387,13 +6387,13 @@ Function11b20b:
 	ld hl, $c6d0
 	add hl, de
 	ld a, [hl]
-	ld [wd265], a
+	ld [wTempSpecies], a
 	ret
 
 CheckCaughtMemMon:
 	push de
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckCaughtMon
 	pop hl
@@ -6403,7 +6403,7 @@ CheckCaughtMemMon:
 CheckSeenMemMon:
 	push de
 	push hl
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	dec a
 	call CheckSeenMon
 	pop hl
@@ -6463,7 +6463,7 @@ Function11b275:
 	ret
 
 Function11b279:
-	ld a, [wd265]
+	ld a, [wTempSpecies]
 	ld [wCurSpecies], a
 	call CheckSeenMemMon
 	jr z, .asm_11b28f

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -3367,7 +3367,7 @@ Function119987:
 	ret
 
 Function1199b4:
-	ld a, [w3_d081+1]
+	ld a, [w3_d081 + 1]
 	and a
 	jr nz, .asm_1199c7
 	ld a, [w3_d081]

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -121,10 +121,10 @@ Function170c06:
 	push hl
 	ld de, 0
 	xor a
-	ld [wd265], a
+	ld [wTempByteValue], a
 .asm_170c30
 	ld hl, wPartyMon1HP
-	ld a, [wd265]
+	ld a, [wTempByteValue]
 	call GetPartyLocation
 	ld a, [hli]
 	ld b, a
@@ -143,9 +143,9 @@ Function170c06:
 	push hl
 	pop de
 	jr c, .asm_170c58
-	ld a, [wd265]
+	ld a, [wTempByteValue]
 	inc a
-	ld [wd265], a
+	ld [wTempByteValue], a
 	cp $3
 	jr c, .asm_170c30
 	jr .asm_170c5b

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -3902,7 +3902,7 @@ Function17f1d0:
 	ld a, [hl]
 	ld a, $1
 	ld [rSVBK], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop hl
 	call PlaceString
@@ -4021,7 +4021,7 @@ Function17f27b:
 	ld a, [hl]
 	ld a, $1
 	ld [rSVBK], a
-	ld [wd265], a
+	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	pop hl
 	call PlaceString

--- a/wram.asm
+++ b/wram.asm
@@ -1883,7 +1883,7 @@ wTMHMPocketScrollPosition::     db
 wSwitchMon::
 wSwitchItem::
 wMoveSwapBuffer::
-wd0e3::
+wd0e3:: ; mobile
 	db
 
 wMenuScrollPosition:: ds 4

--- a/wram.asm
+++ b/wram.asm
@@ -1701,7 +1701,7 @@ NEXTU ; d002
 ; trainer HUD data
 	ds 1
 wPlaceBallsDirection:: db
-wTrainerHUDTiles:: db
+wTrainerHUDTiles:: ds 4
 
 NEXTU ; d002
 ; mobile participant nicknames

--- a/wram.asm
+++ b/wram.asm
@@ -1320,9 +1320,7 @@ wcf5d:: dw
 
 wMonType:: db ; cf5f
 
-wCurSpecies::
-wCurMove::
-	db ; cf60
+wCurSpecies:: db ; cf60
 
 wNamedObjectTypeBuffer:: db
 

--- a/wram.asm
+++ b/wram.asm
@@ -1675,11 +1675,7 @@ wRadioTextEnd::
 
 NEXTU ; d002
 ; lucky number show
-wLuckyNumberDigit1Buffer:: db
-wLuckyNumberDigit2Buffer:: db
-wLuckyNumberDigit3Buffer:: db
-wLuckyNumberDigit4Buffer:: db
-wLuckyNumberDigit5Buffer:: db
+wLuckyNumberDigitsBuffer:: ds 5
 
 NEXTU ; d002
 ; movement buffer data
@@ -1731,7 +1727,8 @@ wd003:: db
 wd004:: db
 
 ; mobile?
-	ds 3
+	ds 1
+wd006:: ds 2
 wd008:: ds 2
 	ds 2
 wd00c:: ds 1

--- a/wram.asm
+++ b/wram.asm
@@ -2199,11 +2199,24 @@ wPutativeTMHMMove:: db
 wInitListType:: db
 wBattleHasJustStarted:: db
 
+; d265 has many different short-term uses
 wNamedObjectIndexBuffer::
-wCurTMHM::
+wDeciramBuffer::
+wTempByteValue::
+wNumSetBits::
 wTypeMatchup::
-wFoundMatchingIDInParty::
-wd265::
+wCurType::
+wTempSpecies::
+wTempIconSpecies::
+wTempTMHM::
+wTempPP::
+wNextBoxOrPartyIndex::
+wChosenCableClubRoom::
+wBreedingCompatibility::
+wMoveGrammar::
+wApplyStatLevelMultipliersToEnemy::
+wUsePPUp::
+wd265:: ; mobile
 	db
 
 wFailedToFlee:: db


### PR DESCRIPTION
Also introduce `MONICON_*` and `BATTLEPLAYERACTION_*` constants, revise the bug docs, and do some miscellaneous minor WRAM cleanup.

One unidentified use of `wd265` is left, in `Function11b483` in mobile/mobile_46.asm. It's being initialized along with `wPlayerID`, `wSecretID`, `wcd2e`, `wcd2f`, and `wcd30`.