### PR TITLE
Update lzcomp to the newest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ pokecrystal11.gbc: $(crystal11_obj) pokecrystal.link
 	$(eval filename := $@.$(hash))
 	$(if $(wildcard $(filename)),\
 		cp $(filename) $@,\
-		tools/lzcomp $< $@)
+		tools/lzcomp -- $< $@)
 
 
 ### Terrible hacks to match animations. Delete these rules if you don't care about matching.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -19,5 +19,10 @@ clean:
 	rm -f $(tools)
 
 gfx md5: common.h
+
+# suppress warnings
+lzcomp: lzcomp.c
+	$(CC) -O3 -o $@ $<
+
 %: %.c
 	$(CC) $(CFLAGS) -o $@ $<


### PR DESCRIPTION
This pull request updates lzcomp to the newest version, the one currently in use in Prism. I don't remember when I fixed a small bug in it, but it was a very long time ago; apparently that fix was not ported here, which causes some pixels to render incorrectly. 
It does not affect the actual ROM, but it affects ROM hackers who attempt to use the tool.

Also, since the code works properly, and there's little point in fixing what isn't broken just because a tool falsely believes it is, I updated the tools' Makefile to remove the unnecessary `-Wall -Wextra` for lzcomp only. I updated the main Makefile as well, since the new version of lzcomp accepts some command-line options; I added `--` to the invocation of lzcomp to ensure that it doesn't interpret the first argument as an option if it happens to begin with a dash (unlikely, but possible).