### PR TITLE
Avoid warnings from gcc for lzcomp

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,9 +20,5 @@ clean:
 
 gfx md5: common.h
 
-# suppress warnings
-lzcomp: lzcomp.c
-	$(CC) -O3 -o $@ $<
-
 %: %.c
 	$(CC) $(CFLAGS) -o $@ $<


### PR DESCRIPTION
- `get_options`: unused parameter `[-Wunused-parameter]`
- `write_command_to_textfile`: comparison is always false due to limited range of data type `[-Wtype-limits]`
- `write_command_to_file`: comparison between signed and unsigned integer expressions `[-Wsign-compare]`
- `find_best_copy`: suggest parentheses around assignment used as truth value `[-Wparentheses]`
- `optimize`: this statement may fall through `[-Wimplicit-fallthrough]`
