### PR TITLE
Use real labels for HRAM instead of constants, and the ldh instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(crystal11_obj): RGBASMFLAGS = -D _CRYSTAL -D _CRYSTAL11
 # It doesn't look like $(shell) can be deferred so there might not be a better way.
 define DEP
 $1: $2 $$(shell tools/scan_includes $2)
-	$$(RGBASM) $$(RGBASMFLAGS) -o $$@ $$<
+	$$(RGBASM) $$(RGBASMFLAGS) -L -o $$@ $$<
 endef
 
 # Build tools when building the rom.

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -202,10 +202,10 @@ _UpdateSound::
 	call FadeMusic
 	; write volume to hardware register
 	ld a, [wVolume]
-	ld [rNR50], a
+	ldh [rNR50], a
 	; write SO on/off to hardware register
 	ld a, [wSoundOutput]
-	ld [rNR51], a
+	ldh [rNR51], a
 	ret
 
 UpdateChannels:
@@ -244,7 +244,7 @@ UpdateChannels:
 	jr z, .asm_e8159
 	;
 	ld a, [wSoundInput]
-	ld [rNR10], a
+	ldh [rNR10], a
 .asm_e8159
 	bit NOTE_REST, [hl] ; rest
 	jr nz, .ch1rest
@@ -258,35 +258,35 @@ UpdateChannels:
 
 .frequency_override
 	ld a, [wCurTrackFrequency]
-	ld [rNR13], a
+	ldh [rNR13], a
 	ld a, [wCurTrackFrequency + 1]
-	ld [rNR14], a
+	ldh [rNR14], a
 .check_duty_override
 	bit NOTE_DUTY_OVERRIDE, [hl]
 	ret z
 	ld a, [wCurTrackDuty]
 	ld d, a
-	ld a, [rNR11]
+	ldh a, [rNR11]
 	and $3f ; sound length
 	or d
-	ld [rNR11], a
+	ldh [rNR11], a
 	ret
 
 .asm_e8184
 	ld a, [wCurTrackDuty]
 	ld d, a
-	ld a, [rNR11]
+	ldh a, [rNR11]
 	and $3f ; sound length
 	or d
-	ld [rNR11], a
+	ldh [rNR11], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR13], a
+	ldh [rNR13], a
 	ret
 
 .ch1rest
-	ld a, [rNR52]
+	ldh a, [rNR52]
 	and %10001110 ; ch1 off
-	ld [rNR52], a
+	ldh [rNR52], a
 	ld hl, rNR10
 	call ClearChannel
 	ret
@@ -295,14 +295,14 @@ UpdateChannels:
 	ld hl, wCurTrackDuty
 	ld a, $3f ; sound length
 	or [hl]
-	ld [rNR11], a
+	ldh [rNR11], a
 	ld a, [wCurTrackIntensity]
-	ld [rNR12], a
+	ldh [rNR12], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR13], a
+	ldh [rNR13], a
 	ld a, [wCurTrackFrequency + 1]
 	or $80
-	ld [rNR14], a
+	ldh [rNR14], a
 	ret
 
 .Channel2:
@@ -319,34 +319,34 @@ UpdateChannels:
 	ret z
 	ld a, [wCurTrackDuty]
 	ld d, a
-	ld a, [rNR21]
+	ldh a, [rNR21]
 	and $3f ; sound length
 	or d
-	ld [rNR21], a
+	ldh [rNR21], a
 	ret
 
 .asm_e81db ; unused
 	ld a, [wCurTrackFrequency]
-	ld [rNR23], a
+	ldh [rNR23], a
 	ld a, [wCurTrackFrequency + 1]
-	ld [rNR24], a
+	ldh [rNR24], a
 	ret
 
 .asm_e81e6
 	ld a, [wCurTrackDuty]
 	ld d, a
-	ld a, [rNR21]
+	ldh a, [rNR21]
 	and $3f ; sound length
 	or d
-	ld [rNR21], a
+	ldh [rNR21], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR23], a
+	ldh [rNR23], a
 	ret
 
 .ch2rest
-	ld a, [rNR52]
+	ldh a, [rNR52]
 	and %10001101 ; ch2 off
-	ld [rNR52], a
+	ldh [rNR52], a
 	ld hl, rNR20
 	call ClearChannel
 	ret
@@ -355,14 +355,14 @@ UpdateChannels:
 	ld hl, wCurTrackDuty
 	ld a, $3f ; sound length
 	or [hl]
-	ld [rNR21], a
+	ldh [rNR21], a
 	ld a, [wCurTrackIntensity]
-	ld [rNR22], a
+	ldh [rNR22], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR23], a
+	ldh [rNR23], a
 	ld a, [wCurTrackFrequency + 1]
 	or $80 ; initial (restart)
-	ld [rNR24], a
+	ldh [rNR24], a
 	ret
 
 .Channel3:
@@ -379,37 +379,37 @@ UpdateChannels:
 
 .asm_e822f ; unused
 	ld a, [wCurTrackFrequency]
-	ld [rNR33], a
+	ldh [rNR33], a
 	ld a, [wCurTrackFrequency + 1]
-	ld [rNR34], a
+	ldh [rNR34], a
 	ret
 
 .asm_e823a
 	ld a, [wCurTrackFrequency]
-	ld [rNR33], a
+	ldh [rNR33], a
 	ret
 
 .ch3rest
-	ld a, [rNR52]
+	ldh a, [rNR52]
 	and %10001011 ; ch3 off
-	ld [rNR52], a
+	ldh [rNR52], a
 	ld hl, rNR30
 	call ClearChannel
 	ret
 
 .asm_e824d
 	ld a, $3f ; sound length
-	ld [rNR31], a
+	ldh [rNR31], a
 	xor a
-	ld [rNR30], a
+	ldh [rNR30], a
 	call .asm_e8268
 	ld a, $80
-	ld [rNR30], a
+	ldh [rNR30], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR33], a
+	ldh [rNR33], a
 	ld a, [wCurTrackFrequency + 1]
 	or $80
-	ld [rNR34], a
+	ldh [rNR34], a
 	ret
 
 .asm_e8268
@@ -428,42 +428,42 @@ endr
 	add hl, de
 	; load wavepattern into rWave_0-rWave_f
 	ld a, [hli]
-	ld [rWave_0], a
+	ldh [rWave_0], a
 	ld a, [hli]
-	ld [rWave_1], a
+	ldh [rWave_1], a
 	ld a, [hli]
-	ld [rWave_2], a
+	ldh [rWave_2], a
 	ld a, [hli]
-	ld [rWave_3], a
+	ldh [rWave_3], a
 	ld a, [hli]
-	ld [rWave_4], a
+	ldh [rWave_4], a
 	ld a, [hli]
-	ld [rWave_5], a
+	ldh [rWave_5], a
 	ld a, [hli]
-	ld [rWave_6], a
+	ldh [rWave_6], a
 	ld a, [hli]
-	ld [rWave_7], a
+	ldh [rWave_7], a
 	ld a, [hli]
-	ld [rWave_8], a
+	ldh [rWave_8], a
 	ld a, [hli]
-	ld [rWave_9], a
+	ldh [rWave_9], a
 	ld a, [hli]
-	ld [rWave_a], a
+	ldh [rWave_a], a
 	ld a, [hli]
-	ld [rWave_b], a
+	ldh [rWave_b], a
 	ld a, [hli]
-	ld [rWave_c], a
+	ldh [rWave_c], a
 	ld a, [hli]
-	ld [rWave_d], a
+	ldh [rWave_d], a
 	ld a, [hli]
-	ld [rWave_e], a
+	ldh [rWave_e], a
 	ld a, [hli]
-	ld [rWave_f], a
+	ldh [rWave_f], a
 	pop hl
 	ld a, [wCurTrackIntensity]
 	and $f0
 	sla a
-	ld [rNR32], a
+	ldh [rNR32], a
 	ret
 
 .Channel4:
@@ -478,26 +478,26 @@ endr
 
 .asm_e82c1 ; unused
 	ld a, [wCurTrackFrequency]
-	ld [rNR43], a
+	ldh [rNR43], a
 	ret
 
 .ch4rest
-	ld a, [rNR52]
+	ldh a, [rNR52]
 	and %10000111 ; ch4 off
-	ld [rNR52], a
+	ldh [rNR52], a
 	ld hl, rNR40
 	call ClearChannel
 	ret
 
 .asm_e82d4
 	ld a, $3f ; sound length
-	ld [rNR41], a
+	ldh [rNR41], a
 	ld a, [wCurTrackIntensity]
-	ld [rNR42], a
+	ldh [rNR42], a
 	ld a, [wCurTrackFrequency]
-	ld [rNR43], a
+	ldh [rNR43], a
 	ld a, $80
-	ld [rNR44], a
+	ldh [rNR44], a
 	ret
 
 _CheckSFX:
@@ -551,15 +551,15 @@ PlayDanger:
 
 .applychannel
 	xor a
-	ld [rNR10], a
+	ldh [rNR10], a
 	ld a, [hli]
-	ld [rNR11], a
+	ldh [rNR11], a
 	ld a, [hli]
-	ld [rNR12], a
+	ldh [rNR12], a
 	ld a, [hli]
-	ld [rNR13], a
+	ldh [rNR13], a
 	ld a, [hli]
-	ld [rNR14], a
+	ldh [rNR14], a
 
 .increment
 	ld a, d
@@ -1221,7 +1221,7 @@ ParseMusic:
 	jr nz, .ok
 	; ????
 	xor a
-	ld [rNR10], a ; sweep = 0
+	ldh [rNR10], a ; sweep = 0
 .ok
 ; stop playing
 	; turn channel off
@@ -2476,56 +2476,56 @@ _PlaySFX::
 	jr z, .ch6
 	res SOUND_CHANNEL_ON, [hl] ; turn it off
 	xor a
-	ld [rNR11], a ; length/wavepattern = 0
+	ldh [rNR11], a ; length/wavepattern = 0
 	ld a, $8
-	ld [rNR12], a ; envelope = 0
+	ldh [rNR12], a ; envelope = 0
 	xor a
-	ld [rNR13], a ; frequency lo = 0
+	ldh [rNR13], a ; frequency lo = 0
 	ld a, $80
-	ld [rNR14], a ; restart sound (freq hi = 0)
+	ldh [rNR14], a ; restart sound (freq hi = 0)
 	xor a
 	ld [wSoundInput], a ; global sound off
-	ld [rNR10], a ; sweep = 0
+	ldh [rNR10], a ; sweep = 0
 .ch6
 	ld hl, wChannel6Flags1
 	bit SOUND_CHANNEL_ON, [hl]
 	jr z, .ch7
 	res SOUND_CHANNEL_ON, [hl] ; turn it off
 	xor a
-	ld [rNR21], a ; length/wavepattern = 0
+	ldh [rNR21], a ; length/wavepattern = 0
 	ld a, $8
-	ld [rNR22], a ; envelope = 0
+	ldh [rNR22], a ; envelope = 0
 	xor a
-	ld [rNR23], a ; frequency lo = 0
+	ldh [rNR23], a ; frequency lo = 0
 	ld a, $80
-	ld [rNR24], a ; restart sound (freq hi = 0)
+	ldh [rNR24], a ; restart sound (freq hi = 0)
 .ch7
 	ld hl, wChannel7Flags1
 	bit SOUND_CHANNEL_ON, [hl]
 	jr z, .ch8
 	res SOUND_CHANNEL_ON, [hl] ; turn it off
 	xor a
-	ld [rNR30], a ; sound mode #3 off
-	ld [rNR31], a ; length/wavepattern = 0
+	ldh [rNR30], a ; sound mode #3 off
+	ldh [rNR31], a ; length/wavepattern = 0
 	ld a, $8
-	ld [rNR32], a ; envelope = 0
+	ldh [rNR32], a ; envelope = 0
 	xor a
-	ld [rNR33], a ; frequency lo = 0
+	ldh [rNR33], a ; frequency lo = 0
 	ld a, $80
-	ld [rNR34], a ; restart sound (freq hi = 0)
+	ldh [rNR34], a ; restart sound (freq hi = 0)
 .ch8
 	ld hl, wChannel8Flags1
 	bit SOUND_CHANNEL_ON, [hl]
 	jr z, .chscleared
 	res SOUND_CHANNEL_ON, [hl] ; turn it off
 	xor a
-	ld [rNR41], a ; length/wavepattern = 0
+	ldh [rNR41], a ; length/wavepattern = 0
 	ld a, $8
-	ld [rNR42], a ; envelope = 0
+	ldh [rNR42], a ; envelope = 0
 	xor a
-	ld [rNR43], a ; frequency lo = 0
+	ldh [rNR43], a ; frequency lo = 0
 	ld a, $80
-	ld [rNR44], a ; restart sound (freq hi = 0)
+	ldh [rNR44], a ; restart sound (freq hi = 0)
 	xor a
 	ld [wNoiseSampleAddress], a
 	ld [wNoiseSampleAddress + 1], a

--- a/constants.asm
+++ b/constants.asm
@@ -2,8 +2,6 @@ INCLUDE "charmap.asm"
 
 INCLUDE "macros.asm"
 
-INCLUDE "hram.asm"
-
 INCLUDE "constants/hardware_constants.asm"
 INCLUDE "constants/deco_constants.asm"
 INCLUDE "constants/wram_constants.asm"

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -485,7 +485,7 @@ In [engine/battle/effect_commands.asm](/engine/battle/effect_commands.asm).
 ```asm
 BattleCheckTypeMatchup:
 	ld hl, wEnemyMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, CheckTypeMatchup
 	ld hl, wBattleMonType1
@@ -962,7 +962,7 @@ Then edit [engine/battle/start_battle.asm](/engine/battle/start_battle.asm):
 ```diff
  FindFirstAliveMonAndStartBattle:
  	xor a
- 	ld [hMapAnims], a
+ 	ldh [hMapAnims], a
  	call DelayFrame
 -	ld b, 6
 -	ld hl, wPartyMon1HP
@@ -1520,7 +1520,7 @@ ScriptCall:
  	ld a, 1
  .bank_loop
  	push af
- 	ld [rSVBK], a
+ 	ldh [rSVBK], a
  	xor a
  	ld hl, WRAM1_Begin
  	ld bc, WRAM1_End - WRAM1_Begin

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -520,7 +520,7 @@ AIUpdateHUD:
 	call UpdateEnemyMonInParty
 	farcall UpdateEnemyHUD
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wEnemyItemState
 	dec [hl]
 	scf
@@ -671,7 +671,7 @@ AI_Switch:
 	ld hl, wEnemySubStatus4
 	res SUBSTATUS_RAGE, [hl]
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	callfar PursuitSwitch
 
 	push af
@@ -755,17 +755,17 @@ EnemyUsedDireHit:
 	jp PrintText_UsedItemOn_AND_AIUpdateHUD
 
 Function3851e: ; This appears to be unused
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld hl, wEnemyMonMaxHP
 	ld a, [hli]
-	ld [hDividend], a
+	ldh [hDividend], a
 	ld a, [hl]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld c, a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld b, a
 	ld hl, wEnemyMonHP + 1
 	ld a, [hld]

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -165,7 +165,7 @@ AI_Types:
 	push bc
 	push de
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	callfar BattleCheckTypeMatchup
 	pop de
 	pop bc
@@ -410,7 +410,7 @@ AI_Smart_Sleep:
 AI_Smart_LeechHit:
 	push hl
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	callfar BattleCheckTypeMatchup
 	pop hl
 
@@ -486,7 +486,7 @@ AI_Smart_LockOn:
 	jr nc, .asm_3884f
 
 	ld a, $1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 
 	push hl
 	push bc
@@ -1289,7 +1289,7 @@ AI_Smart_Mimic:
 	call AIGetEnemyMove
 
 	ld a, $1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	callfar BattleCheckTypeMatchup
 
 	ld a, [wTypeMatchup]
@@ -1631,7 +1631,7 @@ AI_Smart_PriorityHit:
 
 ; Greatly encourage this move if it will KO the player.
 	ld a, $1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	push hl
 	callfar EnemyAttackDamage
 	callfar BattleCommand_DamageCalc
@@ -1675,7 +1675,7 @@ AI_Smart_Conversion2:
 	ld [wPlayerMoveStruct + MOVE_TYPE], a
 
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 
 	callfar BattleCheckTypeMatchup
 
@@ -2285,7 +2285,7 @@ AI_Smart_RapidSpin:
 AI_Smart_HiddenPower:
 	push hl
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 
 ; Calculate Hidden Power's type and base power based on enemy's DVs.
 	callfar HiddenPowerDamage
@@ -3013,7 +3013,7 @@ INCLUDE "data/battle/ai/reckless_moves.asm"
 
 AIDamageCalc:
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld a, [wEnemyMoveStruct + MOVE_EFFECT]
 	ld de, 1
 	ld hl, ConstantDamageEffects
@@ -3119,7 +3119,7 @@ AI_Status:
 	push bc
 	push de
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	callfar BattleCheckTypeMatchup
 	pop de
 	pop bc

--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -277,7 +277,7 @@ HPBarAnim_UpdateHPRemaining:
 	ret
 
 HPBarAnim_PaletteUpdate:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 	ld hl, wCurHPAnimPal
@@ -288,7 +288,7 @@ HPBarAnim_PaletteUpdate:
 	ret
 
 HPBarAnim_BGMapUpdate:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	call DelayFrame
@@ -316,15 +316,15 @@ HPBarAnim_BGMapUpdate:
 	cp $5
 	jr z, .skip_delay
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, c
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call DelayFrame
 .skip_delay
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, c
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call DelayFrame
 	pop af
 	cp $2
@@ -336,14 +336,14 @@ HPBarAnim_BGMapUpdate:
 .two_frames
 	inc c
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, c
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call DelayFrame
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, c
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call DelayFrame
 	ret
 
@@ -356,7 +356,7 @@ HPBarAnim_BGMapUpdate:
 .finish
 	call DelayFrame
 	ld a, c
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call DelayFrame
 	ret
 

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -315,7 +315,7 @@ StartTrainerBattle_SetUpForWavyOutro:
 
 	call StartTrainerBattle_NextScene
 
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	xor a
 	ldh [hLYOverrideStart], a

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -10,11 +10,11 @@ BATTLETRANSITION_SQUARE EQUS "\"8\"" ; $fe
 
 DoBattleTransition:
 	call .InitGFX
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld [wBGP], a
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld [wOBP0], a
-	ld a, [rOBP1]
+	ldh a, [rOBP1]
 	ld [wOBP1], a
 	call DelayFrame
 	ld hl, hVBlank
@@ -31,10 +31,10 @@ DoBattleTransition:
 	jr .loop
 
 .done
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBGPals1
 	ld bc, 8 palettes
@@ -42,22 +42,22 @@ DoBattleTransition:
 	call ByteFill
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, %11111111
 	ld [wBGP], a
 	call DmgToCgbBGPals
 	call DelayFrame
 	xor a
-	ld [hLCDCPointer], a
-	ld [hLYOverrideStart], a
-	ld [hLYOverrideEnd], a
-	ld [hSCY], a
+	ldh [hLCDCPointer], a
+	ldh [hLYOverrideStart], a
+	ldh [hLYOverrideEnd], a
+	ldh [hSCY], a
 
 	ld a, 1 ; unnecessary bankswitch?
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call DelayFrame
 	ret
 
@@ -77,10 +77,10 @@ DoBattleTransition:
 
 .resume
 	ld a, SCREEN_HEIGHT_PX
-	ld [hWY], a
+	ldh [hWY], a
 	call DelayFrame
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wJumptableIndex
 	xor a
 	ld [hli], a
@@ -104,10 +104,10 @@ LoadTrainerBattlePokeballTiles:
 	ld c, 2
 	call Request2bpp
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld de, TrainerBattlePokeballTiles
 	ld hl, vTiles3 tile BATTLETRANSITION_SQUARE
@@ -116,14 +116,14 @@ LoadTrainerBattlePokeballTiles:
 	call Request2bpp
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 ConvertTrainerBattlePokeballTilesTo2bpp:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push hl
 	ld hl, wDecompressScratch
 	ld bc, $28 tiles
@@ -142,7 +142,7 @@ ConvertTrainerBattlePokeballTilesTo2bpp:
 	ld c, $28
 	call Request2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 TrainerBattlePokeballTiles:
@@ -258,7 +258,7 @@ StartTrainerBattle_SetUpBGMap:
 	call StartTrainerBattle_NextScene
 	xor a
 	ld [wcf64], a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 StartTrainerBattle_Flash:
@@ -311,16 +311,16 @@ StartTrainerBattle_Flash:
 StartTrainerBattle_SetUpForWavyOutro:
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call StartTrainerBattle_NextScene
 
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $90
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	xor a
 	ld [wcf64], a
 	ld [wcf65], a
@@ -369,7 +369,7 @@ StartTrainerBattle_SineWave:
 StartTrainerBattle_SetUpForSpinOutro:
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call StartTrainerBattle_NextScene
 	xor a
 	ld [wcf64], a
@@ -377,7 +377,7 @@ StartTrainerBattle_SetUpForSpinOutro:
 
 StartTrainerBattle_SpinToBlack:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wcf64]
 	ld e, a
 	ld d, 0
@@ -391,7 +391,7 @@ endr
 	ld [wcf65], a
 	call .load
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ld hl, wcf64
@@ -400,12 +400,12 @@ endr
 
 .end
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, BATTLETRANSITION_FINISH
 	ld [wJumptableIndex], a
 	ret
@@ -511,12 +511,12 @@ ENDM
 StartTrainerBattle_SetUpForRandomScatterOutro:
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call StartTrainerBattle_NextScene
 	ld a, $10
 	ld [wcf64], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 StartTrainerBattle_SpeckleToBlack:
@@ -536,12 +536,12 @@ StartTrainerBattle_SpeckleToBlack:
 
 .done
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, BATTLETRANSITION_FINISH
 	ld [wJumptableIndex], a
 	ret
@@ -583,7 +583,7 @@ StartTrainerBattle_LoadPokeBallGraphics:
 	jp z, .nextscene ; don't need to be here if wild
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0, wAttrMap
 	ld bc, SCREEN_HEIGHT * SCREEN_WIDTH
 	inc b
@@ -640,11 +640,11 @@ StartTrainerBattle_LoadPokeBallGraphics:
 	dec b
 	jr nz, .loop2
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	jr .nextscene
@@ -657,10 +657,10 @@ StartTrainerBattle_LoadPokeBallGraphics:
 	jr nz, .daytime
 	ld hl, .nightpals
 .daytime
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call .copypals
 	push hl
 	ld de, wBGPals1 palette PAL_BG_TEXT
@@ -671,9 +671,9 @@ StartTrainerBattle_LoadPokeBallGraphics:
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	call DelayFrame
 	call BattleStart_CopyTilemapAtOnce
 
@@ -731,10 +731,10 @@ PokeBallTransition:
 	db %00000011, %11000000
 
 WipeLYOverrides:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wLYOverrides
 	call .wipe
@@ -742,7 +742,7 @@ WipeLYOverrides:
 	call .wipe
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .wipe
@@ -777,7 +777,7 @@ StartTrainerBattle_ZoomToBlack:
 	inc de
 	ld h, a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .Copy
 	call WaitBGMap
 	jr .loop
@@ -823,8 +823,8 @@ ENDM
 
 Unreferenced_Function8c7c9:
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret

--- a/engine/battle/consume_held_item.asm
+++ b/engine/battle/consume_held_item.asm
@@ -2,7 +2,7 @@ ConsumeHeldItem:
 	push hl
 	push de
 	push bc
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wOTPartyMon1Item
 	ld de, wEnemyMonItem
@@ -38,7 +38,7 @@ ConsumeHeldItem:
 	pop af
 	pop hl
 	call GetPartyLocation
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .ourturn
 	ld a, [wBattleMode]

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -26,7 +26,7 @@ DoBattle:
 	and a
 	jr z, .not_linked
 
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .player_2
 
@@ -97,7 +97,7 @@ DoBattle:
 	ld a, [wLinkMode]
 	and a
 	jr z, .not_linked_2
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr nz, .not_linked_2
 	xor a
@@ -247,7 +247,7 @@ Stubbed_Function3c1bf:
 	ret
 
 HandleBetweenTurnEffects:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .CheckEnemyFirst
 	call CheckFaint_PlayerThenEnemy
@@ -343,7 +343,7 @@ CheckFaint_EnemyThenPlayer:
 	ret
 
 HandleBerserkGene:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .reverse
 
@@ -449,7 +449,7 @@ DetermineMoveOrder:
 	ld a, [wBattlePlayerAction]
 	cp BATTLEPLAYERACTION_SWITCH
 	jr nz, .switch
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .player_2
 
@@ -506,7 +506,7 @@ DetermineMoveOrder:
 	jp .enemy_first
 
 .both_have_quick_claw
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .player_2b
 	call BattleRandom
@@ -536,7 +536,7 @@ DetermineMoveOrder:
 	jp .enemy_first
 
 .speed_tie
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .player_2c
 	call BattleRandom
@@ -633,7 +633,7 @@ ParsePlayerAction:
 
 .struggle
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop af
 	ret nz
 
@@ -695,7 +695,7 @@ ParsePlayerAction:
 	ret
 
 HandleEncore:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_1
 	call .do_player
@@ -982,7 +982,7 @@ EndUserDestinyBond:
 	ret
 
 HasUserFainted:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, HasPlayerFainted
 HasEnemyFainted:
@@ -1027,7 +1027,7 @@ ResidualDamage:
 	call Call_PlayBattleAnim_OnlyIfVisible
 	call GetEighthMaxHP
 	ld de, wPlayerToxicCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .check_toxic
 	ld de, wEnemyToxicCount
@@ -1074,7 +1074,7 @@ ResidualDamage:
 	call GetEighthMaxHP
 	call SubtractHPFromUser
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call RestoreHP
 	ld hl, LeechSeedSapsText
 	call StdBattleTextBox
@@ -1116,7 +1116,7 @@ ResidualDamage:
 
 .not_cursed
 	ld hl, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .check_fainted
 	ld hl, wEnemyMonHP
@@ -1134,7 +1134,7 @@ ResidualDamage:
 	ret
 
 HandlePerishSong:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .EnemyFirst
 	call SetPlayerTurn
@@ -1149,7 +1149,7 @@ HandlePerishSong:
 
 .do_it
 	ld hl, wPlayerPerishCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_count
 	ld hl, wEnemyPerishCount
@@ -1170,7 +1170,7 @@ HandlePerishSong:
 	ld a, BATTLE_VARS_SUBSTATUS1
 	call GetBattleVarAddr
 	res SUBSTATUS_PERISH, [hl]
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .kill_enemy
 	ld hl, wBattleMonHP
@@ -1202,7 +1202,7 @@ HandlePerishSong:
 	ret
 
 HandleWrap:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .EnemyFirst
 	call SetPlayerTurn
@@ -1218,7 +1218,7 @@ HandleWrap:
 .do_it
 	ld hl, wPlayerWrapCount
 	ld de, wPlayerTrappingMove
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_addrs
 	ld hl, wEnemyWrapCount
@@ -1266,13 +1266,13 @@ HandleWrap:
 	jp StdBattleTextBox
 
 SwitchTurnCore:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	xor 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 HandleLeftovers:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .DoEnemyFirst
 	call SetPlayerTurn
@@ -1295,7 +1295,7 @@ HandleLeftovers:
 	ret nz
 
 	ld hl, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wEnemyMonHP
@@ -1321,7 +1321,7 @@ HandleLeftovers:
 	jp StdBattleTextBox
 
 HandleMysteryberry:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .DoEnemyFirst
 	call SetPlayerTurn
@@ -1347,7 +1347,7 @@ HandleMysteryberry:
 	ld hl, wPartyMon1Moves
 	ld a, [wCurBattleMon]
 	call GetPartyLocation
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .wild
 	ld de, wWildMonPP
@@ -1400,7 +1400,7 @@ HandleMysteryberry:
 	ld [wTempByteValue], a
 	ld de, wBattleMonMoves - 1
 	ld hl, wBattleMonPP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player_pp
 	ld de, wEnemyMonMoves - 1
@@ -1420,7 +1420,7 @@ HandleMysteryberry:
 	ld a, [wTempByteValue]
 	cp [hl]
 	jr nz, .skip_checks
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wPlayerSubStatus5]
 	jr z, .check_transform
@@ -1438,7 +1438,7 @@ HandleMysteryberry:
 	xor a
 	ld [hl], a
 	call GetPartymonItem
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .consume_item
 	ld a, [wBattleMode]
@@ -1459,7 +1459,7 @@ HandleMysteryberry:
 	jp StdBattleTextBox
 
 HandleFutureSight:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .enemy_first
 	call SetPlayerTurn
@@ -1474,7 +1474,7 @@ HandleFutureSight:
 
 .do_it
 	ld hl, wPlayerFutureSightCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .okay
 	ld hl, wEnemyFutureSightCount
@@ -1517,7 +1517,7 @@ HandleFutureSight:
 	jp UpdateEnemyMonInParty
 
 HandleDefrost:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .enemy_first
 	call .do_player_turn
@@ -1576,7 +1576,7 @@ HandleDefrost:
 	jp StdBattleTextBox
 
 HandleSafeguard:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player1
 	call .CheckPlayer
@@ -1608,12 +1608,12 @@ HandleSafeguard:
 	ld a, $1
 
 .print
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld hl, BattleText_SafeguardFaded
 	jp StdBattleTextBox
 
 HandleScreens:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .Both
 	call .CheckPlayer
@@ -1693,7 +1693,7 @@ HandleWeather:
 	cp WEATHER_SANDSTORM
 	ret nz
 
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .enemy_first
 
@@ -1715,7 +1715,7 @@ HandleWeather:
 	ret nz
 
 	ld hl, wBattleMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonType1
@@ -1790,7 +1790,7 @@ SubtractHPFromUser:
 
 SubtractHP:
 	ld hl, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonHP
@@ -1885,7 +1885,7 @@ GetMaxHP:
 ; output: bc, wBuffer1-2
 
 	ld hl, wBattleMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonMaxHP
@@ -1901,7 +1901,7 @@ GetMaxHP:
 
 Unreferenced_GetHalfHP:
 	ld hl, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonHP
@@ -1920,7 +1920,7 @@ Unreferenced_GetHalfHP:
 
 CheckUserHasEnoughHP:
 	ld hl, wBattleMonHP + 1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonHP + 1
@@ -1934,7 +1934,7 @@ CheckUserHasEnoughHP:
 
 RestoreHP
 	ld hl, wEnemyMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wBattleMonMaxHP
@@ -1982,7 +1982,7 @@ UpdateHPBarBattleHuds:
 
 UpdateHPBar:
 	hlcoord 10, 9
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, 1
 	jr z, .ok
@@ -2015,7 +2015,7 @@ HandleEnemyMonFaint:
 	call nz, UpdatePlayerHUD
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 60
 	call DelayFrames
 
@@ -2064,7 +2064,7 @@ HandleEnemyMonFaint:
 	ret
 
 DoubleSwitch:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_1
 	call ClearSprites
@@ -3059,7 +3059,7 @@ MonFaintedAnimation:
 	db "       @"
 
 SlideBattlePicOut:
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld c, a
 .loop
 	push bc
@@ -3082,7 +3082,7 @@ SlideBattlePicOut:
 	ret
 
 .DoFrame:
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld c, a
 	cp $8
 	jr nz, .back
@@ -3517,7 +3517,7 @@ OfferSwitch:
 
 ClearEnemyMonBox:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ExitMenu
 	call ClearSprites
 	hlcoord 1, 0
@@ -3577,7 +3577,7 @@ Function_SetEnemyMonAndSendOutAnimation:
 .skip_cry
 	call UpdateEnemyHUD
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 NewEnemyMonStatus:
@@ -3715,14 +3715,14 @@ TryToRunAwayFromBattle:
 	inc a
 	ld [wNumFleeAttempts], a
 	ld a, [hli]
-	ld [hPartyMon1Speed + 0], a
+	ldh [hPartyMon1Speed + 0], a
 	ld a, [hl]
-	ld [hPartyMon1Speed + 1], a
+	ldh [hPartyMon1Speed + 1], a
 	ld a, [de]
 	inc de
-	ld [hEnemyMonSpeed + 0], a
+	ldh [hEnemyMonSpeed + 0], a
 	ld a, [de]
-	ld [hEnemyMonSpeed + 1], a
+	ldh [hEnemyMonSpeed + 1], a
 	call Call_LoadTempTileMapToTileMap
 	ld de, hPartyMon1Speed
 	ld hl, hEnemyMonSpeed
@@ -3731,27 +3731,27 @@ TryToRunAwayFromBattle:
 	jr nc, .can_escape
 
 	xor a
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 	ld a, 32
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
-	ld a, [hProduct + 2]
-	ld [hDividend + 0], a
-	ld a, [hProduct + 3]
-	ld [hDividend + 1], a
-	ld a, [hEnemyMonSpeed + 0]
+	ldh a, [hProduct + 2]
+	ldh [hDividend + 0], a
+	ldh a, [hProduct + 3]
+	ldh [hDividend + 1], a
+	ldh a, [hEnemyMonSpeed + 0]
 	ld b, a
-	ld a, [hEnemyMonSpeed + 1]
+	ldh a, [hEnemyMonSpeed + 1]
 	srl b
 	rr a
 	srl b
 	rr a
 	and a
 	jr z, .can_escape
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	and a
 	jr nz, .can_escape
 	ld a, [wNumFleeAttempts]
@@ -3760,16 +3760,16 @@ TryToRunAwayFromBattle:
 	dec c
 	jr z, .cant_escape_2
 	ld b, 30
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add b
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 	jr c, .can_escape
 	jr .loop
 
 .cant_escape_2
 	call BattleRandom
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	cp b
 	jr nc, .can_escape
 	ld a, BATTLEPLAYERACTION_USEITEM
@@ -4013,10 +4013,10 @@ SendOutPlayerMon:
 	call ClearBox
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call GetBattleMonBackpic
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	ld [wBattleMenuCursorBuffer], a
 	ld [wCurMoveNum], a
 	ld [wTypeModifier], a
@@ -4056,7 +4056,7 @@ SendOutPlayerMon:
 .statused
 	call UpdatePlayerHUD
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 NewBattleMonStatus:
@@ -4098,7 +4098,7 @@ SpikesDamage:
 	ld hl, wPlayerScreens
 	ld de, wBattleMonType
 	ld bc, UpdatePlayerHUD
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyScreens
@@ -4147,7 +4147,7 @@ PursuitSwitch:
 	push af
 
 	ld hl, DoPlayerTurn
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .do_turn
 	ld hl, DoEnemyTurn
@@ -4165,7 +4165,7 @@ PursuitSwitch:
 	pop af
 	ld [wCurBattleMon], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .check_enemy_fainted
 
@@ -4214,19 +4214,19 @@ PursuitSwitch:
 	ret
 
 RecallPlayerMon:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	push af
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld [wNumHits], a
 	ld de, ANIM_RETURN_MON
 	call Call_PlayBattleAnim
 	pop af
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 HandleHealingItems:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_1
 	call SetPlayerTurn
@@ -4255,7 +4255,7 @@ HandleHPHealingItem:
 	ret nz
 	ld de, wEnemyMonHP + 1
 	ld hl, wEnemyMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go
 	ld de, wBattleMonHP + 1
@@ -4321,7 +4321,7 @@ HandleHPHealingItem:
 	inc de
 	ld a, [wBuffer5]
 	ld [de], a
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	ld [wWhichHPBar], a
 	and a
 	hlcoord 2, 2
@@ -4397,7 +4397,7 @@ UseHeldStatusHealingItem:
 
 .skip_confuse
 	ld hl, CalcEnemyStats
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_pointer
 	ld hl, CalcPlayerStats
@@ -4437,7 +4437,7 @@ UseConfusionHealingItem:
 	call ItemRecoveryAnim
 	ld hl, BattleText_ItemHealedConfusion
 	call StdBattleTextBox
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .do_partymon
 	call GetOTPartymonItem
@@ -4458,7 +4458,7 @@ UseConfusionHealingItem:
 
 HandleStatBoostingHeldItems:
 ; The effects handled here are not used in-game.
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_1
 	call .DoPlayer
@@ -4477,7 +4477,7 @@ HandleStatBoostingHeldItems:
 	call GetOTPartymonItem
 	ld a, $1
 .HandleItem:
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld d, h
 	ld e, l
 	push de
@@ -4570,7 +4570,7 @@ UpdatePlayerHUD::
 
 DrawPlayerHUD:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	; Clear the area
 	hlcoord 9, 7
@@ -4708,7 +4708,7 @@ UpdateEnemyHUD::
 
 DrawEnemyHUD:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	hlcoord 1, 0
 	lb bc, 4, 11
@@ -4774,9 +4774,9 @@ DrawEnemyHUD:
 
 	ld hl, wEnemyMonHP
 	ld a, [hli]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hld]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	or [hl]
 	jr nz, .not_fainted
 
@@ -4787,44 +4787,44 @@ DrawEnemyHUD:
 
 .not_fainted
 	xor a
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 	ld a, HP_BAR_LENGTH_PX
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld hl, wEnemyMonMaxHP
 	ld a, [hli]
 	ld b, a
 	ld a, [hl]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	ld a, b
 	and a
 	jr z, .less_than_256_max
-	ld a, [hMultiplier]
+	ldh a, [hMultiplier]
 	srl b
 	rr a
 	srl b
 	rr a
-	ld [hDivisor], a
-	ld a, [hProduct + 2]
+	ldh [hDivisor], a
+	ldh a, [hProduct + 2]
 	ld b, a
 	srl b
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	rr a
 	srl b
 	rr a
-	ld [hProduct + 3], a
+	ldh [hProduct + 3], a
 	ld a, b
-	ld [hProduct + 2], a
+	ldh [hProduct + 2], a
 
 .less_than_256_max
-	ld a, [hProduct + 2]
-	ld [hDividend + 0], a
-	ld a, [hProduct + 3]
-	ld [hDividend + 1], a
+	ldh a, [hProduct + 2]
+	ldh [hDividend + 0], a
+	ldh a, [hProduct + 3]
+	ldh [hDividend + 1], a
 	ld a, 2
 	ld b, a
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld e, a
 	ld a, HP_BAR_LENGTH
 	ld d, a
@@ -4856,7 +4856,7 @@ ret_3e138:
 
 BattleMenu:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadTempTileMapToTileMap
 
 	ld a, [wBattleType]
@@ -4889,7 +4889,7 @@ BattleMenu:
 
 .next
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wBattleMenuCursorBuffer]
 	cp $1
 	jp z, BattleMenu_Fight
@@ -5001,7 +5001,7 @@ BattleMenu_Pack:
 
 .ball
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call _LoadBattleFontsHPBar
 	call ClearSprites
 	ld a, [wBattleType]
@@ -5203,7 +5203,7 @@ PlayerSwitch:
 	ret
 
 .dont_run
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_1
 	call BattleMonEntrance
@@ -5332,7 +5332,7 @@ MoveSelectionScreen:
 	ld bc, NUM_MOVES
 	call CopyBytes
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	hlcoord 4, 17 - NUM_MOVES - 1
 	ld b, 4
@@ -5429,7 +5429,7 @@ MoveSelectionScreen:
 
 .interpret_joypad
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ScrollingMenuJoypad
 	bit D_UP_F, a
 	jp nz, .pressed_up
@@ -5618,7 +5618,7 @@ MoveSelectionScreen:
 
 MoveInfoBox:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	hlcoord 0, 8
 	ld b, 3
@@ -6513,8 +6513,8 @@ BattleWinSlideInEnemyTrainerFrontpic:
 	cp 7
 	ret z
 	xor a
-	ld [hBGMapMode], a
-	ld [hBGMapThird], a
+	ldh [hBGMapMode], a
+	ldh [hBGMapThird], a
 	ld d, $0
 	push bc
 	push hl
@@ -6529,7 +6529,7 @@ BattleWinSlideInEnemyTrainerFrontpic:
 	jr nz, .inner_loop
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 	pop hl
@@ -6564,12 +6564,12 @@ ApplyStatusEffectOnEnemyStats:
 	xor a
 
 ApplyStatusEffectOnStats:
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	call ApplyPrzEffectOnSpeed
 	jp ApplyBrnEffectOnAttack
 
 ApplyPrzEffectOnSpeed:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .enemy
 	ld a, [wBattleMonStatus]
@@ -6614,7 +6614,7 @@ ApplyPrzEffectOnSpeed:
 	ret
 
 ApplyBrnEffectOnAttack:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .enemy
 	ld a, [wBattleMonStatus]
@@ -6707,38 +6707,38 @@ ApplyStatLevelMultiplier:
 	ld b, 0
 	add hl, bc
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld a, [de]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	inc de
 	ld a, [de]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [hli]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, [hl]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 	pop hl
 
 ; Cap at 999.
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	sub LOW(MAX_STAT_VALUE)
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	sbc HIGH(MAX_STAT_VALUE)
 	jp c, .okay3
 
 	ld a, HIGH(MAX_STAT_VALUE)
-	ld [hQuotient + 1], a
+	ldh [hQuotient + 1], a
 	ld a, LOW(MAX_STAT_VALUE)
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 
 .okay3
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [hli], a
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [hl], a
 	or b
 	jr nz, .okay4
@@ -7054,15 +7054,15 @@ GiveExperiencePoints:
 	dec c
 	jr nz, .loop1
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [wEnemyMonBaseExp]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [wEnemyMonLevel]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, 7
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 ; Boost Experience for traded Pokemon
@@ -7095,9 +7095,9 @@ GiveExperiencePoints:
 	ld a, [hl]
 	cp LUCKY_EGG
 	call z, BoostExp
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [wStringBuffer2 + 1], a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [wStringBuffer2], a
 	ld a, [wCurPartyMon]
 	ld hl, wPartyMonNicknames
@@ -7105,9 +7105,9 @@ GiveExperiencePoints:
 	ld hl, Text_MonGainedExpPoint
 	call BattleTextBox
 	ld a, [wStringBuffer2 + 1]
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 	ld a, [wStringBuffer2]
-	ld [hQuotient + 1], a
+	ldh [hQuotient + 1], a
 	pop bc
 	call AnimateExpBar
 	push bc
@@ -7116,11 +7116,11 @@ GiveExperiencePoints:
 	ld hl, MON_EXP + 2
 	add hl, bc
 	ld d, [hl]
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add d
 	ld [hld], a
 	ld d, [hl]
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	adc d
 	ld [hl], a
 	jr nc, .skip2
@@ -7148,11 +7148,11 @@ GiveExperiencePoints:
 	ld hl, MON_EXP + 2
 	add hl, bc
 	push bc
-	ld a, [hQuotient]
+	ldh a, [hQuotient]
 	ld b, a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld c, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld d, a
 	ld a, [hld]
 	sub d
@@ -7265,7 +7265,7 @@ GiveExperiencePoints:
 	call EmptyBattleTextBox
 	call LoadTileMapToTempTileMap
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 .skip_animation
 	farcall LevelUpHappinessMod
@@ -7364,14 +7364,14 @@ GiveExperiencePoints:
 	ld c, wEnemyMonEnd - wEnemyMonBaseStats
 .count_loop2
 	xor a
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, [hl]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, [wTempByteValue]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [hli], a
 	dec c
 	jr nz, .count_loop2
@@ -7381,19 +7381,19 @@ BoostExp:
 ; Multiply experience by 1.5x
 	push bc
 ; load experience value
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld b, a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld c, a
 ; halve it
 	srl b
 	rr c
 ; add it back to the whole exp value
 	add c
-	ld [hProduct + 3], a
-	ld a, [hProduct + 2]
+	ldh [hProduct + 3], a
+	ldh a, [hProduct + 2]
 	adc b
-	ld [hProduct + 2], a
+	ldh [hProduct + 2], a
 	pop bc
 	ret
 
@@ -7428,10 +7428,10 @@ AnimateExpBar:
 	cp MAX_LEVEL
 	jp nc, .finish
 
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [wd004], a
 	push af
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [wd003], a
 	push af
 	xor a
@@ -7464,11 +7464,11 @@ AnimateExpBar:
 .NoOverflow:
 	ld d, MAX_LEVEL
 	callfar CalcExpAtLevel
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld b, a
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld c, a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld d, a
 	ld hl, wTempMonExp + 2
 	ld a, [hld]
@@ -7539,9 +7539,9 @@ AnimateExpBar:
 	call .LoopBarAnimation
 	call TerminateExpBarSound
 	pop af
-	ld [hProduct + 2], a
+	ldh [hProduct + 2], a
 	pop af
-	ld [hProduct + 3], a
+	ldh [hProduct + 3], a
 
 .finish
 	pop bc
@@ -7568,11 +7568,11 @@ AnimateExpBar:
 	call PlaceExpBar
 	pop de
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, d
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop bc
 	ld a, c
 	cp b
@@ -7584,11 +7584,11 @@ AnimateExpBar:
 	call PlaceExpBar
 	pop de
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, d
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	dec d
 	jr nz, .min_number_of_frames
 	ld d, 1
@@ -7599,7 +7599,7 @@ AnimateExpBar:
 	jr nz, .anim_loop
 .end_animation
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 SendOutMonText:
@@ -7623,16 +7623,16 @@ SendOutMonText:
 
 	; compute enemy helth remaining as a percentage
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld hl, wEnemyMonHP
 	ld a, [hli]
 	ld [wEnemyHPAtTimeOfPlayerSwitch], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
 	ld [wEnemyHPAtTimeOfPlayerSwitch + 1], a
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, 25
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld hl, wEnemyMonMaxHP
 	ld a, [hli]
@@ -7643,10 +7643,10 @@ SendOutMonText:
 	rr b
 	ld a, b
 	ld b, 4
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	call Divide
 
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld hl, JumpText_GoMon
 	cp 70
 	jr nc, .skip_to_textbox
@@ -7706,14 +7706,14 @@ WithdrawMonText:
 	dec hl
 	ld a, [de]
 	sub b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	dec de
 	ld b, [hl]
 	ld a, [de]
 	sbc b
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, 25
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld hl, wEnemyMonMaxHP
 	ld a, [hli]
@@ -7724,11 +7724,11 @@ WithdrawMonText:
 	rr b
 	ld a, b
 	ld b, 4
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	call Divide
 	pop bc
 	pop de
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld hl, TextJump_ThatsEnoughComeBack
 	and a
 	ret z
@@ -7826,17 +7826,17 @@ CalcExpBar:
 ; back up the next level exp, and subtract the two levels
 	ld hl, hMultiplicand + 2
 	ld a, [hl]
-	ld [hMathBuffer + 2], a
+	ldh [hMathBuffer + 2], a
 	pop bc
 	sub b
 	ld [hld], a
 	ld a, [hl]
-	ld [hMathBuffer + 1], a
+	ldh [hMathBuffer + 1], a
 	pop bc
 	sbc b
 	ld [hld], a
 	ld a, [hl]
-	ld [hMathBuffer], a
+	ldh [hMathBuffer], a
 	pop bc
 	sbc b
 	ld [hl], a
@@ -7852,25 +7852,25 @@ CalcExpBar:
 	ld a, [de]
 	dec de
 	ld c, a
-	ld a, [hMathBuffer + 2]
+	ldh a, [hMathBuffer + 2]
 	sub c
 	ld [hld], a
 	ld a, [de]
 	dec de
 	ld b, a
-	ld a, [hMathBuffer + 1]
+	ldh a, [hMathBuffer + 1]
 	sbc b
 	ld [hld], a
 	ld a, [de]
 	ld c, a
-	ld a, [hMathBuffer]
+	ldh a, [hMathBuffer]
 	sbc c
 	ld [hld], a
 	xor a
 	ld [hl], a
 ; multiply by 64
 	ld a, $40
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	pop af
 	ld c, a
@@ -7894,10 +7894,10 @@ CalcExpBar:
 
 .done
 	ld a, c
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld b, a
 	ld a, $40
 	sub b
@@ -7959,14 +7959,14 @@ DropPlayerSub:
 	ret
 
 GetBattleMonBackpic_DoAnim:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	push af
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld a, BANK(BattleAnimCommands)
 	rst FarCall
 	pop af
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 GetEnemyMonFrontpic:
@@ -7996,13 +7996,13 @@ DropEnemySub:
 	ret
 
 GetEnemyMonFrontpic_DoAnim:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	push af
 	call SetEnemyTurn
 	ld a, BANK(BattleAnimCommands)
 	rst FarCall
 	pop af
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 StartBattle:
@@ -8034,7 +8034,7 @@ BattleIntro:
 	ld [wTempBattleMonSpecies], a
 	ld [wBattleMenuCursorBuffer], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	farcall PlayBattleMusic
 	farcall ShowLinkBattleParticipants
 	farcall FindFirstAliveMonAndStartBattle
@@ -8051,7 +8051,7 @@ BattleIntro:
 	ld hl, rLCDC
 	set rLCDC_WINDOW_TILEMAP, [hl] ; select 9C00-9FFF
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EmptyBattleTextBox
 	hlcoord 9, 7
 	lb bc, 5, 11
@@ -8064,7 +8064,7 @@ BattleIntro:
 	cp WILD_BATTLE
 	call z, UpdateEnemyHUD
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 LoadTrainerOrWildMonPic:
@@ -8085,26 +8085,26 @@ InitEnemy:
 	jp InitEnemyWildmon ; wild
 
 BackUpBGMap2:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wDecompressScratch
 	ld bc, $40 tiles ; vBGMap3 - vBGMap2
 	ld a, $2
 	call ByteFill
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld de, wDecompressScratch
 	hlbgcoord 0, 0 ; vBGMap2
 	lb bc, BANK(BackUpBGMap2), $40
 	call Request2bpp
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 InitEnemyTrainer:
@@ -8126,7 +8126,7 @@ InitEnemyTrainer:
 	ld de, vTiles2
 	callfar GetTrainerPic
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	dec a
 	ld [wEnemyItemState], a
 	hlcoord 12, 0
@@ -8190,7 +8190,7 @@ InitEnemyWildmon:
 	predef GetAnimatedFrontpic
 	xor a
 	ld [wTrainerClass], a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 12, 0
 	lb bc, 7, 7
 	predef PlaceGraphic
@@ -8906,41 +8906,41 @@ InitBattleDisplay:
 	call _LoadBattleFontsHPBar
 	call .BlankBGMap
 	xor a
-	ld [hMapAnims], a
-	ld [hSCY], a
+	ldh [hMapAnims], a
+	ldh [hSCY], a
 	ld a, $90
-	ld [hWY], a
-	ld [rWY], a
+	ldh [hWY], a
+	ldh [rWY], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall BattleIntroSlidingPics
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 2, 6
 	lb bc, 6, 6
 	predef PlaceGraphic
 	xor a
-	ld [hWY], a
-	ld [rWY], a
+	ldh [hWY], a
+	ldh [rWY], a
 	call WaitBGMap
 	call HideSprites
 	ld b, SCGB_BATTLE_COLORS
 	call GetSGBLayout
 	call SetPalettes
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 .BlankBGMap:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wDecompressScratch
 	ld bc, wScratchAttrMap - wDecompressScratch
@@ -8953,7 +8953,7 @@ InitBattleDisplay:
 	call Request2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .InitBackPic:
@@ -8995,21 +8995,21 @@ GetTrainerBackpic:
 	ret
 
 CopyBackpic:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, vTiles0
 	ld de, vTiles2 tile $31
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	ld c, $31
 	call Get2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call .LoadTrainerBackpicAsOAM
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 2, 6
 	lb bc, 6, 6
 	predef PlaceGraphic
@@ -9018,7 +9018,7 @@ CopyBackpic:
 .LoadTrainerBackpicAsOAM:
 	ld hl, wVirtualOAMSprite00
 	xor a
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld b, 6
 	ld e, (SCREEN_WIDTH + 1) * TILE_WIDTH
 .outer_loop
@@ -9029,10 +9029,10 @@ CopyBackpic:
 	inc hl
 	ld [hl], e ; x
 	inc hl
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld [hli], a ; tile id
 	inc a
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, PAL_BATTLE_OB_PLAYER
 	ld [hli], a ; attributes
 	ld a, d
@@ -9040,9 +9040,9 @@ CopyBackpic:
 	ld d, a
 	dec c
 	jr nz, .inner_loop
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	add $3
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, e
 	add 1 * TILE_WIDTH
 	ld e, a
@@ -9074,7 +9074,7 @@ BattleStartMessage:
 	xor a
 	ld [wNumHits], a
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld a, 1
 	ld [wBattleAnimParam], a
 	ld de, ANIM_SEND_OUT_MON

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -130,7 +130,7 @@ BattleCommand_CheckTurn:
 	ld a, EFFECTIVE
 	ld [wTypeModifier], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, CheckEnemyTurn
 
@@ -171,7 +171,7 @@ CheckPlayerTurn:
 	ld hl, UpdatePlayerHUD
 	call CallBattleCore
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wPlayerSubStatus1
 	res SUBSTATUS_NIGHTMARE, [hl]
 	jr .not_asleep
@@ -402,7 +402,7 @@ CheckEnemyTurn:
 	ld hl, UpdateEnemyHUD
 	call CallBattleCore
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wEnemySubStatus1
 	res SUBSTATUS_NIGHTMARE, [hl]
 	jr .not_asleep
@@ -623,7 +623,7 @@ HitConfusion:
 	ld hl, UpdatePlayerHUD
 	call CallBattleCore
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, TRUE
 	call DoPlayerDamage
 	jp BattleCommand_RaiseSub
@@ -632,7 +632,7 @@ BattleCommand_CheckObedience:
 ; checkobedience
 
 	; Enemy can't disobey
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ret nz
 
@@ -945,7 +945,7 @@ BattleCommand_UsedMoveText:
 	ret
 
 CheckUserIsCharging:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wPlayerCharging] ; player
 	jr z, .end
@@ -962,7 +962,7 @@ BattleCommand_DoTurn:
 	ld de, wPlayerSubStatus3
 	ld bc, wPlayerTurnsTaken
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .proceed
 
@@ -999,7 +999,7 @@ BattleCommand_DoTurn:
 	bit SUBSTATUS_TRANSFORMED, a
 	ret nz
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 
 	ld hl, wPartyMon1PP
@@ -1022,7 +1022,7 @@ BattleCommand_DoTurn:
 	ret c
 
 .consume_pp
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wCurMoveNum]
 	jr z, .okay
@@ -1091,7 +1091,7 @@ BattleCommand_DoTurn:
 	db -1
 
 CheckMimicUsed:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wCurMoveNum]
 	jr z, .player
@@ -1133,7 +1133,7 @@ BattleCommand_Critical:
 	and a
 	ret z
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wEnemyMonItem
 	ld a, [wEnemyMonSpecies]
@@ -1232,7 +1232,7 @@ BattleCommand_Stab:
 	ld d, a
 	ld e, [hl]
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go ; Who Attacks and who Defends
 
@@ -1339,48 +1339,48 @@ BattleCommand_Stab:
 	ld [wAttackMissed], a
 	xor a
 .NotImmune:
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	add b
 	ld [wTypeModifier], a
 
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 
 	ld hl, wCurDamage
 	ld a, [hli]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hld]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 	call Multiply
 
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld b, a
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	or b
 	ld b, a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	or b
 	jr z, .ok ; This is a very convoluted way to get back that we've essentially dealt no damage.
 
 ; Take the product and divide it by 10.
 	ld a, 10
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	or b
 	jr nz, .ok
 
 	ld a, 1
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 .ok
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	ld [hli], a
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	ld [hl], a
 	pop bc
 	pop hl
@@ -1402,7 +1402,7 @@ BattleCommand_Stab:
 
 BattleCheckTypeMatchup:
 	ld hl, wEnemyMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, CheckTypeMatchup
 	ld hl, wBattleMonType1
@@ -1455,21 +1455,21 @@ CheckTypeMatchup:
 
 .Yup:
 	xor a
-	ld [hDividend + 0], a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hDividend + 0], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hli]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [wTypeMatchup]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, 10
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	push bc
 	ld b, 4
 	call Divide
 	pop bc
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [wTypeMatchup], a
 	jr .TypesLoop
 
@@ -1523,12 +1523,12 @@ BattleCommand_DamageVariation:
 .go
 ; Start with the maximum damage.
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	dec hl
 	ld a, [hli]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 ; Multiply by 85-100%...
 .loop
@@ -1537,20 +1537,20 @@ BattleCommand_DamageVariation:
 	cp 85 percent + 1
 	jr c, .loop
 
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 
 ; ...divide by 100%...
 	ld a, $ff ; 100%
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, $4
 	call Divide
 
 ; ...to get .85-1.00x damage.
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld hl, wCurDamage
 	ld [hli], a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [hl], a
 	ret
 
@@ -1588,7 +1588,7 @@ BattleCommand_CheckHit:
 
 	ld a, [wPlayerMoveStruct + MOVE_ACC]
 	ld b, a
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .BrightPowder
 	ld a, [wEnemyMoveStruct + MOVE_ACC]
@@ -1769,7 +1769,7 @@ BattleCommand_CheckHit:
 	ret
 
 .StatModifiers:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 
 	; load the user's accuracy into b and the opponent's evasion into c.
@@ -1805,10 +1805,10 @@ BattleCommand_CheckHit:
 	ld c, a
 	; store the base move accuracy for math ops
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	push hl
 	ld d, 2 ; do this twice, once for the user's accuracy and once for the target's evasion
 
@@ -1824,22 +1824,22 @@ BattleCommand_CheckHit:
 	pop bc
 	; multiply by the first byte in that row...
 	ld a, [hli]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	; ... and divide by the second byte
 	ld a, [hl]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 	; minimum accuracy is $0001
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld b, a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	or b
 	jr nz, .min_accuracy
-	ld [hQuotient + 1], a
+	ldh [hQuotient + 1], a
 	ld a, 1
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 
 .min_accuracy
 	; do the same thing to the target's evasion
@@ -1848,9 +1848,9 @@ BattleCommand_CheckHit:
 	jr nz, .accuracy_loop
 
 	; if the result is more than 2 bytes, max out at 100%
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	and a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	jr z, .finish_accuracy
 	ld a, $ff
 
@@ -1871,7 +1871,7 @@ BattleCommand_EffectChance:
 
 	push hl
 	ld hl, wPlayerMoveStruct + MOVE_CHANCE
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_move_chance
 	ld hl, wEnemyMoveStruct + MOVE_CHANCE
@@ -1967,7 +1967,7 @@ BattleCommand_MoveAnimNoSub:
 	and a
 	jp nz, BattleCommand_MoveDelay
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld de, wPlayerRolloutCount
 	ld a, BATTLEANIM_ENEMY_DAMAGE
@@ -2039,7 +2039,7 @@ BattleCommand_StatDownAnim:
 	and a
 	jp nz, BattleCommand_MoveDelay
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, BATTLEANIM_ENEMY_STAT_DOWN
 	jr z, BattleCommand_StatUpDownAnim
@@ -2060,9 +2060,9 @@ BattleCommand_StatUpDownAnim:
 BattleCommand_SwitchTurn:
 ; switchturn
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	xor 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 BattleCommand_RaiseSub:
@@ -2159,7 +2159,7 @@ BattleCommand_ApplyDamage:
 	push bc
 	call .update_damage_taken
 	ld c, FALSE
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .damage_player
 	call DoEnemyDamage
@@ -2194,7 +2194,7 @@ BattleCommand_ApplyDamage:
 	ret nz
 
 	ld de, wPlayerDamageTaken + 1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .got_damage_taken
 	ld de, wEnemyDamageTaken + 1
@@ -2271,7 +2271,7 @@ endr
 	ld [wKickCounter], a
 	call LoadMoveAnim
 	ld c, TRUE
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, DoEnemyDamage
 	jp DoPlayerDamage
@@ -2331,7 +2331,7 @@ BattleCommand_StartLoop:
 ; startloop
 
 	ld hl, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyRolloutCount
@@ -2371,7 +2371,7 @@ BattleCommand_CheckFaint:
 ; Ends the move effect if the opponent faints.
 
 	ld hl, wEnemyMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wBattleMonHP
@@ -2389,7 +2389,7 @@ BattleCommand_CheckFaint:
 	ld hl, TookDownWithItText
 	call StdBattleTextBox
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wEnemyMonMaxHP + 1
 	bccoord 2, 2 ; hp bar
@@ -2468,7 +2468,7 @@ BattleCommand_BuildOpponentRage:
 	ret z
 
 	ld de, wEnemyRageCounter
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	ld de, wPlayerRageCounter
@@ -2492,7 +2492,7 @@ BattleCommand_RageDamage:
 	ld a, [wCurDamage + 1]
 	ld l, a
 	ld c, a
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wPlayerRageCounter]
 	jr z, .rage_loop
@@ -2525,7 +2525,7 @@ EndMoveEffect:
 DittoMetalPowder:
 	ld a, MON_SPECIES
 	call BattlePartyAttr
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [hl]
 	jr nz, .Ditto
@@ -2561,7 +2561,7 @@ DittoMetalPowder:
 BattleCommand_DamageStats:
 ; damagestats
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, EnemyAttackDamage
 
@@ -2706,7 +2706,7 @@ CheckDamageStatsCritical:
 
 	push hl
 	push bc
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy
 	ld a, [wPlayerMoveStructType]
@@ -2784,7 +2784,7 @@ SpeciesItemBoost:
 	ld a, MON_SPECIES
 	call BattlePartyAttr
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [hl]
 	jr z, .CompareSpecies
@@ -2900,7 +2900,7 @@ BattleCommand_ClearMissDamage:
 
 HitSelfInConfusion:
 	call ResetDamage
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wBattleMonDefense
 	ld de, wPlayerScreens
@@ -3049,12 +3049,12 @@ BattleCommand_DamageCalc:
 ; * 100 + item effect amount
 	ld a, c
 	add 100
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 
 ; / 100
 	ld a, 100
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 
@@ -3065,44 +3065,44 @@ BattleCommand_DamageCalc:
 ; Update wCurDamage (capped at 997).
 	ld hl, wCurDamage
 	ld b, [hl]
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	add b
-	ld [hProduct + 3], a
+	ldh [hProduct + 3], a
 	jr nc, .dont_cap_1
 
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	inc a
-	ld [hProduct + 2], a
+	ldh [hProduct + 2], a
 	and a
 	jr z, .Cap
 
 .dont_cap_1
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	ld b, a
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	or a
 	jr nz, .Cap
 
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	cp HIGH(MAX_STAT_VALUE - MIN_NEUTRAL_DAMAGE + 1)
 	jr c, .dont_cap_2
 
 	cp HIGH(MAX_STAT_VALUE - MIN_NEUTRAL_DAMAGE + 1) + 1
 	jr nc, .Cap
 
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	cp LOW(MAX_STAT_VALUE - MIN_NEUTRAL_DAMAGE + 1)
 	jr nc, .Cap
 
 .dont_cap_2
 	inc hl
 
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld b, [hl]
 	add b
 	ld [hld], a
 
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld b, [hl]
 	adc b
 	ld [hl], a
@@ -3146,20 +3146,20 @@ BattleCommand_DamageCalc:
 	ret z
 
 ; x2
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add a
-	ld [hProduct + 3], a
+	ldh [hProduct + 3], a
 
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	rl a
-	ld [hProduct + 2], a
+	ldh [hProduct + 2], a
 
 ; Cap at $ffff.
 	ret nc
 
 	ld a, $ff
-	ld [hProduct + 2], a
-	ld [hProduct + 3], a
+	ldh [hProduct + 2], a
+	ldh [hProduct + 3], a
 
 	ret
 
@@ -3169,7 +3169,7 @@ BattleCommand_ConstantDamage:
 ; constantdamage
 
 	ld hl, wBattleMonLevel
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_turn
 	ld hl, wEnemyMonLevel
@@ -3216,7 +3216,7 @@ BattleCommand_ConstantDamage:
 
 .super_fang
 	ld hl, wEnemyMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wBattleMonHP
@@ -3245,50 +3245,50 @@ BattleCommand_ConstantDamage:
 
 .reversal
 	ld hl, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .reversal_got_hp
 	ld hl, wEnemyMonHP
 .reversal_got_hp
 	xor a
-	ld [hDividend], a
-	ld [hMultiplicand + 0], a
+	ldh [hDividend], a
+	ldh [hMultiplicand + 0], a
 	ld a, [hli]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hli]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, $30
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, [hli]
 	ld b, a
 	ld a, [hl]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld a, b
 	and a
 	jr z, .skip_to_divide
 
-	ld a, [hProduct + 4]
+	ldh a, [hProduct + 4]
 	srl b
 	rr a
 	srl b
 	rr a
-	ld [hDivisor], a
-	ld a, [hProduct + 2]
+	ldh [hDivisor], a
+	ldh a, [hProduct + 2]
 	ld b, a
 	srl b
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	rr a
 	srl b
 	rr a
-	ld [hDividend + 3], a
+	ldh [hDividend + 3], a
 	ld a, b
-	ld [hDividend + 2], a
+	ldh [hDividend + 2], a
 
 .skip_to_divide
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld b, a
 	ld hl, FlailReversalPower
 
@@ -3300,7 +3300,7 @@ BattleCommand_ConstantDamage:
 	jr .reversal_loop
 
 .break_loop
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [hl]
 	jr nz, .notPlayersTurn
@@ -3521,7 +3521,7 @@ DoSubstituteDamage:
 	call StdBattleTextBox
 
 	ld de, wEnemySubstituteHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld de, wPlayerSubstituteHP
@@ -3662,7 +3662,7 @@ BattleCommand_SleepTarget:
 
 .CheckAIRandomFail:
 	; Enemy turn
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .dont_fail
 
@@ -3758,7 +3758,7 @@ BattleCommand_Poison:
 	and a
 	jr nz, .failed
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .dont_sample_failure
 
@@ -3819,7 +3819,7 @@ BattleCommand_Poison:
 .check_toxic
 	ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	call GetBattleVarAddr
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld de, wEnemyToxicCount
 	jr z, .ok
@@ -3832,7 +3832,7 @@ BattleCommand_Poison:
 
 CheckIfTargetIsPoisonType:
 	ld de, wEnemyMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld de, wBattleMonType1
@@ -3868,20 +3868,20 @@ SapHealth:
 	ld hl, wCurDamage
 	ld a, [hli]
 	srl a
-	ld [hDividend], a
+	ldh [hDividend], a
 	ld b, a
 	ld a, [hl]
 	rr a
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	or b
 	jr nz, .at_least_one
 	ld a, 1
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 .at_least_one
 
 	ld hl, wBattleMonHP
 	ld de, wBattleMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .battlemonhp
 	ld hl, wEnemyMonHP
@@ -3906,12 +3906,12 @@ SapHealth:
 	ld [bc], a
 
 	; Add hDividend to current HP and copy it to little endian wBuffer5/6
-	ld a, [hDividend + 1]
+	ldh a, [hDividend + 1]
 	ld b, [hl]
 	add b
 	ld [hld], a
 	ld [wBuffer5], a
-	ld a, [hDividend]
+	ldh a, [hDividend]
 	ld b, [hl]
 	adc b
 	ld [hli], a
@@ -3943,7 +3943,7 @@ SapHealth:
 	inc de
 
 .finish
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	hlcoord 10, 9
 	ld a, $1
@@ -4005,7 +4005,7 @@ Defrost:
 	xor a
 	ld [hl], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wCurOTMon]
 	ld hl, wOTPartyMon1Status
@@ -4067,7 +4067,7 @@ BattleCommand_FreezeTarget:
 	call OpponentCantMove
 	call EndRechargeOpp
 	ld hl, wEnemyJustGotFrozen
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .finish
 	ld hl, wPlayerJustGotFrozen
@@ -4193,7 +4193,7 @@ RaiseStat:
 	ld a, b
 	ld [wLoweredStat], a
 	ld hl, wPlayerStatLevels
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_stat_levels
 	ld hl, wEnemyStatLevels
@@ -4230,7 +4230,7 @@ RaiseStat:
 	jr nc, .done_calcing_stats
 	ld hl, wBattleMonStats + 1
 	ld de, wPlayerStats
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_stats_pointer
 	ld hl, wEnemyMonStats + 1
@@ -4254,7 +4254,7 @@ RaiseStat:
 	sbc HIGH(MAX_STAT_VALUE)
 	jp z, .stats_already_max
 .not_already_max
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .calc_player_stats
 	call CalcEnemyStats
@@ -4290,7 +4290,7 @@ MinimizeDropSub:
 
 	ld bc, wPlayerMinimized
 	ld hl, DropPlayerSub
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .do_player
 	ld bc, wEnemyMinimized
@@ -4307,7 +4307,7 @@ MinimizeDropSub:
 	ret nc
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CallBattleCore
 	call WaitBGMap
 	jp BattleCommand_MoveDelay
@@ -4390,7 +4390,7 @@ BattleCommand_StatDown:
 	jp nz, .Mist
 
 	ld hl, wEnemyStatLevels
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .GetStatLevel
 	ld hl, wPlayerStatLevels
@@ -4416,7 +4416,7 @@ BattleCommand_StatDown:
 
 .ComputerMiss:
 ; Computer opponents have a 25% chance of failing.
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .DidntMiss
 
@@ -4467,7 +4467,7 @@ BattleCommand_StatDown:
 	push hl
 	ld hl, wEnemyMonAttack + 1
 	ld de, wEnemyStats
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .do_enemy
 	ld hl, wBattleMonAttack + 1
@@ -4613,7 +4613,7 @@ TryLowerStat:
 	ret z
 
 .not_min
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .Player
 
@@ -4728,7 +4728,7 @@ LowerStat:
 	ld [wLoweredStat], a
 
 	ld hl, wPlayerStatLevels
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_target
 	ld hl, wEnemyStatLevels
@@ -4759,7 +4759,7 @@ LowerStat:
 	push hl
 	ld hl, wBattleMonStats + 1
 	ld de, wPlayerStats
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_target_2
 	ld hl, wEnemyMonStats + 1
@@ -4771,7 +4771,7 @@ LowerStat:
 	jr z, .failed
 
 .accuracy_evasion
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -4825,25 +4825,25 @@ BattleCommand_Curl:
 
 BattleCommand_RaiseSubNoAnim:
 	ld hl, GetBattleMonBackpic
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .PlayerTurn
 	ld hl, GetEnemyMonFrontpic
 .PlayerTurn:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CallBattleCore
 	jp WaitBGMap
 
 BattleCommand_LowerSubNoAnim:
 	ld hl, DropPlayerSub
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .PlayerTurn
 	ld hl, DropEnemySub
 .PlayerTurn:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CallBattleCore
 	jp WaitBGMap
 
@@ -4901,51 +4901,51 @@ CalcStats:
 	add hl, bc
 
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld a, [de]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	inc de
 	ld a, [de]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	inc de
 
 	ld a, [hli]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 
 	ld a, [hl]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	or b
 	jr nz, .check_maxed_out
 
 	ld a, 1
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 	jr .not_maxed_out
 
 .check_maxed_out
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	cp LOW(MAX_STAT_VALUE)
 	ld a, b
 	sbc HIGH(MAX_STAT_VALUE)
 	jr c, .not_maxed_out
 
 	ld a, LOW(MAX_STAT_VALUE)
-	ld [hQuotient + 2], a
+	ldh [hQuotient + 2], a
 	ld a, HIGH(MAX_STAT_VALUE)
-	ld [hQuotient + 1], a
+	ldh [hQuotient + 1], a
 
 .not_maxed_out
 	pop bc
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [bc], a
 	inc bc
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [bc], a
 	inc bc
 	pop hl
@@ -4961,7 +4961,7 @@ BattleCommand_CheckRampage:
 ; checkrampage
 
 	ld de, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	ld de, wEnemyRolloutCount
@@ -5004,7 +5004,7 @@ BattleCommand_Rampage:
 	ret nz
 
 	ld de, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld de, wEnemyRolloutCount
@@ -5042,7 +5042,7 @@ BattleCommand_ForceSwitch:
 	jp z, .fail
 	cp BATTLETYPE_SUICUNE
 	jp z, .fail
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, .force_player_switch
 	ld a, [wAttackMissed]
@@ -5285,7 +5285,7 @@ BattleCommand_EndLoop:
 
 	ld de, wPlayerRolloutCount
 	ld bc, wPlayerDamageTaken
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_addrs
 	ld de, wEnemyRolloutCount
@@ -5321,7 +5321,7 @@ BattleCommand_EndLoop:
 	jr .done_loop
 
 .beat_up
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .check_ot_beat_up
 	ld a, [wPartyCount]
@@ -5377,7 +5377,7 @@ BattleCommand_EndLoop:
 	res SUBSTATUS_IN_LOOP, [hl]
 
 	ld hl, PlayerHitTimesText
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hit_n_times_text
 	ld hl, EnemyHitTimesText
@@ -5463,7 +5463,7 @@ CheckOpponentWentFirst:
 	push bc
 	ld a, [wEnemyGoesFirst] ; 0 if player went first
 	ld b, a
-	ld a, [hBattleTurn] ; 0 if it's the player's turn
+	ldh a, [hBattleTurn] ; 0 if it's the player's turn
 	xor b ; 1 if opponent went first
 	pop bc
 	ret
@@ -5506,7 +5506,7 @@ BattleCommand_OHKO:
 	ld hl, wEnemyMonLevel
 	ld de, wBattleMonLevel
 	ld bc, wPlayerMoveStruct + MOVE_ACC
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_move_accuracy
 	push hl
@@ -5708,7 +5708,7 @@ BattleCommand_TrapTarget:
 	ret nz
 	ld hl, wEnemyWrapCount
 	ld de, wEnemyTrappingMove
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_trap
 	ld hl, wPlayerWrapCount
@@ -5764,7 +5764,7 @@ BattleCommand_Recoil:
 ; recoil
 
 	ld hl, wBattleMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wEnemyMonMaxHP
@@ -5811,7 +5811,7 @@ BattleCommand_Recoil:
 	ld [hl], a
 .dont_ko
 	hlcoord 10, 9
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, 1
 	jr z, .animate_hp_bar
@@ -5875,7 +5875,7 @@ BattleCommand_Confuse:
 	jr nz, BattleCommand_Confuse_CheckSnore_Swagger_ConfuseHit
 BattleCommand_FinishConfusingTarget:
 	ld bc, wEnemyConfuseCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_confuse_count
 	ld bc, wPlayerConfuseCount
@@ -5949,7 +5949,7 @@ BattleCommand_Paralyze:
 	jp StdBattleTextBox
 
 .no_item_protection
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .dont_sample_failure
 
@@ -5983,7 +5983,7 @@ BattleCommand_Paralyze:
 	call DelayFrames
 	call AnimateCurrentMove
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, BATTLE_VARS_STATUS_OPP
 	call GetBattleVarAddr
 	set PAR, [hl]
@@ -6015,7 +6015,7 @@ CheckMoveTypeMatchesTarget:
 	push hl
 
 	ld hl, wEnemyMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wBattleMonType1
@@ -6112,7 +6112,7 @@ BattleCommand_ResetStats:
 	ld hl, wEnemyStatLevels
 	call .Fill
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	push af
 
 	call SetPlayerTurn
@@ -6121,7 +6121,7 @@ BattleCommand_ResetStats:
 	call CalcEnemyStats
 
 	pop af
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 
 	call AnimateCurrentMove
 
@@ -6141,7 +6141,7 @@ BattleCommand_Heal:
 
 	ld de, wBattleMonHP
 	ld hl, wBattleMonMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld de, wEnemyMonHP
@@ -6180,7 +6180,7 @@ BattleCommand_Heal:
 	ld hl, RestedText
 .no_status_to_heal
 	call StdBattleTextBox
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .calc_enemy_stats
 	call CalcPlayerStats
@@ -6223,7 +6223,7 @@ INCLUDE "engine/battle/move_effects/transform.asm"
 BattleSideCopy:
 ; Copy bc bytes from hl to de if it's the player's turn.
 ; Copy bc bytes from de to hl if it's the enemy's turn.
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .copy
 
@@ -6252,7 +6252,7 @@ ClearLastMove:
 	ret
 
 ResetActorDisable:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -6272,7 +6272,7 @@ BattleCommand_Screen:
 
 	ld hl, wPlayerScreens
 	ld bc, wPlayerLightScreenCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_screens_pointer
 	ld hl, wEnemyScreens
@@ -6375,7 +6375,7 @@ CheckUserMove:
 ; Return z if the user has move a.
 	ld b, a
 	ld de, wBattleMonMoves
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld de, wEnemyMonMoves
@@ -6397,7 +6397,7 @@ CheckUserMove:
 
 ResetTurn:
 	ld hl, wPlayerCharging
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	ld hl, wEnemyCharging
@@ -6452,7 +6452,7 @@ BattleCommand_Defrost:
 
 ; Don't update the enemy's party struct in a wild battle.
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .party
 
@@ -6505,7 +6505,7 @@ INCLUDE "engine/battle/move_effects/safeguard.asm"
 SafeCheckSafeguard:
 	push hl
 	ld hl, wEnemyScreens
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_turn
 	ld hl, wPlayerScreens
@@ -6518,7 +6518,7 @@ SafeCheckSafeguard:
 BattleCommand_CheckSafeguard:
 ; checksafeguard
 	ld hl, wEnemyScreens
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_turn
 	ld hl, wPlayerScreens
@@ -6560,7 +6560,7 @@ BattleCommand_TimeBasedHealContinue:
 
 	ld hl, wBattleMonMaxHP
 	ld de, wBattleMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .start
 	ld hl, wEnemyMonMaxHP
@@ -6653,7 +6653,7 @@ BattleCommand_DoubleMinimizeDamage:
 ; doubleminimizedamage
 
 	ld hl, wEnemyMinimized
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wPlayerMinimized
@@ -6693,7 +6693,7 @@ CheckHiddenOpponent:
 GetUserItem:
 ; Return the effect of the user's item in bc, and its id at hl.
 	ld hl, wBattleMonItem
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go
 	ld hl, wEnemyMonItem
@@ -6704,7 +6704,7 @@ GetUserItem:
 GetOpponentItem:
 ; Return the effect of the opponent's item in bc, and its id at hl.
 	ld hl, wEnemyMonItem
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go
 	ld hl, wBattleMonItem
@@ -6775,7 +6775,7 @@ PlayDamageAnim:
 
 	ld [wFXAnimID], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, BATTLEANIM_ENEMY_DAMAGE
 	jr z, .player

--- a/engine/battle/hidden_power.asm
+++ b/engine/battle/hidden_power.asm
@@ -2,7 +2,7 @@ HiddenPowerDamage:
 ; Override Hidden Power's type and power based on the user's DVs.
 
 	ld hl, wBattleMonDVs
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_dvs
 	ld hl, wEnemyMonDVs

--- a/engine/battle/link_result.asm
+++ b/engine/battle/link_result.asm
@@ -83,13 +83,13 @@ DetermineLinkBattleResult:
 	jr z, .next
 	dec hl
 	xor a
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, [hli]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, [hli]
-	ld [hDividend + 2], a
+	ldh [hDividend + 2], a
 	xor a
-	ld [hDividend + 3], a
+	ldh [hDividend + 3], a
 	ld a, [hli]
 	ld b, a
 	ld a, [hld]
@@ -97,13 +97,13 @@ DetermineLinkBattleResult:
 	rr a
 	srl b
 	rr a
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, $4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add e
 	ld e, a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	adc d
 	ld d, a
 	dec hl

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -1,7 +1,7 @@
 _DisappearUser:
 	xor a
-	ld [hBGMapMode], a
-	ld a, [hBattleTurn]
+	ldh [hBGMapMode], a
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	call GetEnemyFrontpicCoords
@@ -21,8 +21,8 @@ _AppearUserLowerSub:
 
 AppearUser:
 	xor a
-	ld [hBGMapMode], a
-	ld a, [hBattleTurn]
+	ldh [hBGMapMode], a
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	call GetEnemyFrontpicCoords
@@ -32,11 +32,11 @@ AppearUser:
 	call GetPlayerBackpicCoords
 	ld a, $31
 .okay
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	predef PlaceGraphic
 FinishAppearDisappearUser:
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 GetEnemyFrontpicCoords:
@@ -101,32 +101,32 @@ DoWeatherModifiers:
 
 .ApplyModifier:
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld hl, wCurDamage
 	ld a, [hli]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 	inc de
 	ld a, [de]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 
 	call Multiply
 
 	ld a, 10
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 
-	ld a, [hQuotient + 0]
+	ldh a, [hQuotient + 0]
 	and a
 	ld bc, -1
 	jr nz, .Update
 
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld c, a
 	or b
 	jr nz, .Update
@@ -153,7 +153,7 @@ DoBadgeTypeBoosts:
 	and a
 	ret nz
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ret nz
 

--- a/engine/battle/move_effects/baton_pass.asm
+++ b/engine/battle/move_effects/baton_pass.asm
@@ -1,7 +1,7 @@
 BattleCommand_BatonPass:
 ; batonpass
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, .Enemy
 

--- a/engine/battle/move_effects/beat_up.asm
+++ b/engine/battle/move_effects/beat_up.asm
@@ -2,7 +2,7 @@ BattleCommand_BeatUp:
 ; beatup
 
 	call ResetDamage
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp nz, .enemy_beats_up
 
@@ -210,7 +210,7 @@ GetBeatupMonLocation:
 	push bc
 	ld c, a
 	ld b, 0
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wPartyMon1Species
 	jr z, .got_species

--- a/engine/battle/move_effects/bide.asm
+++ b/engine/battle/move_effects/bide.asm
@@ -7,7 +7,7 @@ BattleCommand_StoreEnergy:
 	ret z
 
 	ld hl, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .check_still_storing_energy
 	ld hl, wEnemyRolloutCount
@@ -28,7 +28,7 @@ BattleCommand_StoreEnergy:
 	ld [hl], a
 	ld hl, wPlayerDamageTaken + 1
 	ld de, wPlayerCharging ; player
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	ld hl, wEnemyDamageTaken + 1
@@ -74,7 +74,7 @@ BattleCommand_UnleashEnergy:
 
 	ld de, wPlayerDamageTaken
 	ld bc, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_damage
 	ld de, wEnemyDamageTaken

--- a/engine/battle/move_effects/conversion.asm
+++ b/engine/battle/move_effects/conversion.asm
@@ -3,7 +3,7 @@ BattleCommand_Conversion:
 
 	ld hl, wBattleMonMoves
 	ld de, wBattleMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_moves
 	ld hl, wEnemyMonMoves

--- a/engine/battle/move_effects/conversion2.asm
+++ b/engine/battle/move_effects/conversion2.asm
@@ -5,7 +5,7 @@ BattleCommand_Conversion2:
 	and a
 	jr nz, .failed
 	ld hl, wBattleMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_type
 	ld hl, wEnemyMonType1

--- a/engine/battle/move_effects/curse.asm
+++ b/engine/battle/move_effects/curse.asm
@@ -3,7 +3,7 @@ BattleCommand_Curse:
 
 	ld de, wBattleMonType1
 	ld bc, wPlayerStatLevels
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go
 	ld de, wEnemyMonType1

--- a/engine/battle/move_effects/disable.asm
+++ b/engine/battle/move_effects/disable.asm
@@ -7,7 +7,7 @@ BattleCommand_Disable:
 
 	ld de, wEnemyDisableCount
 	ld hl, wEnemyMonMoves
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_moves
 	ld de, wPlayerDisableCount
@@ -33,7 +33,7 @@ BattleCommand_Disable:
 	cp b
 	jr nz, .loop
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wEnemyMonPP
 	jr z, .got_pp
@@ -55,7 +55,7 @@ BattleCommand_Disable:
 	ld [de], a
 	call AnimateCurrentMove
 	ld hl, wDisabledMove
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .got_disabled_move_pointer
 	inc hl

--- a/engine/battle/move_effects/encore.asm
+++ b/engine/battle/move_effects/encore.asm
@@ -3,7 +3,7 @@ BattleCommand_Encore:
 
 	ld hl, wEnemyMonMoves
 	ld de, wEnemyEncoreCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wBattleMonMoves
@@ -47,7 +47,7 @@ BattleCommand_Encore:
 	ld [de], a
 	call CheckOpponentWentFirst
 	jr nz, .finish_move
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .force_last_enemy_move
 

--- a/engine/battle/move_effects/false_swipe.asm
+++ b/engine/battle/move_effects/false_swipe.asm
@@ -4,7 +4,7 @@ BattleCommand_FalseSwipe:
 ; Makes sure wCurDamage < MonHP
 
 	ld hl, wEnemyMonHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wBattleMonHP

--- a/engine/battle/move_effects/frustration.asm
+++ b/engine/battle/move_effects/frustration.asm
@@ -3,25 +3,25 @@ BattleCommand_FrustrationPower:
 
 	push bc
 	ld hl, wBattleMonHappiness
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_happiness
 	ld hl, wEnemyMonHappiness
 .got_happiness
 	ld a, $ff
 	sub [hl]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, 10
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, 25
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld d, a
 	pop bc
 	ret

--- a/engine/battle/move_effects/fury_cutter.asm
+++ b/engine/battle/move_effects/fury_cutter.asm
@@ -2,7 +2,7 @@ BattleCommand_FuryCutter:
 ; furycutter
 
 	ld hl, wPlayerFuryCutterCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .go
 	ld hl, wEnemyFuryCutterCount
@@ -42,7 +42,7 @@ ResetFuryCutterCount:
 	push hl
 
 	ld hl, wPlayerFuryCutterCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .reset
 	ld hl, wEnemyFuryCutterCount

--- a/engine/battle/move_effects/future_sight.asm
+++ b/engine/battle/move_effects/future_sight.asm
@@ -3,7 +3,7 @@ BattleCommand_CheckFutureSight:
 
 	ld hl, wPlayerFutureSightCount
 	ld de, wPlayerFutureSightDamage
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyFutureSightCount
@@ -41,7 +41,7 @@ BattleCommand_FutureSight:
 	ld [hl], b
 .AlreadyChargingFutureSight:
 	ld hl, wPlayerFutureSightCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .GotFutureSightCount
 	ld hl, wEnemyFutureSightCount
@@ -57,7 +57,7 @@ BattleCommand_FutureSight:
 	call StdBattleTextBox
 	call BattleCommand_RaiseSub
 	ld de, wPlayerFutureSightDamage
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .StoreDamage
 	ld de, wEnemyFutureSightDamage

--- a/engine/battle/move_effects/heal_bell.asm
+++ b/engine/battle/move_effects/heal_bell.asm
@@ -5,7 +5,7 @@ BattleCommand_HealBell:
 	call GetBattleVarAddr
 	res SUBSTATUS_NIGHTMARE, [hl]
 	ld de, wPartyMon1Status
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_status
 	ld de, wOTPartyMon1Status
@@ -28,7 +28,7 @@ BattleCommand_HealBell:
 	ld hl, BellChimedText
 	call StdBattleTextBox
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jp z, CalcPlayerStats
 	jp CalcEnemyStats

--- a/engine/battle/move_effects/leech_seed.asm
+++ b/engine/battle/move_effects/leech_seed.asm
@@ -7,7 +7,7 @@ BattleCommand_LeechSeed:
 	jr nz, .evaded
 
 	ld de, wEnemyMonType1
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld de, wBattleMonType1

--- a/engine/battle/move_effects/mimic.asm
+++ b/engine/battle/move_effects/mimic.asm
@@ -7,7 +7,7 @@ BattleCommand_Mimic:
 	and a
 	jr nz, .fail
 	ld hl, wBattleMonMoves
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player_turn
 	ld hl, wEnemyMonMoves

--- a/engine/battle/move_effects/pay_day.asm
+++ b/engine/battle/move_effects/pay_day.asm
@@ -5,7 +5,7 @@ BattleCommand_PayDay:
 	ld hl, wStringBuffer1
 	ld [hli], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wBattleMonLevel]
 	jr z, .ok

--- a/engine/battle/move_effects/present.asm
+++ b/engine/battle/move_effects/present.asm
@@ -54,7 +54,7 @@ BattleCommand_Present:
 	call AnimateCurrentMove
 	call BattleCommand_SwitchTurn
 	ld hl, AICheckPlayerMaxHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp_fn_pointer
 	ld hl, AICheckEnemyMaxHP

--- a/engine/battle/move_effects/protect.asm
+++ b/engine/battle/move_effects/protect.asm
@@ -14,7 +14,7 @@ BattleCommand_Protect:
 
 ProtectChance:
 	ld de, wPlayerProtectCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .asm_37637
 	ld de, wEnemyProtectCount

--- a/engine/battle/move_effects/psych_up.asm
+++ b/engine/battle/move_effects/psych_up.asm
@@ -3,7 +3,7 @@ BattleCommand_PsychUp:
 
 	ld hl, wEnemyStatLevels
 	ld de, wPlayerStatLevels
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .pointers_correct
 ; It's the enemy's turn, so swap the pointers.
@@ -35,7 +35,7 @@ BattleCommand_PsychUp:
 	inc de
 	dec b
 	jr nz, .loop2
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .calc_enemy_stats
 	call CalcPlayerStats

--- a/engine/battle/move_effects/pursuit.asm
+++ b/engine/battle/move_effects/pursuit.asm
@@ -3,7 +3,7 @@ BattleCommand_Pursuit:
 ; Double damage if the opponent is switching.
 
 	ld hl, wEnemyIsSwitching
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wPlayerIsSwitching

--- a/engine/battle/move_effects/rapid_spin.asm
+++ b/engine/battle/move_effects/rapid_spin.asm
@@ -12,7 +12,7 @@ BattleCommand_ClearHazards:
 
 	ld hl, wPlayerScreens
 	ld de, wPlayerWrapCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_screens_wrap
 	ld hl, wEnemyScreens

--- a/engine/battle/move_effects/return.asm
+++ b/engine/battle/move_effects/return.asm
@@ -2,24 +2,24 @@ BattleCommand_HappinessPower:
 ; happinesspower
 	push bc
 	ld hl, wBattleMonHappiness
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyMonHappiness
 .ok
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, 10
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld a, 25
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld d, a
 	pop bc
 	ret

--- a/engine/battle/move_effects/rollout.asm
+++ b/engine/battle/move_effects/rollout.asm
@@ -4,7 +4,7 @@ BattleCommand_CheckCurl:
 ; checkcurl
 
 	ld de, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld de, wEnemyRolloutCount
@@ -31,7 +31,7 @@ BattleCommand_RolloutPower:
 	ret nz
 
 	ld hl, wPlayerRolloutCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_rollout_count
 	ld hl, wEnemyRolloutCount

--- a/engine/battle/move_effects/safeguard.asm
+++ b/engine/battle/move_effects/safeguard.asm
@@ -3,7 +3,7 @@ BattleCommand_Safeguard:
 
 	ld hl, wPlayerScreens
 	ld de, wPlayerSafeguardCount
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ok
 	ld hl, wEnemyScreens

--- a/engine/battle/move_effects/sketch.asm
+++ b/engine/battle/move_effects/sketch.asm
@@ -27,7 +27,7 @@ BattleCommand_Sketch:
 	ld e, l
 ; Get the battle move structs.
 	ld hl, wBattleMonMoves
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .get_last_move
 	ld hl, wEnemyMonMoves
@@ -74,7 +74,7 @@ BattleCommand_Sketch:
 	ld [hl], a
 	pop bc
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .user_trainer
 	ld a, [wBattleMode]

--- a/engine/battle/move_effects/sleep_talk.asm
+++ b/engine/battle/move_effects/sleep_talk.asm
@@ -5,7 +5,7 @@ BattleCommand_SleepTalk:
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .fail
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld hl, wBattleMonMoves + 1
 	ld a, [wDisabledMove]
@@ -77,7 +77,7 @@ BattleCommand_SleepTalk:
 	ret
 
 .check_has_usable_move
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wDisabledMove]
 	jr z, .got_move_2

--- a/engine/battle/move_effects/spikes.asm
+++ b/engine/battle/move_effects/spikes.asm
@@ -2,7 +2,7 @@ BattleCommand_Spikes:
 ; spikes
 
 	ld hl, wEnemyScreens
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .asm_3768e
 	ld hl, wPlayerScreens

--- a/engine/battle/move_effects/spite.asm
+++ b/engine/battle/move_effects/spite.asm
@@ -6,7 +6,7 @@ BattleCommand_Spite:
 	jp nz, .failed
 	ld bc, PARTYMON_STRUCT_LENGTH ; ????
 	ld hl, wEnemyMonMoves
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_moves
 	ld hl, wBattleMonMoves
@@ -63,7 +63,7 @@ BattleCommand_Spite:
 	call GetBattleVar
 	bit SUBSTATUS_TRANSFORMED, a
 	jr nz, .transformed
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .not_wildmon
 	ld a, [wBattleMode]

--- a/engine/battle/move_effects/substitute.asm
+++ b/engine/battle/move_effects/substitute.asm
@@ -4,7 +4,7 @@ BattleCommand_Substitute:
 	call BattleCommand_MoveDelay
 	ld hl, wBattleMonMaxHP
 	ld de, wPlayerSubstituteHP
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .got_hp
 	ld hl, wEnemyMonMaxHP
@@ -46,7 +46,7 @@ BattleCommand_Substitute:
 
 	ld hl, wPlayerWrapCount
 	ld de, wPlayerTrappingMove
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 	ld hl, wEnemyWrapCount

--- a/engine/battle/move_effects/teleport.asm
+++ b/engine/battle/move_effects/teleport.asm
@@ -16,7 +16,7 @@ BattleCommand_Teleport:
 	bit SUBSTATUS_CANT_RUN, a
 	jr nz, .failed
 ; Only need to check these next things if it's your turn
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy_turn
 ; Can't teleport from a trainer battle

--- a/engine/battle/move_effects/thief.asm
+++ b/engine/battle/move_effects/thief.asm
@@ -1,7 +1,7 @@
 BattleCommand_Thief:
 ; thief
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy
 

--- a/engine/battle/move_effects/transform.asm
+++ b/engine/battle/move_effects/transform.asm
@@ -30,7 +30,7 @@ BattleCommand_Transform:
 	call ResetActorDisable
 	ld hl, wBattleMonSpecies
 	ld de, wEnemyMonSpecies
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .got_mon_species
 	ld hl, wEnemyMonSpecies
@@ -46,7 +46,7 @@ BattleCommand_Transform:
 	inc de
 	ld bc, NUM_MOVES
 	call CopyBytes
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .mimic_enemy_backup
 	ld a, [de]
@@ -112,7 +112,7 @@ BattleCommand_Transform:
 	call BattleSideCopy
 	call _CheckBattleScene
 	jr c, .mimic_anims
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ld a, [wPlayerMinimized]
 	jr z, .got_byte

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -315,9 +315,9 @@ ComputeTrainerReward:
 	ld hl, wBattleReward
 	xor a
 	ld [hli], a
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [hli], a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [hl], a
 	ret
 

--- a/engine/battle/sliding_intro.asm
+++ b/engine/battle/sliding_intro.asm
@@ -1,22 +1,22 @@
 BattleIntroSlidingPics:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call .subfunction1
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	call .subfunction2
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .subfunction1
 	call .subfunction4
 	ld a, $90
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, %11100100
 	call DmgToCgbBGPals
 	lb de, %11100100, %11100100
@@ -31,11 +31,11 @@ BattleIntroSlidingPics:
 .loop1
 	push af
 .loop2
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $60
 	jr c, .loop2
 	ld a, d
-	ld [hSCX], a
+	ldh [hSCX], a
 	call .subfunction5
 	inc e
 	inc e

--- a/engine/battle/sliding_intro.asm
+++ b/engine/battle/sliding_intro.asm
@@ -4,7 +4,7 @@ BattleIntroSlidingPics:
 	ld a, BANK(wLYOverrides)
 	ldh [rSVBK], a
 	call .subfunction1
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	call .subfunction2
 	xor a

--- a/engine/battle/start_battle.asm
+++ b/engine/battle/start_battle.asm
@@ -14,7 +14,7 @@ ShowLinkBattleParticipants:
 
 FindFirstAliveMonAndStartBattle:
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call DelayFrame
 	ld b, PARTY_LENGTH
 	ld hl, wPartyMon1HP
@@ -36,14 +36,14 @@ FindFirstAliveMonAndStartBattle:
 	predef DoBattleTransition
 	farcall _LoadBattleFontsHPBar
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
-	ld [hWY], a
-	ld [rWY], a
-	ld [hMapAnims], a
+	ldh [hBGMapMode], a
+	ldh [hWY], a
+	ldh [rWY], a
+	ldh [hMapAnims], a
 	ret
 
 PlayBattleMusic:

--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -1,6 +1,6 @@
 BattleStart_TrainerHuds:
 	ld a, $e4
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	call LoadBallIconGFX
 	call ShowPlayerMonsRemaining
 	ld a, [wBattleMode]
@@ -10,7 +10,7 @@ BattleStart_TrainerHuds:
 
 EnemySwitch_TrainerHud:
 	ld a, $e4
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	call LoadBallIconGFX
 	jp ShowOTTrainerMonsRemaining
 
@@ -253,5 +253,5 @@ _ShowLinkBattleParticipants:
 	call GetSGBLayout
 	call SetPalettes
 	ld a, $e4
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	ret

--- a/engine/battle/used_move_text.asm
+++ b/engine/battle/used_move_text.asm
@@ -8,7 +8,7 @@ UsedMoveText:
 ; this is a stream of text and asm from 105db9 to 105ef6
 	text_jump _ActorNameText
 	start_asm
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .start
 

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -1,16 +1,16 @@
 ; Battle animation command interpreter.
 
 PlayBattleAnim:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wActiveAnimObjects)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call _PlayBattleAnim
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 _PlayBattleAnim:
@@ -25,7 +25,7 @@ _PlayBattleAnim:
 	call BattleAnimDelayFrame
 
 	ld c, 1
-	ld a, [rKEY1]
+	ldh a, [rKEY1]
 	bit 7, a
 	jr nz, .asm_cc0ff
 	ld c, 3
@@ -39,10 +39,10 @@ _PlayBattleAnim:
 	call BattleAnimRunScript
 
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	call BattleAnimDelayFrame
 	call BattleAnimDelayFrame
@@ -65,8 +65,8 @@ BattleAnimRunScript:
 	call BattleAnimRequestPals
 
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	call BattleAnimDelayFrame
 	call BattleAnimRestoreHuds
 
@@ -139,7 +139,7 @@ BattleAnimClearHud:
 	call WaitTop
 	call ClearActorHud
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BattleAnimDelayFrame
 	call BattleAnimDelayFrame
 	call BattleAnimDelayFrame
@@ -150,20 +150,20 @@ BattleAnimRestoreHuds:
 	call BattleAnimDelayFrame
 	call WaitTop
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurBattleMon) ; alternatively: BANK(wTempMon), BANK(wPartyMon1), several others
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, UpdateBattleHuds
 	ld a, BANK(UpdatePlayerHUD)
 	rst FarCall ; Why not "call UpdateBattleHuds"?
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BattleAnimDelayFrame
 	call BattleAnimDelayFrame
 	call BattleAnimDelayFrame
@@ -171,17 +171,17 @@ BattleAnimRestoreHuds:
 	ret
 
 BattleAnimRequestPals:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld b, a
 	ld a, [wBGP]
 	cp b
 	call nz, BattleAnim_SetBGPals
 
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld b, a
 	ld a, [wOBP0]
 	cp b
@@ -200,7 +200,7 @@ BattleAnimDelayFrame:
 	ret
 
 ClearActorHud:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -217,18 +217,18 @@ ClearActorHud:
 
 Unreferenced_Functioncc220:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, LOW(vBGMap0 tile $28)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0 tile $28)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call WaitBGMap2
 	ld a, $60
-	ld [hWY], a
+	ldh [hWY], a
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call BattleAnimDelayFrame
 	ret
 
@@ -633,7 +633,7 @@ BattleAnimCmd_OBP1:
 	ret
 
 BattleAnimCmd_ResetObp0:
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ld a, $e0
 	jr z, .not_sgb
@@ -885,14 +885,14 @@ BattleAnimCmd_E7:
 	ret
 
 BattleAnimCmd_Transform:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurPartySpecies)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wCurPartySpecies] ; CurPartySpecies
 	push af
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -916,12 +916,12 @@ BattleAnimCmd_Transform:
 	pop af
 	ld [wCurPartySpecies], a ; CurPartySpecies
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 BattleAnimCmd_UpdateActorPic:
 	ld de, vTiles0 tile $00
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -939,10 +939,10 @@ BattleAnimCmd_UpdateActorPic:
 	ret
 
 BattleAnimCmd_RaiseSub:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 1 ; unnecessary bankswitch?
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a ; sScratch
 	call GetSRAMBank
 
@@ -958,7 +958,7 @@ GetSubstitutePic: ; used only for BANK(GetSubstitutePic)
 	or b
 	jr nz, .loop
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -1003,7 +1003,7 @@ GetSubstitutePic: ; used only for BANK(GetSubstitutePic)
 .done
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .CopyTile:
@@ -1013,17 +1013,17 @@ GetSubstitutePic: ; used only for BANK(GetSubstitutePic)
 	ret
 
 BattleAnimCmd_MinimizeOpp:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 1 ; unnecessary bankswitch?
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a ; sScratch
 	call GetSRAMBank
 	call GetMinimizePic
 	call Request2bpp
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 GetMinimizePic:
@@ -1037,7 +1037,7 @@ GetMinimizePic:
 	or b
 	jr nz, .loop
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -1067,10 +1067,10 @@ MinimizePic:
 INCBIN "gfx/battle/minimize.2bpp"
 
 BattleAnimCmd_Minimize:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 1 ; unnecessary bankswitch?
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a ; sScratch
 	call GetSRAMBank
 	call GetMinimizePic
@@ -1078,18 +1078,18 @@ BattleAnimCmd_Minimize:
 	call Request2bpp
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 BattleAnimCmd_DropSub:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurPartySpecies)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, [wCurPartySpecies] ; CurPartySpecies
 	push af
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -1103,21 +1103,21 @@ BattleAnimCmd_DropSub:
 	pop af
 	ld [wCurPartySpecies], a ; CurPartySpecies
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 BattleAnimCmd_BeatUp:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurPartySpecies)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wCurPartySpecies] ; CurPartySpecies
 	push af
 
 	ld a, [wBattleAnimParam]
 	ld [wCurPartySpecies], a ; CurPartySpecies
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .player
 
@@ -1139,17 +1139,17 @@ BattleAnimCmd_BeatUp:
 	ld b, SCGB_BATTLE_COLORS
 	call GetSGBLayout
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 BattleAnimCmd_OAMOn:
 	xor a
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 BattleAnimCmd_OAMOff:
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 BattleAnimCmd_ClearSprites:
@@ -1194,7 +1194,7 @@ BattleAnimCmd_Sound:
 	db $f0, $0f, $f0, $0f
 
 .GetCryTrack:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy
 
@@ -1216,12 +1216,12 @@ rept 4
 	add hl, de
 endr
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wEnemyMon) ; wBattleMon is in WRAM0, but EnemyMon is in WRAMX
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy
 
@@ -1278,7 +1278,7 @@ endr
 
 .done
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .CryData:
@@ -1314,10 +1314,10 @@ PlayHitSound:
 	ret
 
 BattleAnimAssignPals:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ld a, %11100000
 	jr z, .sgb
@@ -1374,59 +1374,59 @@ BattleAnim_RevertPals:
 	lb de, %11100100, %11100100
 	call DmgToCgbObjPals
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	call BattleAnimDelayFrame
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 BattleAnim_SetBGPals:
-	ld [rBGP], a
-	ld a, [hCGB]
+	ldh [rBGP], a
+	ldh a, [hCGB]
 	and a
 	ret z
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld de, wBGPals1
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld b, a
 	ld c, 7
 	call CopyPals
 	ld hl, wOBPals2
 	ld de, wOBPals1
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld b, a
 	ld c, 2
 	call CopyPals
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 BattleAnim_SetOBPals:
-	ld [rOBP0], a
-	ld a, [hCGB]
+	ldh [rOBP0], a
+	ldh a, [hCGB]
 	and a
 	ret z
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wOBPals2 palette PAL_BATTLE_OB_GRAY
 	ld de, wOBPals1 palette PAL_BATTLE_OB_GRAY
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld b, a
 	ld c, 2
 	call CopyPals
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 BattleAnim_UpdateOAM_All:

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -978,7 +978,7 @@ BattleBGEffect_Whirlpool:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	ldh [hLCDCPointer], a
 	xor a
 	ldh [hLYOverrideStart], a
@@ -998,7 +998,7 @@ BattleBGEffect_Whirlpool:
 
 BattleBGEffect_30:
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms1
 	call EndBattleBGEffect
 	ret
@@ -1051,7 +1051,7 @@ BattleBGEffect_Psychic:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	xor a
 	ldh [hLYOverrideStart], a
@@ -1088,7 +1088,7 @@ BattleBGEffect_Teleport:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	lb de, 6, 5
 	call Functionc8f2e
@@ -1112,7 +1112,7 @@ BattleBGEffect_NightShade:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
@@ -1142,7 +1142,7 @@ BattleBGEffect_DoubleTeam:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1233,7 +1233,7 @@ BattleBGEffect_AcidArmor:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
@@ -1295,7 +1295,7 @@ BattleBGEffect_Withdraw:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1344,7 +1344,7 @@ BattleBGEffect_Dig:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1410,7 +1410,7 @@ BattleBGEffect_Tackle:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1444,7 +1444,7 @@ BattleBGEffect_25:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms2
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1575,7 +1575,7 @@ BattleBGEffect_2d:
 BGEffect2d_2f_zero:
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1618,7 +1618,7 @@ BattleBGEffect_26:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1656,7 +1656,7 @@ BattleBGEffect_2c:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1710,7 +1710,7 @@ BattleBGEffect_28:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ret
 
@@ -1752,7 +1752,7 @@ BattleBGEffect_BounceDown:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	call BattleBGEffect_SetLCDStatCustoms2
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -1909,7 +1909,7 @@ BattleBGEffect_2b:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
@@ -1950,7 +1950,7 @@ BattleBGEffect_1c:
 	call BattleBGEffects_IncrementJumptable
 	ld a, $e4
 	call BattleBGEffects_SetLYOverrides
-	ld a, rBGP - $ff00
+	ld a, LOW(rBGP)
 	ldh [hLCDCPointer], a
 	xor a
 	ldh [hLYOverrideStart], a
@@ -2175,7 +2175,7 @@ BattleBGEffect_VibrateMon:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
 	inc a
@@ -2220,7 +2220,7 @@ BattleBGEffect_WobbleMon:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	xor a
 	ldh [hLYOverrideStart], a

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -363,14 +363,14 @@ BattleBGEffect_HideMon:
 	call ClearBox
 	pop bc
 	xor a
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .four
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EndBattleBGEffect
 	ret
 
@@ -460,13 +460,13 @@ BattleBGEffect_FeetFollow:
 .okay2
 	call ClearBox
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop bc
 	ret
 
 .five
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EndBattleBGEffect
 	ret
 
@@ -527,13 +527,13 @@ BattleBGEffect_HeadFollow:
 .okay2
 	call ClearBox
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop bc
 	ret
 
 .five
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EndBattleBGEffect
 	ret
 
@@ -615,9 +615,9 @@ BattleBGEffect_27:
 	jr nz, .row2
 .okay2
 	xor a
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BattleBGEffects_IncrementJumptable
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
@@ -626,7 +626,7 @@ BattleBGEffect_27:
 
 .four
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld a, [hl]
@@ -736,7 +736,7 @@ BattleBGEffect_RunPicResizeScript:
 .skip
 	call BattleBGEffects_IncrementJumptable
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .clear
@@ -745,7 +745,7 @@ BattleBGEffect_RunPicResizeScript:
 
 .restart
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, BG_EFFECT_STRUCT_JT_INDEX
 	add hl, bc
 	ld [hl], $0
@@ -753,7 +753,7 @@ BattleBGEffect_RunPicResizeScript:
 
 .end
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EndBattleBGEffect
 	ret
 
@@ -915,7 +915,7 @@ BattleBGEffect_Surf:
 	call InitSurfWaves
 
 .one
-	ld a, [hLCDCPointer]
+	ldh a, [hLCDCPointer]
 	and a
 	ret z
 	push bc
@@ -945,7 +945,7 @@ BattleBGEffect_Surf:
 	ld hl, wSurfWaveBGEffect
 	ld bc, $0
 .loop2
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	cp e
 	jr nc, .load_zero
 	push hl
@@ -979,11 +979,11 @@ BattleBGEffect_Whirlpool:
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCY - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $5e
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	lb de, 2, 2
 	call Functionc8f2e
 	ret
@@ -1052,11 +1052,11 @@ BattleBGEffect_Psychic:
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $5f
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	lb de, 6, 5
 	call Functionc8f2e
 	ld hl, BG_EFFECT_STRUCT_03
@@ -1144,9 +1144,9 @@ BattleBGEffect_DoubleTeam:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
 	ld [hl], $0
@@ -1201,9 +1201,9 @@ BattleBGEffect_DoubleTeam:
 	inc a
 	ld d, a
 	ld h, HIGH(wLYOverridesBackup)
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	srl a
 	push af
@@ -1241,7 +1241,7 @@ BattleBGEffect_AcidArmor:
 	ld d, 2
 	call Functionc8f2e
 	ld h, HIGH(wLYOverridesBackup)
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	ld l, a
 	ld [hl], $0
 	dec l
@@ -1249,7 +1249,7 @@ BattleBGEffect_AcidArmor:
 	ret
 
 .one
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	ld l, a
 	ld h, HIGH(wLYOverridesBackup)
 	ld e, l
@@ -1259,11 +1259,11 @@ BattleBGEffect_AcidArmor:
 	ld a, [de]
 	dec de
 	ld [hld], a
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	cp l
 	jr nz, .loop
 	ld [hl], $90
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	ld l, a
 	ld a, [hl]
 	cp $1
@@ -1297,9 +1297,9 @@ BattleBGEffect_Withdraw:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCY - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
 	ld [hl], $1
@@ -1346,9 +1346,9 @@ BattleBGEffect_Dig:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCY - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
 	ld [hl], $2
@@ -1370,9 +1370,9 @@ BattleBGEffect_Dig:
 	ld [hl], $10
 	call BattleBGEffects_IncrementJumptable
 .two
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	dec a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
@@ -1412,9 +1412,9 @@ BattleBGEffect_Tackle:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
@@ -1446,9 +1446,9 @@ BattleBGEffect_25:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms2
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
@@ -1521,16 +1521,16 @@ Functionc88a5:
 	jp BGEffect_FillLYOverridesBackup
 
 .rollout
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld d, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub d
 	ld d, a
 	ld h, HIGH(wLYOverridesBackup)
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	or a
 	jr nz, .skip1
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	or a
 	jr z, .skip2
 	dec a
@@ -1539,14 +1539,14 @@ Functionc88a5:
 	jr .skip2
 
 .skip1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	dec a
 	ld l, a
 	ld [hl], $0
 .skip2
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld l, a
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	sub l
 	jr nc, .skip3
 	xor a
@@ -1577,9 +1577,9 @@ BGEffect2d_2f_zero:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
@@ -1620,9 +1620,9 @@ BattleBGEffect_26:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
@@ -1658,9 +1658,9 @@ BattleBGEffect_2c:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	xor a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
@@ -1754,9 +1754,9 @@ BattleBGEffect_BounceDown:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCY - $ff00
 	call BattleBGEffect_SetLCDStatCustoms2
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
 	ld [hl], $1
@@ -1808,14 +1808,14 @@ BattleBGEffect_2a:
 	call BattleBGEffects_SetLYOverrides
 	ld a, $47
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
-	ld a, [hLYOverrideStart]
+	ldh [hLYOverrideEnd], a
+	ldh a, [hLYOverrideStart]
 	ld l, a
 	ld h, HIGH(wLYOverridesBackup)
 .loop
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	cp l
 	jr z, .done
 	xor a
@@ -1840,9 +1840,9 @@ BattleBGEffect_2a:
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	inc a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	call BattleBGEffects_IncrementJumptable
 	ret
 
@@ -1850,7 +1850,7 @@ BattleBGEffect_2a:
 	call .GetLYOverride
 	jr nc, .finish
 	call .SetLYOverridesBackup
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	dec a
 	ld l, a
 	ld [hl], e
@@ -1862,9 +1862,9 @@ BattleBGEffect_2a:
 
 .SetLYOverridesBackup:
 	ld e, a
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	srl a
 	ld h, HIGH(wLYOverridesBackup)
@@ -1937,7 +1937,7 @@ BattleBGEffect_2b:
 	ret
 
 BattleBGEffect_1c:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	call BattleBGEffects_AnonJumptable
@@ -1951,11 +1951,11 @@ BattleBGEffect_1c:
 	ld a, $e4
 	call BattleBGEffects_SetLYOverrides
 	ld a, rBGP - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $60
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ret
 
 .one
@@ -2177,9 +2177,9 @@ BattleBGEffect_VibrateMon:
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
 	ld [hl], $1
@@ -2221,11 +2221,11 @@ BattleBGEffect_WobbleMon:
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $37
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld [hl], $0
@@ -2262,7 +2262,7 @@ BattleBGEffect_2e:
 	push af
 	call DelayFrame
 	pop af
-	ld [hSCY], a
+	ldh [hSCY], a
 	xor $ff
 	inc a
 	ld [wAnimObject01YOffset], a
@@ -2273,7 +2273,7 @@ BattleBGEffect_1f:
 	jr nc, .skip
 	xor a
 .skip
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 BattleBGEffect_20:
@@ -2281,7 +2281,7 @@ BattleBGEffect_20:
 	jr nc, .skip
 	xor a
 .skip
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 Functionc8d0b:
@@ -2330,7 +2330,7 @@ BattleBGEffect_35:
 	jr nc, .finish
 	ld d, $6
 	call BattleBGEffects_Sine
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld a, [hl]
@@ -2340,7 +2340,7 @@ BattleBGEffect_35:
 
 .finish
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 BattleBGEffect_GetNthDMGPal:
@@ -2367,7 +2367,7 @@ BattleBGEffect_GetNthDMGPal:
 	ret
 
 BGEffect_RapidCyclePals:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	push de
@@ -2387,9 +2387,9 @@ BGEffect_RapidCyclePals:
 	call BattleBGEffects_SetLYOverrides
 	ld a, $47
 	call BattleBGEffect_SetLCDStatCustoms1
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	inc a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ld hl, BG_EFFECT_STRUCT_03
 	add hl, bc
 	ld a, [hl]
@@ -2427,7 +2427,7 @@ BGEffect_RapidCyclePals:
 .two_dmg
 	call BattleBGEffects_ResetVideoHRAM
 	ld a, %11100100
-	ld [rBGP], a
+	ldh [rBGP], a
 	call EndBattleBGEffect
 	ret
 
@@ -2525,10 +2525,10 @@ BGEffect_RapidCyclePals:
 
 BGEffects_LoadBGPal0_OBPal1:
 	ld h, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, h
 	push bc
 	push af
@@ -2545,17 +2545,17 @@ BGEffects_LoadBGPal0_OBPal1:
 	call CopyPals
 	pop bc
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 BGEffects_LoadBGPal1_OBPal0:
 	ld h, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, h
 	push bc
 	push af
@@ -2572,9 +2572,9 @@ BGEffects_LoadBGPal1_OBPal0:
 	call CopyPals
 	pop bc
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 BattleBGEffect_GetFirstDMGPal:
@@ -2621,7 +2621,7 @@ BattleBGEffects_SetLYOverrides:
 	ret
 
 BattleBGEffect_SetLCDStatCustoms1:
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	call BGEffect_CheckBattleTurn
 	jr nz, .player_turn
 	lb de, $00, $36
@@ -2631,13 +2631,13 @@ BattleBGEffect_SetLCDStatCustoms1:
 	lb de, $2f, $5e
 .okay
 	ld a, d
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, e
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ret
 
 BattleBGEffect_SetLCDStatCustoms2:
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	call BGEffect_CheckBattleTurn
 	jr nz, .player_turn
 	lb de, $00, $36
@@ -2647,30 +2647,30 @@ BattleBGEffect_SetLCDStatCustoms2:
 	lb de, $2d, $5e
 .okay
 	ld a, d
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, e
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ret
 
 BattleAnim_ResetLCDStatCustom:
 	xor a
-	ld [hLYOverrideStart], a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideStart], a
+	ldh [hLYOverrideEnd], a
 	call BattleBGEffects_ClearLYOverrides
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	call EndBattleBGEffect
 	ret
 
 BattleBGEffects_ResetVideoHRAM:
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ld a, %11100100
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld [wBGP], a
 	ld [wOBP1], a
-	ld [hLYOverrideStart], a
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideStart], a
+	ldh [hLYOverrideEnd], a
 	call BattleBGEffects_ClearLYOverrides
 	ret
 
@@ -2686,10 +2686,10 @@ Functionc8f2e:
 	ld [wBattleAnimTemp3], a
 	ld bc, wLYOverridesBackup
 .loop
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	cp c
 	jr nc, .next
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	cp c
 	jr c, .next
 	ld a, [wBattleAnimTemp2]
@@ -2763,14 +2763,14 @@ Functionc8f9a:
 	call BattleBGEffects_Sine
 	ld e, a
 	pop hl
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	cp c
 	jr c, .skip1
 	ld a, e
 	ld [bc], a
 	inc bc
 .skip1
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	cp l
 	jr nc, .skip2
 	ld [hl], e
@@ -2788,7 +2788,7 @@ Functionc8f9a:
 	ret
 
 .GetLYOverrideBackupAddrOffset:
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld e, a
 	ld a, [wBattleAnimTemp0]
 	add e
@@ -2798,13 +2798,13 @@ Functionc8f9a:
 
 BattleBGEffect_WavyScreenFX:
 	push bc
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
 	inc a
 	ld e, a
 	ld h, HIGH(wLYOverridesBackup)
 	ld d, h
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	and a
 	jr z, .done
@@ -2826,9 +2826,9 @@ BattleBGEffect_WavyScreenFX:
 BGEffect_FillLYOverridesBackup:
 	push af
 	ld h, HIGH(wLYOverridesBackup)
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	ld d, a
 	pop af
@@ -2842,14 +2842,14 @@ BGEffect_DisplaceLYOverridesBackup:
 	; e = a; d = [hLYOverrideEnd] - [hLYOverrideStart] - a
 	push af
 	ld e, a
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
-	ld a, [hLYOverrideEnd]
+	ldh a, [hLYOverrideEnd]
 	sub l
 	sub e
 	ld d, a
 	ld h, HIGH(wLYOverridesBackup)
-	ld a, [hLYOverrideStart]
+	ldh a, [hLYOverrideStart]
 	ld l, a
 	ld a, $90
 .loop
@@ -2867,7 +2867,7 @@ BGEffect_DisplaceLYOverridesBackup:
 BGEffect_CheckBattleTurn:
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and $1
 	xor [hl]
 	ret
@@ -2875,7 +2875,7 @@ BGEffect_CheckBattleTurn:
 BGEffect_CheckFlyDigStatus:
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
 	add hl, bc
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and $1
 	xor [hl]
 	jr nz, .player
@@ -2889,7 +2889,7 @@ BGEffect_CheckFlyDigStatus:
 	ret
 
 BattleBGEffects_CheckSGB:
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret
 

--- a/engine/battle_anims/core.asm
+++ b/engine/battle_anims/core.asm
@@ -217,7 +217,7 @@ InitBattleAnimBuffer:
 	ld [wBattleAnimTempXOffset], a
 	ld a, [hli]
 	ld [wBattleAnimTempYOffset], a
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ret z
 	ld hl, BATTLEANIMSTRUCT_01

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -425,14 +425,14 @@ BattleAnimFunction_PokeBallBlocked:
 
 GetBallAnimPal:
 	ld hl, BallColors
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurItem)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wCurItem]
 	ld e, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .IsInArray:
 	ld a, [hli]
 	cp -1
@@ -1138,11 +1138,11 @@ BattleAnimFunction_0D:
 .zero
 	call BattleAnim_IncAnonJumptableIndex
 	ld a, rSCY - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ld a, $58
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld a, $5e
-	ld [hLYOverrideEnd], a
+	ldh [hLYOverrideEnd], a
 	ret
 
 .one
@@ -1156,7 +1156,7 @@ BattleAnimFunction_0D:
 	jr nc, .asm_cd69b
 	call BattleAnim_IncAnonJumptableIndex
 	xor a
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ret
 
 .asm_cd69b
@@ -1175,7 +1175,7 @@ BattleAnimFunction_0D:
 	add [hl]
 	sub $10
 	ret c
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ld hl, BATTLEANIMSTRUCT_XOFFSET
 	add hl, bc
 	ld a, [hl]
@@ -1196,9 +1196,9 @@ BattleAnimFunction_0D:
 	cp $70
 	jr c, asm_cd6da
 	xor a
-	ld [hLCDCPointer], a
-	ld [hLYOverrideStart], a
-	ld [hLYOverrideEnd], a
+	ldh [hLCDCPointer], a
+	ldh [hLYOverrideStart], a
+	ldh [hLYOverrideEnd], a
 .four
 	call DeinitBattleAnimation
 	ret
@@ -1209,7 +1209,7 @@ asm_cd6da:
 	ld [hl], a
 	sub $10
 	ret c
-	ld [hLYOverrideStart], a
+	ldh [hLYOverrideStart], a
 	ret
 
 BattleAnimFunction_0E:
@@ -2252,7 +2252,7 @@ BattleAnimFunction_21:
 	dw Functioncdced
 
 Functioncdcca:
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .asm_cdcd9
 	ld hl, BATTLEANIMSTRUCT_0B
@@ -3227,7 +3227,7 @@ BattleAnimFunction_32:
 
 Functionce260:
 	call BattleAnim_IncAnonJumptableIndex
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .asm_ce26c
 	ld a, $f0
@@ -3280,7 +3280,7 @@ Functionce29f:
 	srl a
 	ld e, a
 	ld d, $0
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	jr nz, .asm_ce2b6
 	ld hl, Unknown_ce2c4

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -1619,7 +1619,7 @@ Functioncd913:
 	ld hl, BATTLEANIMSTRUCT_10
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM ; $ff80
+	ld hl, hTransferVirtualOAM
 	add hl, de
 	ld e, l
 	ld d, h
@@ -2116,7 +2116,7 @@ asm_cdbfa:
 	ld hl, BATTLEANIMSTRUCT_0F
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM ; $ff80
+	ld hl, hTransferVirtualOAM
 	add hl, de
 	ld e, l
 	ld d, h
@@ -3356,7 +3356,7 @@ Functionce306:
 	ld hl, BATTLEANIMSTRUCT_0F
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM ; $ff80
+	ld hl, hTransferVirtualOAM
 	add hl, de
 	ld e, l
 	ld d, h

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -1619,7 +1619,7 @@ Functioncd913:
 	ld hl, BATTLEANIMSTRUCT_10
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM
+	ld hl, -$80
 	add hl, de
 	ld e, l
 	ld d, h
@@ -2116,7 +2116,7 @@ asm_cdbfa:
 	ld hl, BATTLEANIMSTRUCT_0F
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM
+	ld hl, -$80
 	add hl, de
 	ld e, l
 	ld d, h
@@ -3356,7 +3356,7 @@ Functionce306:
 	ld hl, BATTLEANIMSTRUCT_0F
 	add hl, bc
 	ld e, [hl]
-	ld hl, hTransferVirtualOAM
+	ld hl, -$80
 	add hl, de
 	ld e, l
 	ld d, h

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -1137,7 +1137,7 @@ BattleAnimFunction_0D:
 	dw .four
 .zero
 	call BattleAnim_IncAnonJumptableIndex
-	ld a, rSCY - $ff00
+	ld a, LOW(rSCY)
 	ldh [hLCDCPointer], a
 	ld a, $58
 	ldh [hLYOverrideStart], a

--- a/engine/battle_anims/pokeball_wobble.asm
+++ b/engine/battle_anims/pokeball_wobble.asm
@@ -4,12 +4,12 @@ GetPokeBallWobble:
 
 	push de
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	ld d, a
 	push de
 
 	ld a, BANK(wBuffer2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, [wBuffer2]
 	inc a
@@ -54,7 +54,7 @@ GetPokeBallWobble:
 	pop de
 	ld e, a
 	ld a, d
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, e
 	pop de
 	ret

--- a/engine/events/battle_tower/battle_tower.asm
+++ b/engine/events/battle_tower/battle_tower.asm
@@ -10,10 +10,10 @@ Function1700ba:
 	ret
 
 Function1700c4:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call Function17042c
 
@@ -47,7 +47,7 @@ Function1700c4:
 	call CopyBytes
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function170114:
@@ -556,10 +556,10 @@ INCLUDE "data/battle_tower/unknown_levels.asm"
 
 CopyBTTrainer_FromBT_OT_TowBT_OTTemp:
 ; copy the BattleTower-Trainer data that lies at 'wBT_OTTrainer' to 'wBT_OTTemp'
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBT_OTTrainer)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBT_OTTrainer
 	ld de, wBT_OTTemp
@@ -567,7 +567,7 @@ CopyBTTrainer_FromBT_OT_TowBT_OTTemp:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, BANK(sBattleTowerChallengeState)
 	call GetSRAMBank
@@ -982,7 +982,7 @@ BattleTower_RandomlyChooseReward: ; BattleTowerAction $1e
 ; Generate a random stat boosting item.
 .loop
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $7
 	cp 6
 	jr c, .okay
@@ -1153,28 +1153,28 @@ Function17081d: ; BattleTowerAction $17
 SaveBattleTowerLevelGroup: ; BattleTowerAction $07
 	ld a, BANK(sBTChoiceOfLevelGroup)
 	call GetSRAMBank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wBTChoiceOfLvlGroup]
 	ld [sBTChoiceOfLevelGroup], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	ret
 
 LoadBattleTowerLevelGroup: ; BattleTowerAction $08 ; Load level group choice
 	ld a, BANK(sBTChoiceOfLevelGroup)
 	call GetSRAMBank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [sBTChoiceOfLevelGroup]
 	ld [wBTChoiceOfLvlGroup], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	ret
 
@@ -1336,14 +1336,14 @@ String_MysteryJP:
 	db "なぞナゾ@@" ; MYSTERY
 
 Function1709aa: ; BattleTowerAction $0f
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(w3_d090)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [w3_d090]
 	ld [wScriptVar], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function1709bb: ; BattleTowerAction $10
@@ -1557,17 +1557,17 @@ BattleTowerAction_UbersCheck: ; BattleTowerAction $19
 
 LoadOpponentTrainerAndPokemonWithOTSprite:
 	farcall Function_LoadOpponentTrainerAndPokemons
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBT_OTTrainerClass
 	ld a, [hl]
 	dec a
 	ld c, a
 	ld b, $0
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, BTTrainerClassSprites
 	add hl, bc
 	ld a, [hl]
@@ -1593,9 +1593,9 @@ LoadOpponentTrainerAndPokemonWithOTSprite:
 	ld hl, wUsedSprites
 	add hl, de
 	ld [hli], a
-	ld [hUsedSpriteIndex], a
+	ldh [hUsedSpriteIndex], a
 	ld a, [hl]
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 	farcall GetUsedSprite
 	ret
 

--- a/engine/events/battle_tower/load_trainer.asm
+++ b/engine/events/battle_tower/load_trainer.asm
@@ -1,8 +1,8 @@
 Function_LoadOpponentTrainerAndPokemons:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBT_OTTrainer)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	; Fill wBT_OTTrainer with zeros
 	xor a
@@ -19,11 +19,11 @@ Function_LoadOpponentTrainerAndPokemons:
 	; Set wBT_OTTrainer as start address to write the following data to
 	ld de, wBT_OTTrainer
 
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	ld b, a
 .resample ; loop to find a random trainer
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	add b
 	ld b, a ; b contains the nr of the trainer
 if DEF(_CRYSTAL11)
@@ -87,7 +87,7 @@ endc
 	jr nz, .copy_bt_trainer_data_loop
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ret
 
@@ -107,11 +107,11 @@ Function_LoadRandomBattleTowerMon:
 	ld bc, BattleTowerMons2 - BattleTowerMons1 ; size of one level group
 	call AddNTimes
 
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	ld b, a
 .resample
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	add b
 	ld b, a
 	maskbits BATTLETOWER_NUM_UNIQUE_MON

--- a/engine/events/battle_tower/trainer_text.asm
+++ b/engine/events/battle_tower/trainer_text.asm
@@ -3,10 +3,10 @@ BattleTowerText::
 ; 1: Intro text
 ; 2: Player lost
 ; 3: Player won
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBT_OTTrainerClass)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 if DEF(_CRYSTAL11)
 	ld hl, wBT_OTTrainerClass
 else
@@ -28,7 +28,7 @@ endc
 	and a
 	jr nz, .female
 	; generate a random number between 0 and 24
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $1f
 	cp 25
 	jr c, .okay0
@@ -40,7 +40,7 @@ endc
 
 .female
 	; generate a random number between 0 and 14
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $f
 	cp 15
 	jr c, .okay1
@@ -80,7 +80,7 @@ endc
 	ld h, a
 	bccoord 1, 14
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call PlaceHLTextAtBC
 	ret
 

--- a/engine/events/buena.asm
+++ b/engine/events/buena.asm
@@ -188,7 +188,7 @@ PrintBlueCardBalance:
 .DrawBox:
 	push de
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, BlueCardBalanceMenuHeader
 	call CopyMenuHeader
 	call MenuBox
@@ -232,7 +232,7 @@ Buena_PrizeMenu:
 	ld [wMenuCursorBuffer], a
 	xor a
 	ld [wWhichIndexSet], a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call InitScrollingMenu
 	call UpdateSprites
 	call ScrollingMenu

--- a/engine/events/buena_menu.asm
+++ b/engine/events/buena_menu.asm
@@ -43,16 +43,16 @@ AskRememberPassword:
 	ret
 
 Buena_ExitMenu:
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	call ExitMenu
 	call UpdateSprites
 	xor a
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call DelayFrame
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call ApplyTilemap
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret

--- a/engine/events/bug_contest/judging.asm
+++ b/engine/events/bug_contest/judging.asm
@@ -150,9 +150,9 @@ BugContest_JudgeContestants:
 	ld [hli], a
 	ld a, [wContestMon]
 	ld [hli], a
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	ld [hli], a
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld [hl], a
 	call DetermineContestWinners
 	ret
@@ -287,8 +287,8 @@ ContestScore:
 ; Determine the player's score in the Bug Catching Contest.
 
 	xor a
-	ld [hProduct], a
-	ld [hMultiplicand], a
+	ldh [hProduct], a
+	ldh [hMultiplicand], a
 
 	ld a, [wContestMonSpecies] ; Species
 	and a

--- a/engine/events/catch_tutorial.asm
+++ b/engine/events/catch_tutorial.asm
@@ -31,8 +31,8 @@ CatchTutorial::
 	call .LoadDudeData
 
 	xor a
-	ld [hJoyDown], a
-	ld [hJoyPressed], a
+	ldh [hJoyDown], a
+	ldh [hJoyPressed], a
 	ld a, [wOptions]
 	push af
 	and $f8

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -656,11 +656,11 @@ DayCare_InitBreeding:
 	ld d, a
 	callfar CalcExpAtLevel
 	ld hl, wEggMonExp
-	ld a, [hMultiplicand]
+	ldh a, [hMultiplicand]
 	ld [hli], a
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	ld [hli], a
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	ld [hl], a
 	xor a
 	ld b, wEggMonDVs - wEggMonStatExp

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -62,7 +62,7 @@ ShakeHeadbuttTree:
 	call OverworldTextModeSwitch
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall ClearSpriteAnims
 	ld hl, wVirtualOAMSprite36
 	ld bc, wVirtualOAMEnd - wVirtualOAMSprite36
@@ -80,7 +80,7 @@ INCBIN "gfx/overworld/headbutt_tree.2bpp"
 
 HideHeadbuttTree:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wPlayerDirection]
 	and %00001100
 	srl a
@@ -101,7 +101,7 @@ HideHeadbuttTree:
 	ld [hld], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 TreeRelativeLocationTable:
@@ -205,7 +205,7 @@ Cut_SpawnAnimateLeaves:
 
 Cut_StartWaiting:
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 ; Cut_WaitAnimSFX
 	ld hl, wJumptableIndex
 	inc [hl]

--- a/engine/events/fishing_gfx.asm
+++ b/engine/events/fishing_gfx.asm
@@ -1,8 +1,8 @@
 LoadFishingGFX:
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld de, FishingGFX
 	ld a, [wPlayerGender]
@@ -21,7 +21,7 @@ LoadFishingGFX:
 	call .LoadGFX
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 .LoadGFX:

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -44,7 +44,7 @@ RedCredits::
 	farcall FadeOutPalettes
 	xor a
 	ld [wVramState], a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	farcall InitDisplayForRedCredits
 	ld c, 8
 	call DelayFrames
@@ -66,7 +66,7 @@ HallOfFame_FadeOutMusic:
 	farcall FadeOutPalettes
 	xor a
 	ld [wVramState], a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	farcall InitDisplayForHallOfFame
 	ld c, 100
 	jp DelayFrames
@@ -243,17 +243,17 @@ AnimateHOFMonEntrance:
 	ld de, vTiles2 tile $31
 	predef GetMonBackpic
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 6, 6
 	lb bc, 6, 6
 	predef PlaceGraphic
 	ld a, $d0
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $90
-	ld [hSCX], a
+	ldh [hSCX], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld b, SCGB_PLAYER_OR_MON_FRONTPIC_PALS
 	call GetSGBLayout
 	call SetPalettes
@@ -268,29 +268,29 @@ AnimateHOFMonEntrance:
 	call _PrepMonFrontpic
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
-	ld [hSCY], a
+	ldh [hBGMapMode], a
+	ldh [hSCY], a
 	call HOF_SlideFrontpic
 	ret
 
 HOF_SlideBackpic:
 .backpicloop
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	cp $70
 	ret z
 	add $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	jr .backpicloop
 
 HOF_SlideFrontpic:
 .frontpicloop
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	and a
 	ret z
 	dec a
 	dec a
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	jr .frontpicloop
 
@@ -432,7 +432,7 @@ LoadHOFTeam:
 
 DisplayHOFMon:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [hli]
 	ld [wTempMonSpecies], a
 	ld a, [hli]
@@ -528,17 +528,17 @@ HOF_AnimatePlayerPic:
 	call ByteFill
 	farcall GetPlayerBackpic
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 6, 6
 	lb bc, 6, 6
 	predef PlaceGraphic
 	ld a, $d0
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $90
-	ld [hSCX], a
+	ldh [hSCX], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wCurPartySpecies], a
 	ld b, SCGB_PLAYER_OR_MON_FRONTPIC_PALS
 	call GetSGBLayout
@@ -552,19 +552,19 @@ HOF_AnimatePlayerPic:
 	call ByteFill
 	farcall HOF_LoadTrainerFrontpic
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 12, 5
 	lb bc, 7, 7
 	predef PlaceGraphic
 	ld a, $c0
-	ld [hSCX], a
+	ldh [hSCX], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
-	ld [hSCY], a
+	ldh [hBGMapMode], a
+	ldh [hSCY], a
 	call HOF_SlideFrontpic
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 2
 	lb bc, 8, 9
 	call TextBox

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -18,7 +18,7 @@ HealMachineAnim:
 	; 2: Up (Hall of Fame)
 	ld a, [wScriptVar]
 	ld [wBuffer1], a
-	ld a, [rOBP1]
+	ldh a, [rOBP1]
 	ld [wBuffer2], a
 	call .DoJumptableFunctions
 	ld a, [wBuffer2]
@@ -158,7 +158,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 	call IsCGB
 	jr nz, .cgb
 	ld a, %11100000
-	ld [rOBP1], a
+	ldh [rOBP1], a
 	ret
 
 .cgb
@@ -168,7 +168,7 @@ INCBIN "gfx/overworld/heal_machine.2bpp"
 	ld a, BANK(wOBPals2)
 	call FarCopyWRAM
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .palettes
@@ -189,16 +189,16 @@ INCLUDE "gfx/overworld/heal_machine.pal"
 .FlashPalettes:
 	call IsCGB
 	jr nz, .go
-	ld a, [rOBP1]
+	ldh a, [rOBP1]
 	xor %00101000
-	ld [rOBP1], a
+	ldh [rOBP1], a
 	ret
 
 .go
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wOBPals2 palette PAL_OW_TREE
 	ld a, [hli]
@@ -230,9 +230,9 @@ INCLUDE "gfx/overworld/heal_machine.pal"
 	ld [hl], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .PlaceHealingMachineTile:

--- a/engine/events/kurt.asm
+++ b/engine/events/kurt.asm
@@ -59,7 +59,7 @@ Kurt_SelectApricorn:
 	ld a, [wMenuSelection]
 	ld [wMenuCursorBuffer], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call InitScrollingMenu
 	call UpdateSprites
 	call ScrollingMenu
@@ -124,7 +124,7 @@ Kurt_SelectQuantity:
 	call LoadMenuHeader
 .loop
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call UpdateSprites
 	call .PlaceApricornName

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -198,30 +198,30 @@ CalcMagikarpLength:
 	; c = (bc - de) / [hl]
 	call .BCMinusDE
 	ld a, b
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, c
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, [hl]
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld c, a
 
 	; de = c + 100 × (2 + i)
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, 100
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [wTempByteValue]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	ld b, 0
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	add c
 	ld e, a
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	adc b
 	ld d, a
 	jr .done

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -242,7 +242,7 @@ MagnetTrain_InitLYOverrides:
 	ld bc, wLYOverridesBackupEnd - wLYOverridesBackup
 	ld a, [wMagnetTrainInitPosition]
 	call ByteFill
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	ret
 

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -14,10 +14,10 @@ MagnetTrain:
 
 .continue
 	ld h, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wMagnetTrain)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, h
 	ld [wMagnetTrainDirection], a
@@ -30,9 +30,9 @@ MagnetTrain:
 	ld a, d
 	ld [wMagnetTrainPlayerSpriteInitX], a
 
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	push af
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	push af
 	call MagntTrain_LoadGFX_PlayMusic
 	ld hl, hVBlank
@@ -58,13 +58,13 @@ MagnetTrain:
 
 .done
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call ClearBGPalettes
 	xor a
-	ld [hLCDCPointer], a
-	ld [hLYOverrideStart], a
-	ld [hLYOverrideEnd], a
-	ld [hSCX], a
+	ldh [hLCDCPointer], a
+	ldh [hLYOverrideStart], a
+	ldh [hLYOverrideEnd], a
+	ldh [hSCX], a
 	ld [wRequested2bppSource], a
 	ld [wRequested2bppSource + 1], a
 	ld [wRequested2bppDest], a
@@ -73,13 +73,13 @@ MagnetTrain:
 	call ClearTileMap
 
 	pop af
-	ld [hSCY], a
+	ldh [hSCY], a
 	pop af
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 MagnetTrain_UpdateLYOverrides:
@@ -87,7 +87,7 @@ MagnetTrain_UpdateLYOverrides:
 	ld c, $2f
 	ld a, [wMagnetTrainOffset]
 	add a
-	ld [hSCX], a
+	ldh [hSCX], a
 	call .loadloop
 	ld c, $30
 	ld a, [wMagnetTrainPosition]
@@ -119,19 +119,19 @@ MagntTrain_LoadGFX_PlayMusic:
 	call SetMagnetTrainPals
 	call DrawMagnetTrain
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call EnableLCD
 	xor a
-	ld [hBGMapMode], a
-	ld [hSCX], a
-	ld [hSCY], a
-	ld a, [rSVBK]
+	ldh [hBGMapMode], a
+	ldh [hSCX], a
+	ldh [hSCY], a
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPlayerGender)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall GetPlayerIcon
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, vTiles0
 	ld c, 4
 	call Request2bpp
@@ -243,12 +243,12 @@ MagnetTrain_InitLYOverrides:
 	ld a, [wMagnetTrainInitPosition]
 	call ByteFill
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ret
 
 SetMagnetTrainPals:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	; bushes
 	hlbgcoord 0, 0
@@ -275,7 +275,7 @@ SetMagnetTrainPals:
 	call ByteFill
 
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 MagnetTrain_Jumptable:
@@ -309,10 +309,10 @@ MagnetTrain_Jumptable:
 	ld a, [wMagnetTrainPlayerSpriteInitX]
 	ld e, a
 	ld b, SPRITE_ANIM_INDEX_MAGNET_TRAIN_RED
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPlayerGender)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wPlayerGender]
 	bit PLAYERGENDER_FEMALE_F, a
 	jr z, .got_gender
@@ -320,7 +320,7 @@ MagnetTrain_Jumptable:
 
 .got_gender
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, b
 	call _InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
@@ -408,10 +408,10 @@ MagnetTrain_Jumptable_FirstRunThrough:
 	call MagnetTrain_UpdateLYOverrides
 	call PushLYOverrides
 	call DelayFrame
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wEnvironment)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wTimeOfDayPal]
 	push af
 	ld a, [wEnvironment]
@@ -424,18 +424,18 @@ MagnetTrain_Jumptable_FirstRunThrough:
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
 	call UpdateTimePals
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld [wBGP], a
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld [wOBP0], a
-	ld a, [rOBP1]
+	ldh a, [rOBP1]
 	ld [wOBP1], a
 	pop af
 	ld [wEnvironment], a
 	pop af
 	ld [wTimeOfDayPal], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 MagnetTrainTilemap1:

--- a/engine/events/map_name_sign.asm
+++ b/engine/events/map_name_sign.asm
@@ -2,7 +2,7 @@ MAP_NAME_SIGN_START EQU $60
 
 ReturnFromMapSetupScript::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall .inefficient_farcall ; this is a waste of 6 ROM bytes and 6 stack bytes
 	ret
 
@@ -51,10 +51,10 @@ ReturnFromMapSetupScript::
 	ld a, [wCurrentLandmark]
 	ld [wPreviousLandmark], a
 	ld a, $90
-	ld [rWY], a
-	ld [hWY], a
+	ldh [rWY], a
+	ldh [hWY], a
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ret
 
 .CheckMovingWithinLandmark:
@@ -112,16 +112,16 @@ PlaceMapNameSign::
 .skip2
 	ld a, $80
 	ld a, $70
-	ld [rWY], a
-	ld [hWY], a
+	ldh [rWY], a
+	ldh [hWY], a
 	ret
 
 .disappear
 	ld a, $90
-	ld [rWY], a
-	ld [hWY], a
+	ldh [rWY], a
+	ldh [hWY], a
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ret
 
 LoadMapNameSignGFX:

--- a/engine/events/mom.asm
+++ b/engine/events/mom.asm
@@ -1,8 +1,8 @@
 BankOfMom:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
 	ld [wJumptableIndex], a
 .loop
@@ -14,7 +14,7 @@ BankOfMom:
 
 .done
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 .RunJumptable:
@@ -295,7 +295,7 @@ DSTChecks:
 ; check the time; avoid changing DST if doing so would change the current day
 	ld a, [wDST]
 	bit 7, a
-	ld a, [hHours]
+	ldh a, [hHours]
 	jr z, .NotDST
 	and a ; within one hour of 00:00?
 	jr z, .LostBooklet
@@ -429,7 +429,7 @@ Mom_SetUpDepositMenu:
 Mom_ContinueMenuSetup:
 	push de
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	lb bc, 6, 18
 	call TextBox
@@ -475,7 +475,7 @@ Mom_WithdrawDepositMenuJoypad:
 	jr nz, .pressedA
 	call .dpadaction
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 12, 6
 	ld bc, 7
 	ld a, " "
@@ -484,7 +484,7 @@ Mom_WithdrawDepositMenuJoypad:
 	ld de, wStringBuffer2
 	lb bc, PRINTNUM_MONEY | PRINTNUM_LEADINGZEROS | 3, 6
 	call PrintNum
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and $10
 	jr nz, .skip
 	hlcoord 13, 6

--- a/engine/events/mom_phone.asm
+++ b/engine/events/mom_phone.asm
@@ -61,11 +61,11 @@ CheckBalance_MomItem2:
 	jr nc, .nope
 	call GetItemFromMom
 	ld a, [hli]
-	ld [hMoneyTemp], a
+	ldh [hMoneyTemp], a
 	ld a, [hli]
-	ld [hMoneyTemp + 1], a
+	ldh [hMoneyTemp + 1], a
 	ld a, [hli]
-	ld [hMoneyTemp + 2], a
+	ldh [hMoneyTemp + 2], a
 	ld de, wMomsMoney
 	ld bc, hMoneyTemp
 	farcall CompareMoney
@@ -118,11 +118,11 @@ MomBuysItem_DeductFunds:
 	ld de, 3 ; cost
 	add hl, de
 	ld a, [hli]
-	ld [hMoneyTemp], a
+	ldh [hMoneyTemp], a
 	ld a, [hli]
-	ld [hMoneyTemp + 1], a
+	ldh [hMoneyTemp + 1], a
 	ld a, [hli]
-	ld [hMoneyTemp + 2], a
+	ldh [hMoneyTemp + 2], a
 	ld de, wMomsMoney
 	ld bc, hMoneyTemp
 	farcall TakeMoney

--- a/engine/events/odd_egg.asm
+++ b/engine/events/odd_egg.asm
@@ -23,13 +23,13 @@ _GiveOddEgg:
 .not_done
 
 	; Break when [hRandom] <= de.
-	ld a, [hRandom + 1]
+	ldh a, [hRandom + 1]
 	cp d
 	jr c, .done
 	jr z, .ok
 	jr .next
 .ok
-	ld a, [hRandom + 0]
+	ldh a, [hRandom + 0]
 	cp e
 	jr c, .done
 	jr z, .done

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -226,7 +226,7 @@ CutDownTreeOrGrass:
 	ld a, [wBuffer5] ; ReplacementTile
 	ld [hl], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call OverworldTextModeSwitch
 	call UpdateSprites
 	call DelayFrame
@@ -575,7 +575,7 @@ FlyFunction:
 
 .outdoors
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call LoadStandardMenuHeader
 	call ClearSprites
 	farcall _FlyMap
@@ -1199,7 +1199,7 @@ DisappearWhirlpool:
 	ld a, [wBuffer5]
 	ld [hl], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call OverworldTextModeSwitch
 	ld a, [wBuffer6]
 	ld e, a
@@ -1360,12 +1360,12 @@ GetFacingObject:
 	farcall CheckFacingObject
 	jr nc, .fail
 
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	call GetObjectStruct
 	ld hl, OBJECT_MAP_OBJECT_INDEX
 	add hl, bc
 	ld a, [hl]
-	ld [hLastTalked], a
+	ldh [hLastTalked], a
 	call GetMapObject
 	ld hl, MAPOBJECT_MOVEMENT
 	add hl, bc
@@ -1623,7 +1623,7 @@ MovementData_0xd093:
 
 PutTheRodAway:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
 	ld [wPlayerAction], a
 	call UpdateSprites

--- a/engine/events/poisonstep_pals.asm
+++ b/engine/events/poisonstep_pals.asm
@@ -1,12 +1,12 @@
 LoadPoisonBGPals:
 	call .LoadPals
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret nz
 	ret ; ????
 
 .LoadPals:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	ld a, [wTimeOfDayPal]
@@ -24,10 +24,10 @@ LoadPoisonBGPals:
 	ret
 
 .cgb
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld c, 4 palettes
 .loop
@@ -38,9 +38,9 @@ LoadPoisonBGPals:
 	dec c
 	jr nz, .loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ld c, 4
 	call DelayFrames
 	farcall _UpdateTimePals

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -10,7 +10,7 @@ PokemonCenterPC:
 	call LoadMenuHeader
 .loop
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .ChooseWhichPCListToUse
 	ld [wWhichIndexSet], a
 	call DoNthMenu
@@ -360,7 +360,7 @@ PlayerWithdrawItemMenu:
 	ld hl, .WithdrewText
 	call MenuTextBox
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ExitMenu
 	ret
 

--- a/engine/events/pokepic.asm
+++ b/engine/events/pokepic.asm
@@ -7,7 +7,7 @@ Pokepic::
 	ld b, SCGB_POKEPIC
 	call GetSGBLayout
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wCurPartySpecies]
 	ld [wCurSpecies], a
 	call GetBaseData
@@ -21,7 +21,7 @@ Pokepic::
 	ld c, a
 	call Coord2Tile
 	ld a, $80
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	call WaitBGMap
@@ -34,7 +34,7 @@ ClosePokepic::
 	call WaitBGMap
 	call GetMemSGBLayout
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call OverworldTextModeSwitch
 	call ApplyTilemap
 	call UpdateSprites

--- a/engine/events/pokerus/pokerus.asm
+++ b/engine/events/pokerus/pokerus.asm
@@ -22,10 +22,10 @@ GivePokerusAndConvertBerries:
 	bit STATUSFLAGS2_REACHED_GOLDENROD_F, [hl]
 	ret z
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and a
 	ret nz
-	ld a, [hRandomSub]
+	ldh a, [hRandomSub]
 	cp $3
 	ret nc                 ; 3/65536 chance (00 00, 00 01 or 00 02)
 	ld a, [wPartyCount]

--- a/engine/events/print_photo.asm
+++ b/engine/events/print_photo.asm
@@ -12,7 +12,7 @@ PhotoStudio:
 	call DisableSpriteUpdates
 	farcall PrintPartymon
 	call ReturnToMapWithSpeechTextbox
-	ld a, [hPrinter]
+	ldh a, [hPrinter]
 	and a
 	jr nz, .cancel
 	ld hl, .Text_Presto

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -6,10 +6,10 @@ _UnownPrinter:
 	and a
 	ret z
 
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ld a, [wOptions]
 	push af
 	set NO_TEXT_SCROLL, a
@@ -69,11 +69,11 @@ _UnownPrinter:
 .joy_loop
 	call JoyTextDelay
 
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and B_BUTTON
 	jr nz, .pressed_b
 
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jr nz, .pressed_a
 
@@ -94,15 +94,15 @@ _UnownPrinter:
 	pop af
 	ld [wOptions], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call ReturnToMapFromSubmenu
 	ret
 
 .LeftRight:
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_RIGHT
 	jr nz, .press_right
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_LEFT
 	jr nz, .press_left
 	ret
@@ -145,7 +145,7 @@ _UnownPrinter:
 	call .Load2bppToSRAM
 	hlcoord 1, 6
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	ld de, vTiles2 tile $31
@@ -153,23 +153,23 @@ _UnownPrinter:
 	ret
 
 .Load2bppToSRAM:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, BANK(sScratch)
 	call GetSRAMBank
 	ld de, wDecompressScratch
 	ld hl, sScratch
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	ld c, $31
 	call Get2bpp
 	call CloseSRAM
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .vacant
@@ -188,7 +188,7 @@ _UnownPrinter:
 	ld hl, vTiles2 tile $31
 	ld de, sScratch
 	ld c, $31
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	call CloseSRAM
@@ -224,7 +224,7 @@ PlaceUnownPrinterFrontpic:
 	call ByteFill
 	hlcoord 7, 11
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	ret

--- a/engine/events/print_unown_2.asm
+++ b/engine/events/print_unown_2.asm
@@ -37,7 +37,7 @@ RotateUnownFrontpic:
 	pop hl
 	ld de, sScratch
 	ld c, 7 * 7
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	call CloseSRAM

--- a/engine/events/specials.asm
+++ b/engine/events/specials.asm
@@ -380,11 +380,11 @@ PlayCurMonCry:
 	jp PlayMonCry
 
 GameboyCheck:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	jr nz, .sgb
 

--- a/engine/events/treemons.asm
+++ b/engine/events/treemons.asm
@@ -242,34 +242,34 @@ GetTreeScore:
 	add hl, bc
 
 	ld a, h
-	ld [hDividend], a
+	ldh [hDividend], a
 	ld a, l
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, 5
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
 
-	ld a, [hQuotient + 1]
-	ld [hDividend], a
-	ld a, [hQuotient + 2]
-	ld [hDividend + 1], a
+	ldh a, [hQuotient + 1]
+	ldh [hDividend], a
+	ldh a, [hQuotient + 2]
+	ldh [hDividend + 1], a
 	ld a, 10
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
 
-	ld a, [hQuotient + 3]
+	ldh a, [hQuotient + 3]
 	ret
 
 .OTIDScore:
 	ld a, [wPlayerID]
-	ld [hDividend], a
+	ldh [hDividend], a
 	ld a, [wPlayerID + 1]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, 10
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 3]
+	ldh a, [hQuotient + 3]
 	ret

--- a/engine/events/unown_walls.asm
+++ b/engine/events/unown_walls.asm
@@ -115,7 +115,7 @@ DisplayUnownWords:
 .load
 	call LoadMenuHeader
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call UpdateSprites
 	call ApplyTilemap

--- a/engine/games/card_flip.asm
+++ b/engine/games/card_flip.asm
@@ -147,10 +147,10 @@ _CardFlip:
 	ld de, SFX_TRANSACTION
 	call PlaySFX
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CardFlip_PrintCoinBalance
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitSFX
 	call .Increment
 	ret
@@ -162,7 +162,7 @@ _CardFlip:
 
 .ChooseACard:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	lb bc, 12, 9
 	call CardFlip_FillGreenBox
@@ -172,13 +172,13 @@ _CardFlip:
 	call AddNTimes
 	ld [hl], CARDFLIP_LIGHT_ON
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 20
 	call DelayFrames
 	hlcoord 2, 0
 	call PlaceCardFaceDown
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 20
 	call DelayFrames
 	hlcoord 2, 6
@@ -190,7 +190,7 @@ _CardFlip:
 	ld [wCardFlipWhichCard], a
 .loop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and A_BUTTON
 	jr nz, .next
 	ld de, SFX_KINESIS
@@ -242,7 +242,7 @@ _CardFlip:
 	call CardFlip_UpdateCoinBalanceDisplay
 .betloop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and A_BUTTON
 	jr nz, .betdone
 	call ChooseCard_HandleJoypad
@@ -261,7 +261,7 @@ _CardFlip:
 
 .CheckTheCard:
 	xor a
-	ld [hVBlankCounter], a
+	ldh [hVBlankCounter], a
 	call CardFlip_UpdateCursorOAM
 	call WaitSFX
 	ld de, SFX_CHOOSE_A_CARD
@@ -311,7 +311,7 @@ _CardFlip:
 	jr c, .KeepTheCurrentDeck
 	call CardFlip_InitTilemap
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CardFlip_ShuffleDeck
 	ld hl, .CardsShuffledText
 	call PrintText
@@ -396,7 +396,7 @@ GetCoordsOfChosenCard:
 
 PlaceCardFaceDown:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld de, .FaceDownCardTilemap
 	lb bc, 6, 5
 	call CardFlip_CopyToBox
@@ -412,7 +412,7 @@ PlaceCardFaceDown:
 
 CardFlip_DisplayCardFaceUp:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	push hl
 	push hl
 	; Flip the card face up.
@@ -458,7 +458,7 @@ CardFlip_DisplayCardFaceUp:
 	pop hl
 
 	; Pointless CGB check
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
@@ -519,7 +519,7 @@ CardFlip_PrintCoinBalance:
 
 CardFlip_InitTilemap:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_HEIGHT * SCREEN_WIDTH
 	ld a, $29
@@ -607,7 +607,7 @@ CardFlip_ShiftDigitsLeftTwoPixels:
 
 CardFlip_BlankDiscardedCardSlot:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wCardFlipFaceUpCard]
 	ld e, a
 	ld d, 0
@@ -1327,10 +1327,10 @@ ChooseCard_HandleJoypad:
 
 CardFlip_UpdateCursorOAM:
 	call ClearSprites
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .skip
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and $4
 	ret nz
 
@@ -1560,7 +1560,7 @@ ENDM
 	dsprite  1, 0,   1, 0, $00, 0 | X_FLIP | Y_FLIP | PRIORITY
 
 CardFlip_InitAttrPals:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
@@ -1594,16 +1594,16 @@ CardFlip_InitAttrPals:
 	ld a, $1
 	call CardFlip_FillBox
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, .palettes
 	ld de, wBGPals1
 	ld bc, 9 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .palettes

--- a/engine/games/dummy_game.asm
+++ b/engine/games/dummy_game.asm
@@ -28,14 +28,14 @@ _DummyGame:
 	xor a
 	call ByteFill
 	xor a
-	ld [hSCY], a
-	ld [hSCX], a
-	ld [rWY], a
+	ldh [hSCY], a
+	ldh [hSCX], a
+	ldh [rWY], a
 	ld [wJumptableIndex], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ld a, $e4
 	call DmgToCgbBGPals
 	ld a, $e0
@@ -200,7 +200,7 @@ endr
 	ret
 
 .RevealAll:
-	ld a, [hJoypadPressed]
+	ldh a, [hJoypadPressed]
 	and A_BUTTON
 	ret z
 	xor a

--- a/engine/games/dummy_game.asm
+++ b/engine/games/dummy_game.asm
@@ -500,7 +500,7 @@ DummyGame_InterpretJoypad_AnimateCursor:
 	cp $7
 	jr nc, .quit
 	call JoyTextDelay
-	ld hl, hJoypadPressed ; $ffa3
+	ld hl, hJoypadPressed
 	ld a, [hl]
 	and A_BUTTON
 	jr nz, .pressed_a

--- a/engine/games/slot_machine.asm
+++ b/engine/games/slot_machine.asm
@@ -167,7 +167,7 @@ Slots_GetPals:
 	ld a, %11100100
 	call DmgToCgbBGPals
 	lb de, %11100100, %11100100
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	lb de, %11000000, %11100100
@@ -214,7 +214,7 @@ SlotsLoop:
 	ld a, [wTextDelayFrames]
 	and $7
 	ret nz
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	xor %00001100
 	call DmgToCgbBGPals
 	ret
@@ -343,7 +343,7 @@ SlotsAction_WaitStart:
 .proceed
 	call SlotsAction_Next
 	xor a
-	ld [hJoypadSum], a
+	ldh [hJoypadSum], a
 	ret
 
 SlotsAction_WaitReel1:
@@ -365,7 +365,7 @@ SlotsAction_WaitStopReel1:
 	call Slots_LoadReelState
 	call SlotsAction_Next
 	xor a
-	ld [hJoypadSum], a
+	ldh [hJoypadSum], a
 SlotsAction_WaitReel2:
 	ld hl, hJoypadSum
 	ld a, [hl]
@@ -385,7 +385,7 @@ SlotsAction_WaitStopReel2:
 	call Slots_LoadReelState
 	call SlotsAction_Next
 	xor a
-	ld [hJoypadSum], a
+	ldh [hJoypadSum], a
 SlotsAction_WaitReel3:
 	ld hl, hJoypadSum
 	ld a, [hl]
@@ -405,7 +405,7 @@ SlotsAction_WaitStopReel3:
 	call Slots_LoadReelState
 	call SlotsAction_Next
 	xor a
-	ld [hJoypadSum], a
+	ldh [hJoypadSum], a
 	ret
 
 SlotsAction_FlashIfWin:
@@ -429,7 +429,7 @@ SlotsAction_FlashScreen:
 	srl a
 	ret z
 
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	xor $ff
 	ld e, a
 	ld d, a
@@ -2042,7 +2042,7 @@ Slots_AnimateGolem:
 	xor $ff
 	inc a
 	ld [hl], a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 .restart
@@ -2050,7 +2050,7 @@ Slots_AnimateGolem:
 	add hl, bc
 	xor a
 	ld [hl], a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 Slots_AnimateChansey:

--- a/engine/games/unown_puzzle.asm
+++ b/engine/games/unown_puzzle.asm
@@ -4,15 +4,15 @@ PUZZLE_VOID   EQU $ef
 puzcoord EQUS "* 6 +"
 
 _UnownPuzzle:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call ClearBGPalettes
 	call ClearTileMap
 	call ClearSprites
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DisableLCD
 	ld hl, wc608 ; includes wPuzzlePieces
 	ld bc, wc7e8 - wc608
@@ -38,15 +38,15 @@ _UnownPuzzle:
 	call UnownPuzzle_UpdateTilemap
 	call PlaceStartCancelBox
 	xor a
-	ld [hSCY], a
-	ld [hSCX], a
-	ld [rWY], a
+	ldh [hSCY], a
+	ldh [hSCX], a
+	ldh [rWY], a
 	ld [wJumptableIndex], a
 	ld [wHoldingUnownPuzzlePiece], a
 	ld [wUnownPuzzleCursorPosition], a
 	ld [wUnownPuzzleHeldPiece], a
 	ld a, %10010011
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	call WaitBGMap
 	ld b, SCGB_UNOWN_PUZZLE
 	call GetSGBLayout
@@ -66,7 +66,7 @@ _UnownPuzzle:
 	ld a, [wHoldingUnownPuzzlePiece]
 	and a
 	jr nz, .holding_piece
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and $10
 	jr z, .clear
 .holding_piece
@@ -81,12 +81,12 @@ _UnownPuzzle:
 
 .quit
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call ClearBGPalettes
 	call ClearTileMap
 	call ClearSprites
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ret
 
 InitUnownPuzzlePiecePositions:
@@ -185,10 +185,10 @@ UnownPuzzleJumptable:
 	dw .Function
 
 .Function:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and START
 	jp nz, UnownPuzzle_Quit
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jp nz, UnownPuzzle_A
 	ld hl, hJoyLast

--- a/engine/gfx/cgb_layouts.asm
+++ b/engine/gfx/cgb_layouts.asm
@@ -1,7 +1,7 @@
 ; Replaces the functionality of sgb.asm to work with CGB hardware.
 
 CheckCGB:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret
 
@@ -190,7 +190,7 @@ _CGB_PokegearPals:
 	call FarCopyWRAM
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_StatsScreenHPPals:
@@ -244,7 +244,7 @@ _CGB_StatsScreenHPPals:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 StatsScreenPagePals:
@@ -283,7 +283,7 @@ _CGB_Pokedex:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .PokedexQuestionMarkPalette:
@@ -318,7 +318,7 @@ _CGB_BillsPC:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .Function9009:
@@ -340,7 +340,7 @@ _CGB_BillsPC:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .BillsPCOrangePalette:
@@ -363,7 +363,7 @@ _CGB_PokedexUnownMode:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_SlotMachine:
@@ -416,7 +416,7 @@ _CGB_SlotMachine:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB06:
@@ -434,7 +434,7 @@ _CGB06:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_GSIntro:
@@ -574,7 +574,7 @@ _CGB_Evolution:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_GSTitleScreen:
@@ -592,7 +592,7 @@ _CGB_GSTitleScreen:
 	ld [wSGBPredef], a
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB0d:
@@ -609,17 +609,17 @@ _CGB_UnownPuzzle:
 	ld a, PREDEFPAL_UNOWN_PUZZLE
 	call GetPredefPal
 	call LoadHLPaletteIntoDE
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wOBPals1
 	ld a, LOW(palred 31 + palgreen 0 + palblue 0)
 	ld [hli], a
 	ld a, HIGH(palred 31 + palgreen 0 + palblue 0)
 	ld [hl], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call WipeAttrMap
 	call ApplyAttrMap
 	ret
@@ -726,7 +726,7 @@ _CGB_TrainerCard:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_MoveList:
@@ -750,7 +750,7 @@ _CGB_MoveList:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_BetaPikachuMinigame:
@@ -760,7 +760,7 @@ _CGB_BetaPikachuMinigame:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_PokedexSearchOption:
@@ -772,7 +772,7 @@ _CGB_PokedexSearchOption:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_PackPals:
@@ -820,7 +820,7 @@ _CGB_PackPals:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .ChrisPackPals:
@@ -878,7 +878,7 @@ _CGB13:
 	call ApplyAttrMap
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 _CGB_GamefreakLogo:

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -151,7 +151,7 @@ Unreferenced_Function8b07:
 
 	call ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .BGPal:
@@ -169,7 +169,7 @@ Unreferenced_Function8b07:
 Unreferenced_Function8b3f:
 	call CheckCGB
 	ret nz
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 	ld hl, BlkPacket_9a86
@@ -178,7 +178,7 @@ Unreferenced_Function8b3f:
 Unreferenced_Function8b4d:
 	call CheckCGB
 	jr nz, .cgb
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 	ld hl, PalPacket_BetaIntroVenusaur
@@ -193,7 +193,7 @@ Unreferenced_Function8b4d:
 Unreferenced_Function8b67:
 	call CheckCGB
 	jr nz, .cgb
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 	ld hl, PalPacket_Pack
@@ -208,7 +208,7 @@ Unreferenced_Function8b67:
 Unreferenced_Function8b81:
 	call CheckCGB
 	jr nz, .cgb
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 	ld a, c
@@ -274,7 +274,7 @@ got_palette_pointer_8bd7
 	ret
 
 Unreferenced_Function8bec:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 	ld hl, wPlayerLightScreenCount
@@ -353,7 +353,7 @@ ApplyHPBarPals:
 	ld a, BANK(wBGPals2)
 	call FarCopyWRAM
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .PartyMenu:
@@ -383,10 +383,10 @@ LoadStatsScreenPals:
 	dec c
 	add hl, bc
 	add hl, bc
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [hli]
 	ld [wBGPals1 palette 0], a
 	ld [wBGPals1 palette 2], a
@@ -394,7 +394,7 @@ LoadStatsScreenPals:
 	ld [wBGPals1 palette 0 + 1], a
 	ld [wBGPals1 palette 2 + 1], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call ApplyPals
 	ld a, $1
 	ret
@@ -492,10 +492,10 @@ GetPredefPal:
 	ret
 
 LoadHLPaletteIntoDE:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld c, 1 palettes
 .loop
 	ld a, [hli]
@@ -504,14 +504,14 @@ LoadHLPaletteIntoDE:
 	dec c
 	jr nz, .loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 LoadPalette_White_Col1_Col2_Black:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, LOW(PALRGB_WHITE)
 	ld [de], a
@@ -535,7 +535,7 @@ LoadPalette_White_Col1_Col2_Black:
 	inc de
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 FillBoxCGB:
@@ -560,10 +560,10 @@ ResetBGPals:
 	push de
 	push hl
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBGPals1
 	ld c, 1 palettes
@@ -582,7 +582,7 @@ ResetBGPals:
 	jr nz, .loop
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	pop hl
 	pop de
@@ -606,19 +606,19 @@ ApplyPals:
 	ret
 
 ApplyAttrMap:
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jr z, .UpdateVBank1
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .UpdateVBank1:
@@ -626,7 +626,7 @@ ApplyAttrMap:
 	debgcoord 0, 0
 	ld b, SCREEN_HEIGHT
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 .row
 	ld c, SCREEN_WIDTH
 .col
@@ -644,7 +644,7 @@ ApplyAttrMap:
 	dec b
 	jr nz, .row
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 ; CGB layout for SCGB_PARTY_MENU_HP_PALS
@@ -742,11 +742,11 @@ Unreferenced_Function9779:
 	ret z
 	ld hl, BattleObjectPals
 	ld a, $90
-	ld [rOBPI], a
+	ldh [rOBPI], a
 	ld c, 6 palettes
 .loop
 	ld a, [hli]
-	ld [rOBPD], a
+	ldh [rOBPD], a
 	dec c
 	jr nz, .loop
 	ld hl, BattleObjectPals
@@ -763,7 +763,7 @@ Unreferenced_Function97cc:
 	call CheckCGB
 	ret z
 	ld a, $90
-	ld [rOBPI], a
+	ldh [rOBPI], a
 	ld a, PREDEFPAL_TRADE_TUBE
 	call GetPredefPal
 	call .PushPalette
@@ -776,7 +776,7 @@ Unreferenced_Function97cc:
 	ld c, 1 palettes
 .loop
 	ld a, [hli]
-	ld [rOBPD], a
+	ldh [rOBPD], a
 	dec c
 	jr nz, .loop
 	ret
@@ -822,9 +822,9 @@ _PushSGBPals:
 .loop
 	push bc
 	xor a
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld b, $10
 .loop2
 	ld e, $8
@@ -836,18 +836,18 @@ _PushSGBPals:
 	jr nz, .okay
 	ld a, $20
 .okay
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	rr d
 	dec e
 	jr nz, .loop3
 	dec b
 	jr nz, .loop2
 	ld a, $20
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	call SGBDelayCycles
 	pop bc
 	dec b
@@ -864,12 +864,12 @@ InitSGBBorder:
 	set 7, a
 	ld [wcfbe], a
 	xor a
-	ld [rJOYP], a
-	ld [hSGB], a
+	ldh [rJOYP], a
+	ldh [hSGB], a
 	call PushSGBBorderPalsAndWait
 	jr nc, .skip
 	ld a, $1
-	ld [hSGB], a
+	ldh [hSGB], a
 	call _InitSGBBorderPals
 	call SGBBorder_PushBGPals
 	call SGBDelayCycles
@@ -891,43 +891,43 @@ InitCGBPals::
 	ret z
 ; CGB only
 	ld a, BANK(vTiles3)
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles3
 	ld bc, $200 tiles
 	xor a
 	call ByteFill
 	ld a, BANK(vTiles0)
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld a, 1 << rBGPI_AUTO_INCREMENT
-	ld [rBGPI], a
+	ldh [rBGPI], a
 	ld c, 4 * 8
 .bgpals_loop
 	ld a, LOW(PALRGB_WHITE)
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	ld a, HIGH(PALRGB_WHITE)
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	dec c
 	jr nz, .bgpals_loop
 	ld a, 1 << rOBPI_AUTO_INCREMENT
-	ld [rOBPI], a
+	ldh [rOBPI], a
 	ld c, 4 * 8
 .obpals_loop
 	ld a, LOW(PALRGB_WHITE)
-	ld [rOBPD], a
+	ldh [rOBPD], a
 	ld a, HIGH(PALRGB_WHITE)
-	ld [rOBPD], a
+	ldh [rOBPD], a
 	dec c
 	jr nz, .obpals_loop
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1
 	call .LoadWhitePals
 	ld hl, wBGPals2
 	call .LoadWhitePals
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .LoadWhitePals:
@@ -972,7 +972,7 @@ _InitSGBBorderPals:
 Unreferenced_Function9911:
 	di
 	xor a
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld hl, MaskEnFreezePacket
 	call _PushSGBPals
 	call PushSGBBorder
@@ -1007,35 +1007,35 @@ PushSGBBorderPalsAndWait:
 	ld hl, MltReq2Packet
 	call _PushSGBPals
 	call SGBDelayCycles
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
 	and $3
 	cp $3
 	jr nz, .carry
 	ld a, $20
-	ld [rJOYP], a
-	ld a, [rJOYP]
-	ld a, [rJOYP]
+	ldh [rJOYP], a
+	ldh a, [rJOYP]
+	ldh a, [rJOYP]
 	call SGBDelayCycles
 	call SGBDelayCycles
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	call SGBDelayCycles
 	call SGBDelayCycles
 	ld a, $10
-	ld [rJOYP], a
+	ldh [rJOYP], a
 rept 6
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
 endr
 	call SGBDelayCycles
 	call SGBDelayCycles
 	ld a, $30
-	ld [rJOYP], a
-	ld a, [rJOYP]
-	ld a, [rJOYP]
-	ld a, [rJOYP]
+	ldh [rJOYP], a
+	ldh a, [rJOYP]
+	ldh a, [rJOYP]
+	ldh a, [rJOYP]
 	call SGBDelayCycles
 	call SGBDelayCycles
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
 	and $3
 	cp $3
 	jr nz, .carry
@@ -1056,24 +1056,24 @@ endr
 SGBBorder_PushBGPals:
 	call DisableLCD
 	ld a, %11100100
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld hl, PredefPals
 	ld de, vTiles1
 	ld bc, $100 tiles
 	call CopyData
 	call DrawDefaultTiles
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ld hl, PalTrnPacket
 	call _PushSGBPals
 	xor a
-	ld [rBGP], a
+	ldh [rBGP], a
 	ret
 
 SGBBorder_MorePalPushing:
 	call DisableLCD
 	ld a, $e4
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld de, vTiles1
 	ld bc, 20 tiles
 	call CopyData
@@ -1097,17 +1097,17 @@ SGBBorder_MorePalPushing:
 	call CopyData
 	call DrawDefaultTiles
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ld hl, PctTrnPacket
 	call _PushSGBPals
 	xor a
-	ld [rBGP], a
+	ldh [rBGP], a
 	ret
 
 SGBBorder_YetMorePalPushing:
 	call DisableLCD
 	ld a, %11100100
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld de, vTiles1
 	ld b, $80
 .loop
@@ -1121,11 +1121,11 @@ SGBBorder_YetMorePalPushing:
 	jr nz, .loop
 	call DrawDefaultTiles
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ld hl, ChrTrnPacket
 	call _PushSGBPals
 	xor a
-	ld [rBGP], a
+	ldh [rBGP], a
 	ret
 
 CopyData:
@@ -1237,10 +1237,10 @@ LoadMapPals:
 	ld e, l
 	ld d, h
 	; Switch to palettes WRAM bank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1
 	ld b, 8
 .outer_loop
@@ -1269,7 +1269,7 @@ LoadMapPals:
 	dec b
 	jr nz, .outer_loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 .got_pals
 	ld a, [wTimeOfDayPal]

--- a/engine/gfx/crystal_layouts.asm
+++ b/engine/gfx/crystal_layouts.asm
@@ -158,7 +158,7 @@ MG_Mobile_Layout01:
 	farcall ApplyAttrMap
 	farcall ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .Palette_49478:

--- a/engine/gfx/dma_transfer.asm
+++ b/engine/gfx/dma_transfer.asm
@@ -10,11 +10,11 @@ HDMATransferAttrMapAndTileMapToWRAMBank3::
 	ld hl, wScratchTileMap
 	call PadTilemapForHDMATransfer
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransferToWRAMBank3
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransferToWRAMBank3
 	ret
@@ -28,7 +28,7 @@ HDMATransferTileMapToWRAMBank3::
 	ld hl, wScratchTileMap
 	call PadTilemapForHDMATransfer
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransferToWRAMBank3
 	ret
@@ -42,7 +42,7 @@ HDMATransferAttrMapToWRAMBank3:
 	ld hl, wScratchAttrMap
 	call PadAttrMapForHDMATransfer
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransferToWRAMBank3
 	ret
@@ -61,18 +61,18 @@ ReloadMapPart::
 	call DelayFrame
 
 	di
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransfer_Wait127Scanlines_toBGMap
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransfer_Wait127Scanlines_toBGMap
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ei
 
 	ret
@@ -92,18 +92,18 @@ Mobile_ReloadMapPart:
 	call DelayFrame
 
 	di
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransfer_NoDI
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransfer_NoDI
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ei
 
 	ret
@@ -114,20 +114,20 @@ Mobile_ReloadMapPart:
 
 .unreferenced_1040da
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld a, BANK(w3_d800)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, w3_d800
-	ld a, [hBGMapAddress + 1]
-	ld [rHDMA1], a
-	ld a, [hBGMapAddress]
-	ld [rHDMA2], a
+	ldh a, [hBGMapAddress + 1]
+	ldh [rHDMA1], a
+	ldh a, [hBGMapAddress]
+	ldh [rHDMA2], a
 	ld a, d
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, e
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $23
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 	call WaitDMATransfer
 	ret
 
@@ -137,9 +137,9 @@ Mobile_ReloadMapPart:
 
 .unreferenced_104101
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld a, BANK(w3_d800)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, w3_d800
 	call HDMATransferToWRAMBank3
 	ret
@@ -162,18 +162,18 @@ OpenAndCloseMenu_HDMATransferTileMapAndAttrMap::
 	call DelayFrame
 
 	di
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransfer_Wait123Scanlines_toBGMap
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransfer_Wait123Scanlines_toBGMap
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ei
 	ret
 
@@ -194,40 +194,40 @@ Mobile_OpenAndCloseMenu_HDMATransferTileMapAndAttrMap:
 	call PadMapForHDMATransfer
 
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchAttrMap
 	call HDMATransfer_Wait127Scanlines_toBGMap
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, wScratchTileMap
 	call HDMATransfer_Wait127Scanlines_toBGMap
 	ret
 
 CallInSafeGFXMode:
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hBGMapMode], a
-	ld [hMapAnims], a
-	ld a, [rSVBK]
+	ldh [hBGMapMode], a
+	ldh [hMapAnims], a
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wScratchTileMap)
-	ld [rSVBK], a
-	ld a, [rVBK]
+	ldh [rSVBK], a
+	ldh a, [rVBK]
 	push af
 
 	call ._hl_
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 ._hl_
@@ -236,12 +236,12 @@ CallInSafeGFXMode:
 HDMATransferToWRAMBank3:
 	call _LoadHDMAParameters
 	ld a, $23
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 
 WaitDMATransfer:
 .loop
 	call DelayFrame
-	ld a, [hDMATransfer]
+	ldh a, [hDMATransfer]
 	and a
 	jr nz, .loop
 	ret
@@ -250,9 +250,9 @@ HDMATransfer_Wait127Scanlines_toBGMap:
 ; HDMA transfer from hl to [hBGMapAddress]
 ; hBGMapAddress -> de
 ; 2 * SCREEN_HEIGHT -> c
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld d, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld e, a
 	ld c, 2 * SCREEN_HEIGHT
 	jr HDMATransfer_Wait127Scanlines
@@ -262,9 +262,9 @@ HDMATransfer_Wait123Scanlines_toBGMap:
 ; hBGMapAddress -> de
 ; 2 * SCREEN_HEIGHT -> c
 ; $7b --> b
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld d, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld e, a
 	ld c, 2 * SCREEN_HEIGHT
 	jr HDMATransfer_Wait123Scanlines
@@ -273,25 +273,25 @@ HDMATransfer_NoDI:
 ; HDMA transfer from hl to [hBGMapAddress]
 ; [hBGMapAddress] --> de
 ; 2 * SCREEN_HEIGHT --> c
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld d, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld e, a
 	ld c, 2 * SCREEN_HEIGHT
 
 	; [rHDMA1, rHDMA2] = hl & $fff0
 	ld a, h
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, l
 	and $f0
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	; [rHDMA3, rHDMA4] = de & $1ff0
 	ld a, d
 	and $1f
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, e
 	and $f0
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	; b = c | %10000000
 	ld a, c
 	dec c
@@ -303,19 +303,19 @@ HDMATransfer_NoDI:
 	ld d, a
 	; while [rLY] >= d: pass
 .loop1
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp d
 	jr nc, .loop1
 	; while not [rSTAT] & 3: pass
 .loop2
-	ld a, [rSTAT]
+	ldh a, [rSTAT]
 	and $3
 	jr z, .loop2
 	; load the 5th byte of HDMA
 	ld a, b
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 	; wait until rLY advances (c + 1) times
-	ld a, [rLY]
+	ldh a, [rLY]
 	inc c
 	ld hl, rLY
 .loop3
@@ -338,17 +338,17 @@ _continue_HDMATransfer:
 ; a lot of waiting around for hardware registers
 	; [rHDMA1, rHDMA2] = hl & $fff0
 	ld a, h
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, l
 	and $f0 ; high nybble
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	; [rHDMA3, rHDMA4] = de & $1ff0
 	ld a, d
 	and $1f ; lower 5 bits
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, e
 	and $f0 ; high nybble
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	; e = c | %10000000
 	ld a, c
 	dec c
@@ -360,26 +360,26 @@ _continue_HDMATransfer:
 	ld d, a
 	; while [rLY] >= d: pass
 .ly_loop
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp d
 	jr nc, .ly_loop
 
 	di
 	; while [rSTAT] & 3: pass
 .rstat_loop_1
-	ld a, [rSTAT]
+	ldh a, [rSTAT]
 	and $3
 	jr nz, .rstat_loop_1
 	; while not [rSTAT] & 3: pass
 .rstat_loop_2
-	ld a, [rSTAT]
+	ldh a, [rSTAT]
 	and $3
 	jr z, .rstat_loop_2
 	; load the 5th byte of HDMA
 	ld a, e
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 	; wait until rLY advances (c + 1) times
-	ld a, [rLY]
+	ldh a, [rLY]
 	inc c
 	ld hl, rLY
 .final_ly_loop
@@ -396,14 +396,14 @@ _continue_HDMATransfer:
 
 _LoadHDMAParameters:
 	ld a, h
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, l
-	ld [rHDMA2], a
-	ld a, [hBGMapAddress + 1]
+	ldh [rHDMA2], a
+	ldh a, [hBGMapAddress + 1]
 	and $1f
-	ld [rHDMA3], a
-	ld a, [hBGMapAddress]
-	ld [rHDMA4], a
+	ldh [rHDMA3], a
+	ldh a, [hBGMapAddress]
+	ldh [rHDMA4], a
 	ret
 
 PadTilemapForHDMATransfer:
@@ -416,10 +416,10 @@ PadAttrMapForHDMATransfer:
 PadMapForHDMATransfer:
 ; pad a 20x18 map to 32x18 for HDMA transfer
 ; back up the padding value in c to hMapObjectIndexBuffer
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	push af
 	ld a, c
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 
 ; for each row on the screen
 	ld c, SCREEN_HEIGHT
@@ -435,7 +435,7 @@ PadMapForHDMATransfer:
 	jr nz, .loop2
 
 ; load the original padding value of c into hl for 32 - 20 = 12 rows
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld b, BG_MAP_WIDTH - SCREEN_WIDTH
 .loop3
 	ld [hli], a
@@ -447,16 +447,16 @@ PadMapForHDMATransfer:
 
 ; restore the original value of hMapObjectIndexBuffer
 	pop af
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ret
 
 _Get2bpp::
 	; 2bpp when [rLCDC] & $80
 	; switch to WRAM bank 6
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wScratchTileMap)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push bc
 	push hl
@@ -491,7 +491,7 @@ _Get2bpp::
 
 	; restore the previous bank
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 _Get1bpp::
@@ -521,10 +521,10 @@ _Get1bpp::
 	jr .loop
 
 .bankswitch
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wScratchTileMap)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push bc
 	push hl
@@ -555,7 +555,7 @@ _Get1bpp::
 	call HDMATransfer_Wait127Scanlines
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 HDMATransfer_OnlyTopFourRows:
@@ -570,13 +570,13 @@ HDMATransfer_OnlyTopFourRows:
 	decoord 0, 0, wAttrMap
 	call .Copy
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld c, $8
 	ld hl, wScratchTileMap + $80
 	debgcoord 0, 0, vBGMap1
 	call HDMATransfer_Wait127Scanlines
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld c, $8
 	ld hl, wScratchTileMap
 	debgcoord 0, 0, vBGMap1

--- a/engine/gfx/load_font.asm
+++ b/engine/gfx/load_font.asm
@@ -22,7 +22,7 @@ _LoadStandardFont::
 	ld de, Font
 	ld hl, vTiles1
 	lb bc, BANK(Font), 128 ; "A" to "9"
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jp z, Copy1bpp
 

--- a/engine/gfx/load_pics.asm
+++ b/engine/gfx/load_pics.asm
@@ -32,18 +32,18 @@ GetUnownLetter:
 	or b
 
 ; Divide by 10 to get 0-25
-	ld [hDividend + 3], a
+	ldh [hDividend + 3], a
 	xor a
-	ld [hDividend], a
-	ld [hDividend + 1], a
-	ld [hDividend + 2], a
+	ldh [hDividend], a
+	ldh [hDividend + 1], a
+	ldh [hDividend + 2], a
 	ld a, $ff / NUM_UNOWN + 1
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 
 ; Increment to get 1-26
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	inc a
 	ld [wUnownLetter], a
 	ret
@@ -53,11 +53,11 @@ GetMonFrontpic:
 	ld [wCurSpecies], a
 	call IsAPokemon
 	ret c
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	call _GetFrontpic
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 GetAnimatedFrontpic:
@@ -65,14 +65,14 @@ GetAnimatedFrontpic:
 	ld [wCurSpecies], a
 	call IsAPokemon
 	ret c
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call _GetFrontpic
 	call GetAnimatedEnemyFrontpic
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 _GetFrontpic:
@@ -84,7 +84,7 @@ _GetFrontpic:
 	push bc
 	call GetFrontpicPointer
 	ld a, BANK(wDecompressEnemyFrontpic)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, b
 	ld de, wDecompressEnemyFrontpic
 	call FarDecompress
@@ -96,7 +96,7 @@ _GetFrontpic:
 	push hl
 	ld de, wDecompressScratch
 	ld c, 7 * 7
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	pop hl
@@ -131,11 +131,11 @@ GetFrontpicPointer:
 
 GetAnimatedEnemyFrontpic:
 	ld a, BANK(vTiles3)
-	ld [rVBK], a
+	ldh [rVBK], a
 	push hl
 	ld de, wDecompressScratch
 	ld c, 7 * 7
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	pop hl
@@ -164,11 +164,11 @@ GetAnimatedEnemyFrontpic:
 	pop bc
 	pop hl
 	ld de, wDecompressScratch
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 LoadFrontpicTiles:
@@ -201,10 +201,10 @@ GetMonBackpic:
 	ld b, a
 	ld a, [wUnownLetter]
 	ld c, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push de
 
 	; These are assumed to be at the same address in their respective banks.
@@ -236,11 +236,11 @@ GetMonBackpic:
 	call FixBackpicAlignment
 	pop hl
 	ld de, wDecompressScratch
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 FixPicBank:
@@ -314,16 +314,16 @@ GetTrainerPic:
 	ret nc
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, TrainerPicPointers
 	ld a, [wTrainerClass]
 	dec a
 	ld bc, 3
 	call AddNTimes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push de
 	ld a, BANK(TrainerPicPointers)
 	call GetFarByte
@@ -338,23 +338,23 @@ GetTrainerPic:
 	pop hl
 	ld de, wDecompressScratch
 	ld c, 7 * 7
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call WaitBGMap
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 DecompressGet2bpp:
 ; Decompress lz data from b:hl to scratch space at 6:d000, then copy it to address de.
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push de
 	push bc
@@ -364,12 +364,12 @@ DecompressGet2bpp:
 	pop bc
 	ld de, wDecompressScratch
 	pop hl
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 FixBackpicAlignment:

--- a/engine/gfx/load_push_oam.asm
+++ b/engine/gfx/load_push_oam.asm
@@ -1,5 +1,5 @@
 WriteOAMDMACodeToHRAM::
-	ld c, hTransferVirtualOAM - $ff00
+	ld c, LOW(hTransferVirtualOAM)
 	ld b, .PushOAMEnd - .PushOAM
 	ld hl, .PushOAM
 .loop

--- a/engine/gfx/load_push_oam.asm
+++ b/engine/gfx/load_push_oam.asm
@@ -12,7 +12,7 @@ WriteOAMDMACodeToHRAM::
 
 .PushOAM:
 	ld a, HIGH(wVirtualOAM)
-	ld [rDMA], a
+	ldh [rDMA], a
 	ld a, NUM_SPRITE_OAM_STRUCTS
 .pushoam_loop
 	dec a

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -51,7 +51,7 @@ LoadMenuMonIcon:
 
 .GetPartyMonItemGFX:
 	push bc
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld hl, wPartyMon1Item
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
@@ -125,7 +125,7 @@ PartyMenu_InitAnimatedMonIcon:
 
 .SpawnItemIcon:
 	push bc
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld hl, wPartyMon1Item
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
@@ -154,7 +154,7 @@ PartyMenu_InitAnimatedMonIcon:
 InitPartyMenuIcon:
 	ld a, [wCurIconTile]
 	push af
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld hl, wPartySpecies
 	ld e, a
 	ld d, 0
@@ -163,7 +163,7 @@ InitPartyMenuIcon:
 	call ReadMonMenuIcon
 	ld [wCurIcon], a
 	call GetMemIconGFX
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 ; y coord
 	add a
 	add a
@@ -184,7 +184,7 @@ InitPartyMenuIcon:
 
 SetPartyMonIconAnimSpeed:
 	push bc
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld b, a
 	call .getspeed
 	ld a, b

--- a/engine/gfx/pic_animation.asm
+++ b/engine/gfx/pic_animation.asm
@@ -107,10 +107,10 @@ LoadMonAnimation:
 	ret
 
 SetUpPokeAnim:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPokeAnimStruct)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wPokeAnimSceneIndex]
 	ld c, a
 	ld b, 0
@@ -125,7 +125,7 @@ SetUpPokeAnim:
 	ld a, [wPokeAnimSceneIndex]
 	ld c, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, c
 	and $80
 	ret z
@@ -256,16 +256,16 @@ PokeAnim_StereoCry:
 	ret
 
 PokeAnim_DeinitFrames:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPokeAnimCoord)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call PokeAnim_PlaceGraphic
 	farcall HDMATransferTileMapToWRAMBank3
 	call PokeAnim_SetVBank0
 	farcall HDMATransferAttrMapToWRAMBank3
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 AnimateMon_CheckIfPokemon:
@@ -282,10 +282,10 @@ AnimateMon_CheckIfPokemon:
 	ret
 
 PokeAnim_InitPicAttributes:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPokeAnimStruct)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push bc
 	push de
@@ -330,14 +330,14 @@ PokeAnim_InitPicAttributes:
 	ld [wPokeAnimFrontpicHeight], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 PokeAnim_InitAnim:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPokeAnimIdleFlag)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push bc
 	ld hl, wPokeAnimIdleFlag
 	ld bc, wPokeAnimStructEnd - wPokeAnimIdleFlag
@@ -352,12 +352,12 @@ PokeAnim_InitAnim:
 	call GetMonFramesPointer
 	call GetMonBitmaskPointer
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 PokeAnim_DoAnimScript:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 .loop
 	ld a, [wPokeAnimJumptableIndex]
 	and $7f
@@ -823,16 +823,16 @@ PokeAnim_PlaceGraphic:
 	ret
 
 PokeAnim_SetVBank1:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wPokeAnimCoord)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .SetFlag
 	farcall HDMATransferAttrMapToWRAMBank3
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .SetFlag:
@@ -943,10 +943,10 @@ GetMonAnimPointer:
 	ret
 
 PokeAnim_GetFrontpicDims:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wCurPartySpecies)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wCurPartySpecies]
 	ld [wCurSpecies], a
 	call GetBaseData
@@ -954,7 +954,7 @@ PokeAnim_GetFrontpicDims:
 	and $f
 	ld c, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 GetMonFramesPointer:

--- a/engine/gfx/place_graphic.asm
+++ b/engine/gfx/place_graphic.asm
@@ -8,7 +8,7 @@ PlaceGraphic:
 	and a
 	jr nz, .right
 
-	ld a, [hGraphicStartTile]
+	ldh a, [hGraphicStartTile]
 .x1
 	push bc
 	push hl
@@ -35,7 +35,7 @@ PlaceGraphic:
 	add hl, bc
 	pop bc
 
-	ld a, [hGraphicStartTile]
+	ldh a, [hGraphicStartTile]
 .x2
 	push bc
 	push hl

--- a/engine/gfx/player_gfx.asm
+++ b/engine/gfx/player_gfx.asm
@@ -28,11 +28,11 @@ MovePlayerPic:
 	push hl
 	push de
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	xor a
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	call WaitBGMap
 	call DelayFrame
 	pop de
@@ -147,7 +147,7 @@ GetChrisBackpic:
 HOF_LoadTrainerFrontpic:
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld e, 0
 	ld a, [wPlayerGender]
 	bit PLAYERGENDER_FEMALE_F, a
@@ -170,7 +170,7 @@ HOF_LoadTrainerFrontpic:
 	call Get2bpp
 	call WaitBGMap
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 DrawIntroPlayerPic:
@@ -200,7 +200,7 @@ DrawIntroPlayerPic:
 
 ; Draw
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
 	predef PlaceGraphic

--- a/engine/gfx/sprites.asm
+++ b/engine/gfx/sprites.asm
@@ -561,7 +561,7 @@ Sprites_Sine:
 	calc_sine_wave
 
 AnimateEndOfExpBar:
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	ld de, EndOfExpBarGFX
 	and a
 	jr z, .load

--- a/engine/items/buy_sell_toss.asm
+++ b/engine/items/buy_sell_toss.asm
@@ -157,13 +157,13 @@ DisplaySellingPrice:
 
 BuySell_MultiplyPrice:
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld a, [wBuffer1]
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, [wBuffer2]
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [wItemQuantityChangeBuffer]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	push hl
 	call Multiply
 	pop hl
@@ -187,11 +187,11 @@ Sell_HalvePrice:
 BuySell_DisplaySubtotal:
 	push hl
 	ld hl, hMoneyTemp
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld [hli], a
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [hli], a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [hl], a
 	pop hl
 	inc hl

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -258,7 +258,7 @@ PokeBallEffect:
 	jp z, .skip_hp_calc
 
 	ld a, b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 	ld hl, wEnemyMonHP
 	ld b, [hl]
@@ -300,20 +300,20 @@ PokeBallEffect:
 	push bc
 	ld a, b
 	sub c
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	xor a
-	ld [hDividend + 0], a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hDividend + 0], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	call Multiply
 	pop bc
 
 	ld a, b
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, $4
 	call Divide
 
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	and a
 	jr nz, .statuscheck
 	ld a, 1
@@ -389,7 +389,7 @@ PokeBallEffect:
 	ld a, d
 	ld [wFXAnimID + 1], a
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld [wBuffer2], a
 	ld [wNumHits], a
 	predef PlayBattleAnim
@@ -1313,11 +1313,11 @@ RareCandyEffect:
 	ld a, MON_EXP
 	call GetPartyParamLocation
 
-	ld a, [hMultiplicand]
+	ldh a, [hMultiplicand]
 	ld [hli], a
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	ld [hli], a
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	ld [hl], a
 
 	ld a, MON_MAXHP
@@ -1628,7 +1628,7 @@ BitterBerryEffect:
 
 	res SUBSTATUS_CONFUSED, [hl]
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	call UseItemText
 
 	ld hl, ConfusedNoMoreText
@@ -1770,7 +1770,7 @@ ItemActionText:
 
 ItemActionTextWaitButton:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, wTileMapEnd - wTileMap
 	ld a, " "
@@ -1778,7 +1778,7 @@ ItemActionTextWaitButton:
 	ld a, [wPartyMenuActionText]
 	call ItemActionText
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 50
 	call DelayFrames
 	jp WaitPressAorB_BlinkCursor
@@ -1956,16 +1956,16 @@ GetOneFifthMaxHP:
 	ld a, MON_MAXHP
 	call GetPartyParamLocation
 	ld a, [hli]
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, [hl]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, 5
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld d, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld e, a
 	pop bc
 	ret
@@ -2156,7 +2156,7 @@ XItemEffect:
 	inc hl
 	ld b, [hl]
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld [wAttackMissed], a
 	ld [wEffectFailed], a
 	farcall RaiseStat
@@ -2624,7 +2624,7 @@ UseBallInTrainerBattle:
 	ld [wFXAnimID + 1], a
 	xor a
 	ld [wBattleAnimParam], a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ld [wNumHits], a
 	predef PlayBattleAnim
 	ld hl, BlockedTheBallText
@@ -2788,13 +2788,13 @@ ComputeMaxPP:
 	push bc
 	; Divide the base PP by 5.
 	ld a, [de]
-	ld [hDividend + 3], a
+	ldh [hDividend + 3], a
 	xor a
-	ld [hDividend], a
-	ld [hDividend + 1], a
-	ld [hDividend + 2], a
+	ldh [hDividend], a
+	ldh [hDividend + 1], a
+	ldh [hDividend + 2], a
 	ld a, 5
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 	; Get the number of PP, which are bits 6 and 7 of the PP value stored in RAM.
@@ -2814,7 +2814,7 @@ ComputeMaxPP:
 	; Since this would overflow into bit 6, we prevent that from happening
 	; by decreasing the extra amount of PP each PP Up provides, resulting
 	; in a maximum of 61.
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	cp $8
 	jr c, .okay
 	ld a, $7

--- a/engine/items/mart.asm
+++ b/engine/items/mart.asm
@@ -536,11 +536,11 @@ BargainShopAskPurchaseQuantity:
 	add hl, de
 	inc hl
 	ld a, [hli]
-	ld [hMoneyTemp + 2], a
+	ldh [hMoneyTemp + 2], a
 	ld a, [hl]
-	ld [hMoneyTemp + 1], a
+	ldh [hMoneyTemp + 1], a
 	xor a
-	ld [hMoneyTemp], a
+	ldh [hMoneyTemp], a
 	and a
 	ret
 

--- a/engine/items/pack.asm
+++ b/engine/items/pack.asm
@@ -54,7 +54,7 @@ Pack:
 
 .InitGFX:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	ld a, [wPackJumptableIndex]
 	ld [wJumptableIndex], a
@@ -123,7 +123,7 @@ Pack:
 	call ClearPocketList
 	call DrawPocketName
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitBGMap_DrawPackGFX
 	call Pack_JumptableNext
 	ret
@@ -205,7 +205,7 @@ Pack:
 	ld [wOptions], a
 .declined
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	call WaitBGMap_DrawPackGFX
 	call Pack_InitColors
@@ -454,7 +454,7 @@ UseItem:
 	jr z, .NoPokemon
 	call DoItemEffect
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	call WaitBGMap_DrawPackGFX
 	call Pack_InitColors
@@ -604,7 +604,7 @@ GiveItem:
 	pop af
 	ld [wOptions], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	call WaitBGMap_DrawPackGFX
 	call Pack_InitColors
@@ -664,7 +664,7 @@ BattlePack:
 
 .InitGFX:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	ld a, [wPackJumptableIndex]
 	ld [wJumptableIndex], a
@@ -733,7 +733,7 @@ BattlePack:
 	call ClearPocketList
 	call DrawPocketName
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitBGMap_DrawPackGFX
 	ld hl, Text_PackEmptyString
 	call Pack_PrintTextNoScroll
@@ -868,7 +868,7 @@ TMHMSubmenu:
 	and a
 	jr nz, .quit_run_script
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pack_InitGFX
 	call WaitBGMap_DrawPackGFX
 	call Pack_InitColors
@@ -916,7 +916,7 @@ InitPackBuffers:
 
 DepositSellInitPackBuffers:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wJumptableIndex], a ; PACKSTATE_INITGFX
 	ld [wPackJumptableIndex], a ; PACKSTATE_INITGFX
 	ld [wCurrPocket], a ; ITEM_POCKET

--- a/engine/items/tmhm.asm
+++ b/engine/items/tmhm.asm
@@ -1,9 +1,9 @@
 TMHMPocket:
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call TMHM_PocketLoop
 	ld a, $0
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret nc
 	call PlaceHollowCursor
 	call WaitBGMap
@@ -188,7 +188,7 @@ Text_TMHMNotCompatible:
 
 TMHM_PocketLoop:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call TMHM_DisplayPocketItems
 	ld a, 2
 	ld [w2DMenuCursorInitY], a
@@ -227,7 +227,7 @@ TMHM_JoypadLoop:
 	dec a
 	ld [wTMHMPocketCursor], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [w2DMenuFlags2]
 	bit 7, a
 	jp nz, TMHM_ScrollPocket

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -6,8 +6,8 @@ LinkCommunications:
 	call ClearSprites
 	call UpdateSprites
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld c, 80
 	call DelayFrames
 	call ClearScreen
@@ -42,26 +42,26 @@ Gen2ToGen1LinkComms:
 	xor a
 	ld [wPlayerLinkAction], a
 	call WaitLinkTransfer
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr nz, .player_1
 
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 
 	call DelayFrame
 	xor a
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 
 .player_1
 	ld de, MUSIC_NONE
@@ -69,9 +69,9 @@ Gen2ToGen1LinkComms:
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $8
-	ld [rIE], a
+	ldh [rIE], a
 	ld hl, wd1f3
 	ld de, wEnemyMonSpecies
 	ld bc, $11
@@ -89,9 +89,9 @@ Gen2ToGen1LinkComms:
 	ld bc, wTrademons - wLink_c608
 	call Serial_ExchangeBytes
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $1d
-	ld [rIE], a
+	ldh [rIE], a
 	call Link_CopyRandomNumbers
 	ld hl, wOTPlayerName
 	call Link_FindFirstNonControlCharacter_SkipZero
@@ -170,7 +170,7 @@ Gen2ToGen1LinkComms:
 	ld [wUnusedD102 + 1], a
 	ld de, MUSIC_NONE
 	call PlayMusic
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	ld c, 66
 	call z, DelayFrames
@@ -186,26 +186,26 @@ Gen2ToGen2LinkComms:
 	ld a, [wScriptVar]
 	and a
 	jp z, LinkTimeout
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr nz, .Player1
 
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 
 	call DelayFrame
 	xor a
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 
 .Player1:
 	ld de, MUSIC_NONE
@@ -213,9 +213,9 @@ Gen2ToGen2LinkComms:
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $8
-	ld [rIE], a
+	ldh [rIE], a
 	ld hl, wd1f3
 	ld de, wEnemyMonSpecies
 	ld bc, $11
@@ -242,9 +242,9 @@ Gen2ToGen2LinkComms:
 
 .not_trading
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $1d
-	ld [rIE], a
+	ldh [rIE], a
 	ld de, MUSIC_NONE
 	call PlayMusic
 	call Link_CopyRandomNumbers
@@ -412,7 +412,7 @@ Gen2ToGen2LinkComms:
 	ld [wUnusedD102 + 1], a
 	ld de, MUSIC_NONE
 	call PlayMusic
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	ld c, 66
 	call z, DelayFrames
@@ -440,28 +440,28 @@ Gen2ToGen2LinkComms:
 	push af
 	ld a, 1
 	ld [wDisableTextAcceleration], a
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
-	ld a, [rIF]
+	ldh a, [rIF]
 	push af
 	xor a
-	ld [rIF], a
-	ld a, [rIE]
+	ldh [rIF], a
+	ldh a, [rIE]
 	set 1, a
-	ld [rIE], a
+	ldh [rIE], a
 	pop af
-	ld [rIF], a
+	ldh [rIF], a
 
 	predef StartBattle
 
-	ld a, [rIF]
+	ldh a, [rIF]
 	ld h, a
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	ld a, h
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
 	ld [wDisableTextAcceleration], a
 	pop af
@@ -485,7 +485,7 @@ LinkTimeout:
 	xor a
 	ld [hld], a
 	ld [hl], a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	push de
 	hlcoord 0, 12
 	ld b, 4
@@ -512,10 +512,10 @@ LinkTimeout:
 
 ExchangeBytes:
 	ld a, TRUE
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 .loop
 	ld a, [hl]
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	call Serial_ExchangeByte
 	push bc
 	ld b, a
@@ -524,14 +524,14 @@ ExchangeBytes:
 .delay_cycles
 	dec a
 	jr nz, .delay_cycles
-	ld a, [hSerialIgnoringInitialData]
+	ldh a, [hSerialIgnoringInitialData]
 	and a
 	ld a, b
 	pop bc
 	jr z, .load
 	dec hl
 	xor a
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 	jr .loop
 
 .load
@@ -786,10 +786,10 @@ Link_PrepPartyData_Gen1:
 	pop bc
 	pop de
 
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [de], a
 	inc de
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [de], a
 	inc de
 	ld h, b
@@ -1059,9 +1059,9 @@ Function2868a:
 	predef CalcMonStatC
 	pop bc
 	pop hl
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [hli], a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [hli], a
 	push hl
 	push bc
@@ -1072,9 +1072,9 @@ Function2868a:
 	predef CalcMonStatC
 	pop bc
 	pop hl
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	ld [hli], a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld [hli], a
 	push hl
 	ld hl, $1b
@@ -1128,7 +1128,7 @@ Link_CopyOTData:
 	ret
 
 Link_CopyRandomNumbers:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	ret z
 	ld hl, wEnemyMonSpecies
@@ -1518,7 +1518,7 @@ Function28ade:
 	ldcoord_a 9, 17
 .loop2
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and a
 	jr z, .loop2
 	bit A_BUTTON_F, a
@@ -1556,12 +1556,12 @@ Function28b22:
 	xor a
 	ld [wcfbb], a
 	xor a
-	ld [rSB], a
-	ld [hSerialSend], a
+	ldh [rSB], a
+	ldh [hSerialSend], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ret
 
 Unreferenced_Function28b42:
@@ -1851,7 +1851,7 @@ LinkTrade:
 	call LoadFontsBattleExtra
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player_2
 	predef TradeAnimation
@@ -2091,7 +2091,7 @@ EnterTimeCapsule:
 	ld c, 40
 	call DelayFrames
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	inc a
 	ld [wLinkMode], a
 	ret
@@ -2100,46 +2100,46 @@ WaitForOtherPlayerToExit:
 	ld c, 3
 	call DelayFrames
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 	xor a
-	ld [rSB], a
-	ld [hSerialReceive], a
+	ldh [rSB], a
+	ldh [hSerialReceive], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [rSB], a
-	ld [hSerialReceive], a
+	ldh [rSB], a
+	ldh [hSerialReceive], a
 	ld a, (0 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [rSB], a
-	ld [hSerialReceive], a
-	ld [rSC], a
+	ldh [rSB], a
+	ldh [hSerialReceive], a
+	ldh [rSC], a
 	ld c, 3
 	call DelayFrames
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
-	ld a, [rIF]
+	ldh [hSerialConnectionStatus], a
+	ldh a, [rIF]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $f
-	ld [rIE], a
+	ldh [rIE], a
 	pop af
-	ld [rIF], a
+	ldh [rIF], a
 	ld hl, wLinkTimeoutFrames
 	xor a
 	ld [hli], a
 	ld [hl], a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld [wLinkMode], a
 	ret
 
@@ -2157,13 +2157,13 @@ SetBitsForBattleRequest:
 
 SetBitsForTimeCapsuleRequest:
 	ld a, $2
-	ld [rSB], a
+	ldh [rSB], a
 	xor a
-	ld [hSerialReceive], a
+	ldh [hSerialReceive], a
 	ld a, (0 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	xor a ; LINK_TIMECAPSULE - 1
 	ld [wPlayerLinkAction], a
 	ld [wChosenCableClubRoom], a
@@ -2174,13 +2174,13 @@ WaitForLinkedFriend:
 	and a
 	jr z, .no_link_action
 	ld a, $2
-	ld [rSB], a
+	ldh [rSB], a
 	xor a
-	ld [hSerialReceive], a
+	ldh [hSerialReceive], a
 	ld a, (0 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
@@ -2191,21 +2191,21 @@ WaitForLinkedFriend:
 	ld a, $ff
 	ld [wLinkTimeoutFrames], a
 .loop
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .connected
 	cp USING_EXTERNAL_CLOCK
 	jr z, .connected
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 	ld a, $2
-	ld [rSB], a
+	ldh [rSB], a
 	xor a
-	ld [hSerialReceive], a
+	ldh [hSerialReceive], a
 	ld a, (0 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 0
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, [wLinkTimeoutFrames]
 	dec a
 	ld [wLinkTimeoutFrames], a
@@ -2217,11 +2217,11 @@ WaitForLinkedFriend:
 
 .not_done
 	ld a, $1
-	ld [rSB], a
+	ldh [rSB], a
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	call DelayFrame
 	jr .loop
 
@@ -2250,12 +2250,12 @@ CheckLinkTimeout:
 	ld [hl], a
 	call WaitBGMap
 	ld a, $2
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call DelayFrame
 	call DelayFrame
 	call Link_CheckCommunicationError
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, [wScriptVar]
 	and a
 	ret nz
@@ -2271,7 +2271,7 @@ Function29dba:
 	ld [hl], a
 	call WaitBGMap
 	ld a, $2
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call DelayFrame
 	call DelayFrame
 	call Link_CheckCommunicationError
@@ -2305,12 +2305,12 @@ Function29dba:
 
 .vblank
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ret
 
 Link_CheckCommunicationError:
 	xor a
-	ld [hSerialReceivedNewData], a
+	ldh [hSerialReceivedNewData], a
 	ld a, [wLinkTimeoutFrames]
 	ld h, a
 	ld a, [wLinkTimeoutFrames + 1]
@@ -2403,7 +2403,7 @@ CheckBothSelectedSameRoom:
 	inc a
 	ld [wLinkMode], a
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, TRUE
 	ld [wScriptVar], a
 	ret
@@ -2420,7 +2420,7 @@ TimeCapsule:
 	callfar LinkCommunications
 	call EnableSpriteUpdates
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ret
 
 TradeCenter:
@@ -2430,7 +2430,7 @@ TradeCenter:
 	callfar LinkCommunications
 	call EnableSpriteUpdates
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ret
 
 Colosseum:
@@ -2440,7 +2440,7 @@ Colosseum:
 	callfar LinkCommunications
 	call EnableSpriteUpdates
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ret
 
 CloseLink:
@@ -2460,12 +2460,12 @@ Link_ResetSerialRegistersAfterLinkClosure:
 	ld c, 3
 	call DelayFrames
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 	ld a, $2
-	ld [rSB], a
+	ldh [rSB], a
 	xor a
-	ld [hSerialReceive], a
-	ld [rSC], a
+	ldh [hSerialReceive], a
+	ldh [rSC], a
 	ret
 
 Link_EnsureSync:
@@ -2473,7 +2473,7 @@ Link_EnsureSync:
 	ld [wPlayerLinkAction], a
 	ld [wcf57], a
 	ld a, $2
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call DelayFrame
 	call DelayFrame
 .receive_loop
@@ -2491,13 +2491,13 @@ Link_EnsureSync:
 
 .done
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, b
 	and $f
 	ret
 
 CableClubCheckWhichChris:
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	ld a, TRUE
 	jr z, .yes

--- a/engine/link/link_trade.asm
+++ b/engine/link/link_trade.asm
@@ -185,10 +185,10 @@ LinkTradeMenu:
 .GetJoypad:
 	push bc
 	push af
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_PAD
 	ld b, a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and BUTTONS
 	or b
 	ld b, a
@@ -201,11 +201,11 @@ LinkTradeMenu:
 .MenuAction:
 	ld hl, w2DMenuFlags2
 	res 7, [hl]
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	call .loop
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .loop
@@ -228,15 +228,15 @@ LinkTradeMenu:
 	ret
 
 .UpdateBGMapAndOAM:
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call WaitBGMap
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .loop2

--- a/engine/link/mystery_gift.asm
+++ b/engine/link/mystery_gift.asm
@@ -13,16 +13,16 @@ DoMysteryGift:
 	ld [wca01], a
 	ld a, $14
 	ld [wca02], a
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 
 	call Function104a95
 
 	ld d, a
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	push de
 	call ClearTileMap
 	call EnableLCD
@@ -117,7 +117,7 @@ DoMysteryGift:
 .PrintTextAndExit:
 	call PrintText
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ret
 
 .String_PressAToLink_BToCancel:
@@ -233,13 +233,13 @@ Function104a95:
 .loop2
 	call Function104d96
 	call Function104ddd
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $10
 	jp z, Function104bd0
 	cp $6c
 	jr nz, .loop2
 
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	cp $2
 	jr z, Function104b22
 	ld hl, hPrintNum1
@@ -251,7 +251,7 @@ Function104a95:
 	jr Function104b0a
 	; Delay frame
 .ly_loop
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	jr c, .ly_loop
 	ld c, LOW(rRP)
@@ -270,14 +270,14 @@ Function104a95:
 	ld a, [$ff00+c]
 	and b
 	ld b, a
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	jr nc, .ly_loop2
 .ly_loop3
 	ld a, [$ff00+c]
 	and b
 	ld b, a
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	jr c, .ly_loop3
 
@@ -288,11 +288,11 @@ Function104a95:
 	or a
 	jr nz, .loop2
 	; Check if we've pressed the B button
-	ld a, [hMGJoypadReleased]
+	ldh a, [hMGJoypadReleased]
 	bit B_BUTTON_F, a
 	jr z, .loop3
 	ld a, $10
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	jp Function104bd0
 
 Function104b04:
@@ -328,14 +328,14 @@ Function104b40:
 
 Function104b49:
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	cp $96
 	jp nz, Function104d32
 	ld a, $90
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	call Function104d38
 	ret nz
 	ld hl, hPrintNum1
@@ -343,7 +343,7 @@ Function104b49:
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
 	call Function104d43
@@ -354,19 +354,19 @@ Function104b49:
 	call Function104d56
 	ret nz
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104b88:
 	ld a, $96
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	ld hl, hPrintNum1
 	ld b, $1
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
 	call Function104d43
@@ -376,10 +376,10 @@ Function104b88:
 	call Function104d56
 	ret nz
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	cp $90
 	jp nz, Function104d32
 	call Function104d38
@@ -390,13 +390,13 @@ Function104b88:
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104bd0:
 	nop
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $10
 	jr z, .quit
 	cp $6c
@@ -415,7 +415,7 @@ Function104bd0:
 	call MysteryGift_ClearTrainerData
 	ld a, $26
 	ld [wca02], a
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	cp $2
 	jr z, .asm_104c10
 	call Function104d43
@@ -428,14 +428,14 @@ Function104bd0:
 	jp Function104b22
 
 .quit
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	push af
 	call Function104da0
 	xor a
-	ld [rIF], a
-	ld a, [rIE]
+	ldh [rIF], a
+	ldh a, [rIE]
 	or $1
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 	call DelayFrame
 	pop af
@@ -448,12 +448,12 @@ Function104c2d:
 .asm_104c37
 	call Function104d96
 	call Function104ddd
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $10
 	jp z, Function104d1c
 	cp $6c
 	jr nz, .asm_104c37
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	cp $2
 	jr z, .asm_104c6c
 	call Function104c8a
@@ -484,14 +484,14 @@ Function104c8a:
 	call Function104d56
 	ret nz
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	cp $3c
 	jp nz, Function104d32
 	swap a
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	call Function104d38
 	ret nz
 	ld hl, hPrintNum1
@@ -499,7 +499,7 @@ Function104c8a:
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
 	call Function104d43
@@ -510,19 +510,19 @@ Function104c8a:
 	call Function104d56
 	ret nz
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104cd2:
 	ld a, $3c
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	ld hl, hPrintNum1
 	ld b, $1
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
 	call Function104d43
@@ -532,10 +532,10 @@ Function104cd2:
 	call Function104d56
 	ret nz
 	call Function105033
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret nz
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	swap a
 	cp $3c
 	jp nz, Function104d32
@@ -547,20 +547,20 @@ Function104cd2:
 	call Function104d4e
 	ret nz
 	call Function10502e
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104d1c:
 	nop
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	push af
 	call Function104da0
 	xor a
-	ld [rIF], a
-	ld a, [rIE]
+	ldh [rIF], a
+	ldh a, [rIE]
 	or $1
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 	call DelayFrame
 	pop af
@@ -568,42 +568,42 @@ Function104d1c:
 
 Function104d32:
 	ld a, $80
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	and a
 	ret
 
 Function104d38:
 	call Function104d96
 	call Function104e46
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104d43:
 	call Function104d96
 	call Function104dfe
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104d4e:
 	call Function104e93
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104d56:
 	call Function104f57
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	cp $6c
 	ret
 
 Function104d5e:
 	call Function104d74
 	ld a, $4
-	ld [rIE], a
+	ldh [rIE], a
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	call Function104d96
 	xor a
 	ld b, a
@@ -616,46 +616,46 @@ Function104d5e:
 
 Function104d74:
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld a, $fe
-	ld [rTMA], a
-	ld [rTIMA], a
+	ldh [rTMA], a
+	ldh [rTIMA], a
 	ld a, $2
-	ld [rTAC], a
+	ldh [rTAC], a
 	or $4
-	ld [rTAC], a
+	ldh [rTAC], a
 	ret
 
 Function104d86:
 	xor a
-	ld [rTAC], a
-	ld [rTMA], a
-	ld [rTIMA], a
+	ldh [rTAC], a
+	ldh [rTMA], a
+	ldh [rTIMA], a
 	ld a, $2
-	ld [rTAC], a
+	ldh [rTAC], a
 	or $4
-	ld [rTAC], a
+	ldh [rTAC], a
 	ret
 
 Function104d96:
 	ld a, $c0
 	call Function104e8c
 	ld a, $1
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 	ret
 
 Function104da0:
 	xor a
 	call Function104e8c
 	ld a, $2
-	ld [rTAC], a
+	ldh [rTAC], a
 	ret
 
 Function104da9:
 	inc d
 	ret z
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	ld a, [$ff00+c]
 	bit 1, a
@@ -667,7 +667,7 @@ Function104db7:
 	inc d
 	ret z
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	ld a, [$ff00+c]
 	bit 1, a
@@ -682,7 +682,7 @@ Function104dc5:
 	dec d
 	ret z
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	jr .wait
 
@@ -693,7 +693,7 @@ Function104dd1:
 	dec d
 	ret z
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	jr .wait
 
@@ -701,16 +701,16 @@ Function104ddd:
 	ld d, $0
 	ld e, d
 	ld a, $1
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 .loop
 	call MysteryGift_ReadJoypad
 	ld b, $2
 	ld c, LOW(rRP)
-	ld a, [hMGJoypadReleased]
+	ldh a, [hMGJoypadReleased]
 	bit B_BUTTON_F, a
 	jr z, .next
 	ld a, $10
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 .next
@@ -734,7 +734,7 @@ Function104dfe:
 	call Function104da9
 	jp z, Function104f42
 	ld a, $6c
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ld d, $3d
 	call Function104dd1
 	ld d, $5
@@ -760,7 +760,7 @@ Function104e3a:
 	jr nz, .loop
 Function104e46:
 	ld a, $2
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 	ld c, LOW(rRP)
 	ld d, $0
 	ld e, d
@@ -787,19 +787,19 @@ Function104e46:
 	ld d, $3d
 	call Function104dd1
 	ld a, $6c
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 Function104e8c:
-	ld [rRP], a
+	ldh [rRP], a
 	ld a, $ff
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 Function104e93:
 	xor a
-	ld [hPrintNum5], a
-	ld [hPrintNum6], a
+	ldh [hPrintNum5], a
+	ldh [hPrintNum6], a
 	push hl
 	push bc
 	ld c, LOW(rRP)
@@ -815,10 +815,10 @@ Function104e93:
 	pop bc
 	pop hl
 	call Function104ed6
-	ld a, [hPrintNum5]
-	ld [hPrintNum2], a
-	ld a, [hPrintNum6]
-	ld [hPrintNum3], a
+	ldh a, [hPrintNum5]
+	ldh [hPrintNum2], a
+	ldh a, [hPrintNum6]
+	ldh [hPrintNum3], a
 	push hl
 	ld hl, hPrintNum2
 	ld b, $2
@@ -826,10 +826,10 @@ Function104e93:
 	ld hl, hMGStatusFlags
 	ld b, $1
 	call Function104faf
-	ld a, [hPrintNum2]
-	ld [hPrintNum5], a
-	ld a, [hPrintNum3]
-	ld [hPrintNum6], a
+	ldh a, [hPrintNum2]
+	ldh [hPrintNum5], a
+	ldh a, [hPrintNum3]
+	ldh [hPrintNum6], a
 	pop hl
 	ret
 
@@ -845,26 +845,26 @@ Function104ed6:
 	cpl
 	ld b, a
 	ld a, $f4
-	ld [rTMA], a
+	ldh [rTMA], a
 .asm_104eee
 	inc b
 	jr z, .asm_104f2e
 	ld a, $8
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	ld a, [hli]
 	ld e, a
-	ld a, [hPrintNum5]
+	ldh a, [hPrintNum5]
 	add e
-	ld [hPrintNum5], a
-	ld a, [hPrintNum6]
+	ldh [hPrintNum5], a
+	ldh a, [hPrintNum6]
 	adc 0
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 .asm_104f02
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	ld a, $c1
-	ld [rRP], a
+	ldh [rRP], a
 	ld d, $1
 	ld a, e
 	rlca
@@ -872,27 +872,27 @@ Function104ed6:
 	jr nc, .asm_104f13
 	inc d
 .asm_104f13
-	ld a, [rTIMA]
+	ldh a, [rTIMA]
 	cp $f8
 	jr c, .asm_104f13
 	ld a, $c0
-	ld [rRP], a
+	ldh [rRP], a
 	dec d
 	jr z, .asm_104f25
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 .asm_104f25
-	ld a, [hPrintNum4]
+	ldh a, [hPrintNum4]
 	dec a
 	jr z, .asm_104eee
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	jr .asm_104f02
 .asm_104f2e
 	ld a, $fe
-	ld [rTMA], a
+	ldh [rTMA], a
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	halt
 	ld d, $5
 	call Function104dc5
@@ -901,46 +901,46 @@ Function104ed6:
 	ret
 
 Function104f42:
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	or $2
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 Function104f49:
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	or $1
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 Function104f50:
-	ld a, [hMGStatusFlags]
+	ldh a, [hMGStatusFlags]
 	or $80
-	ld [hMGStatusFlags], a
+	ldh [hMGStatusFlags], a
 	ret
 
 Function104f57:
 	xor a
-	ld [hPrintNum5], a
-	ld [hPrintNum6], a
+	ldh [hPrintNum5], a
+	ldh [hPrintNum6], a
 	push bc
 	push hl
 	ld hl, hPrintNum2
 	ld b, $2
 	call Function104faf
-	ld a, [hPrintNum3]
-	ld [hPrintNum8], a
+	ldh a, [hPrintNum3]
+	ldh [hPrintNum8], a
 	ld b, a
 	pop hl
 	pop af
 	cp b
 	jp c, Function104f50
-	ld a, [hPrintNum2]
+	ldh a, [hPrintNum2]
 	cp $5a
 	jp nz, Function104f50
 	call Function104faf
-	ld a, [hPrintNum5]
+	ldh a, [hPrintNum5]
 	ld d, a
-	ld a, [hPrintNum6]
+	ldh a, [hPrintNum6]
 	ld e, a
 	push hl
 	push de
@@ -965,9 +965,9 @@ Function104f57:
 	pop de
 	pop hl
 	ld a, d
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	ld a, e
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ret
 
 Function104faf:
@@ -985,13 +985,13 @@ Function104faf:
 	cpl
 	ld b, a
 	xor a
-	ld [hMGJoypadPressed + 2], a
+	ldh [hMGJoypadPressed + 2], a
 	call Function104d86
 .asm_104fd2
 	inc b
 	jr z, .asm_10501a
 	ld a, $8
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 .asm_104fd9
 	ld d, $0
 .asm_104fdb
@@ -1008,10 +1008,10 @@ Function104faf:
 	bit 1, a
 	jr nz, .asm_104fe5
 .asm_104fed
-	ld a, [hMGJoypadPressed + 2]
+	ldh a, [hMGJoypadPressed + 2]
 	ld d, a
-	ld a, [rTIMA]
-	ld [hMGJoypadPressed + 2], a
+	ldh a, [rTIMA]
+	ldh [hMGJoypadPressed + 2], a
 	sub d
 	cp $12
 	jr c, .asm_104ffd
@@ -1020,9 +1020,9 @@ Function104faf:
 .asm_104ffd
 	res 0, e
 .asm_104fff
-	ld a, [hPrintNum4]
+	ldh a, [hPrintNum4]
 	dec a
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	jr z, .asm_10500b
 	ld a, e
 	rlca
@@ -1031,17 +1031,17 @@ Function104faf:
 .asm_10500b
 	ld a, e
 	ld [hli], a
-	ld a, [hPrintNum5]
+	ldh a, [hPrintNum5]
 	add e
-	ld [hPrintNum5], a
-	ld a, [hPrintNum6]
+	ldh [hPrintNum5], a
+	ldh a, [hPrintNum6]
 	adc 0
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	jr .asm_104fd2
 .asm_10501a
 	call Function104d74
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld d, $0
 	call Function104da9
 	jp z, Function104f42
@@ -1061,10 +1061,10 @@ MysteryGift_ReadJoypad:
 ; We can only get four inputs at a time.
 ; We take d-pad first for no particular reason.
 	ld a, R_DPAD
-	ld [rJOYP], a
+	ldh [rJOYP], a
 ; Read twice to give the request time to take.
-	ld a, [rJOYP]
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
+	ldh a, [rJOYP]
 
 ; The Joypad register output is in the lo nybble (inversed).
 ; We make the hi nybble of our new container d-pad input.
@@ -1078,10 +1078,10 @@ MysteryGift_ReadJoypad:
 ; Buttons make 8 total inputs (A, B, Select, Start).
 ; We can fit this into one byte.
 	ld a, R_BUTTONS
-	ld [rJOYP], a
+	ldh [rJOYP], a
 ; Wait for input to stabilize.
 rept 6
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
 endr
 ; Buttons take the lo nybble.
 	cpl
@@ -1089,17 +1089,17 @@ endr
 	or b
 	ld c, a
 ; To get the delta we xor the last frame's input with the new one.
-	ld a, [hMGJoypadPressed]
+	ldh a, [hMGJoypadPressed]
 	xor c
 ; Released this frame:
 	and c
-	ld [hMGJoypadReleased], a
+	ldh [hMGJoypadReleased], a
 ; Pressed this frame:
 	ld a, c
-	ld [hMGJoypadPressed], a
+	ldh [hMGJoypadPressed], a
 	ld a, $30
 ; Reset the joypad register since we're done with it.
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ret
 
 MysteryGift_CheckAndSetDecorationAlreadyReceived:
@@ -1408,14 +1408,14 @@ Function105688:
 	call MysteryGift_ClearTrainerData
 	ld a, $24
 	ld [wca02], a
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	call Function104c2d
 	ld d, a
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	ld a, d
 	cp $10
 	jp z, Function105712
@@ -1479,7 +1479,7 @@ Function10571a:
 PrintTextAndExit_JP:
 	call PrintText
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ret
 
 String_PressAToLink_BToCancel_JP:

--- a/engine/link/time_capsule.asm
+++ b/engine/link/time_capsule.asm
@@ -128,7 +128,7 @@ PlaceTradePartnerNamesAndParty:
 	push de
 	push hl
 	ld a, c
-	ld [hProduct], a
+	ldh [hProduct], a
 	call GetPokemonName
 	pop hl
 	call PlaceString

--- a/engine/math/math.asm
+++ b/engine/math/math.asm
@@ -4,41 +4,41 @@ _Multiply::
 	ld b, a
 
 	xor a
-	ld [hProduct], a
-	ld [hMathBuffer + 1], a
-	ld [hMathBuffer + 2], a
-	ld [hMathBuffer + 3], a
-	ld [hMathBuffer + 4], a
+	ldh [hProduct], a
+	ldh [hMathBuffer + 1], a
+	ldh [hMathBuffer + 2], a
+	ldh [hMathBuffer + 3], a
+	ldh [hMathBuffer + 4], a
 
 .loop
-	ld a, [hMultiplier]
+	ldh a, [hMultiplier]
 	srl a
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	jr nc, .next
 
-	ld a, [hMathBuffer + 4]
+	ldh a, [hMathBuffer + 4]
 	ld c, a
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	add c
-	ld [hMathBuffer + 4], a
+	ldh [hMathBuffer + 4], a
 
-	ld a, [hMathBuffer + 3]
+	ldh a, [hMathBuffer + 3]
 	ld c, a
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	adc c
-	ld [hMathBuffer + 3], a
+	ldh [hMathBuffer + 3], a
 
-	ld a, [hMathBuffer + 2]
+	ldh a, [hMathBuffer + 2]
 	ld c, a
-	ld a, [hMultiplicand + 0]
+	ldh a, [hMultiplicand + 0]
 	adc c
-	ld [hMathBuffer + 2], a
+	ldh [hMathBuffer + 2], a
 
-	ld a, [hMathBuffer + 1]
+	ldh a, [hMathBuffer + 1]
 	ld c, a
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	adc c
-	ld [hMathBuffer + 1], a
+	ldh [hMathBuffer + 1], a
 
 .next
 	dec b
@@ -46,71 +46,71 @@ _Multiply::
 
 ; hMultiplicand <<= 1
 
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	add a
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	rla
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 
-	ld a, [hMultiplicand + 0]
+	ldh a, [hMultiplicand + 0]
 	rla
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	rla
-	ld [hProduct], a
+	ldh [hProduct], a
 
 	jr .loop
 
 .done
-	ld a, [hMathBuffer + 4]
-	ld [hProduct + 3], a
+	ldh a, [hMathBuffer + 4]
+	ldh [hProduct + 3], a
 
-	ld a, [hMathBuffer + 3]
-	ld [hProduct + 2], a
+	ldh a, [hMathBuffer + 3]
+	ldh [hProduct + 2], a
 
-	ld a, [hMathBuffer + 2]
-	ld [hProduct + 1], a
+	ldh a, [hMathBuffer + 2]
+	ldh [hProduct + 1], a
 
-	ld a, [hMathBuffer + 1]
-	ld [hProduct + 0], a
+	ldh a, [hMathBuffer + 1]
+	ldh [hProduct + 0], a
 
 	ret
 
 _Divide::
 	xor a
-	ld [hMathBuffer + 0], a
-	ld [hMathBuffer + 1], a
-	ld [hMathBuffer + 2], a
-	ld [hMathBuffer + 3], a
-	ld [hMathBuffer + 4], a
+	ldh [hMathBuffer + 0], a
+	ldh [hMathBuffer + 1], a
+	ldh [hMathBuffer + 2], a
+	ldh [hMathBuffer + 3], a
+	ldh [hMathBuffer + 4], a
 
 	ld a, 9
 	ld e, a
 
 .loop
-	ld a, [hMathBuffer + 0]
+	ldh a, [hMathBuffer + 0]
 	ld c, a
-	ld a, [hDividend + 1]
+	ldh a, [hDividend + 1]
 	sub c
 	ld d, a
 
-	ld a, [hDivisor]
+	ldh a, [hDivisor]
 	ld c, a
-	ld a, [hDividend + 0]
+	ldh a, [hDividend + 0]
 	sbc c
 	jr c, .next
 
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 
 	ld a, d
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 
-	ld a, [hMathBuffer + 4]
+	ldh a, [hMathBuffer + 4]
 	inc a
-	ld [hMathBuffer + 4], a
+	ldh [hMathBuffer + 4], a
 
 	jr .loop
 
@@ -119,39 +119,39 @@ _Divide::
 	cp 1
 	jr z, .done
 
-	ld a, [hMathBuffer + 4]
+	ldh a, [hMathBuffer + 4]
 	add a
-	ld [hMathBuffer + 4], a
+	ldh [hMathBuffer + 4], a
 
-	ld a, [hMathBuffer + 3]
+	ldh a, [hMathBuffer + 3]
 	rla
-	ld [hMathBuffer + 3], a
+	ldh [hMathBuffer + 3], a
 
-	ld a, [hMathBuffer + 2]
+	ldh a, [hMathBuffer + 2]
 	rla
-	ld [hMathBuffer + 2], a
+	ldh [hMathBuffer + 2], a
 
-	ld a, [hMathBuffer + 1]
+	ldh a, [hMathBuffer + 1]
 	rla
-	ld [hMathBuffer + 1], a
+	ldh [hMathBuffer + 1], a
 
 	dec e
 	jr nz, .next2
 
 	ld e, 8
-	ld a, [hMathBuffer + 0]
-	ld [hDivisor], a
+	ldh a, [hMathBuffer + 0]
+	ldh [hDivisor], a
 	xor a
-	ld [hMathBuffer + 0], a
+	ldh [hMathBuffer + 0], a
 
-	ld a, [hDividend + 1]
-	ld [hDividend + 0], a
+	ldh a, [hDividend + 1]
+	ldh [hDividend + 0], a
 
-	ld a, [hDividend + 2]
-	ld [hDividend + 1], a
+	ldh a, [hDividend + 2]
+	ldh [hDividend + 1], a
 
-	ld a, [hDividend + 3]
-	ld [hDividend + 2], a
+	ldh a, [hDividend + 3]
+	ldh [hDividend + 2], a
 
 .next2
 	ld a, e
@@ -160,30 +160,30 @@ _Divide::
 	dec b
 
 .okay
-	ld a, [hDivisor]
+	ldh a, [hDivisor]
 	srl a
-	ld [hDivisor], a
+	ldh [hDivisor], a
 
-	ld a, [hMathBuffer + 0]
+	ldh a, [hMathBuffer + 0]
 	rr a
-	ld [hMathBuffer + 0], a
+	ldh [hMathBuffer + 0], a
 
 	jr .loop
 
 .done
-	ld a, [hDividend + 1]
-	ld [hDivisor], a
+	ldh a, [hDividend + 1]
+	ldh [hDivisor], a
 
-	ld a, [hMathBuffer + 4]
-	ld [hDividend + 3], a
+	ldh a, [hMathBuffer + 4]
+	ldh [hDividend + 3], a
 
-	ld a, [hMathBuffer + 3]
-	ld [hDividend + 2], a
+	ldh a, [hMathBuffer + 3]
+	ldh [hDividend + 2], a
 
-	ld a, [hMathBuffer + 2]
-	ld [hDividend + 1], a
+	ldh a, [hMathBuffer + 2]
+	ldh [hDividend + 1], a
 
-	ld a, [hMathBuffer + 1]
-	ld [hDividend + 0], a
+	ldh a, [hMathBuffer + 1]
+	ldh [hDividend + 0], a
 
 	ret

--- a/engine/math/print_num.asm
+++ b/engine/math/print_num.asm
@@ -23,9 +23,9 @@ _PrintNum::
 
 .main
 	xor a
-	ld [hPrintNum1], a
-	ld [hPrintNum2], a
-	ld [hPrintNum3], a
+	ldh [hPrintNum1], a
+	ldh [hPrintNum2], a
+	ldh [hPrintNum3], a
 	ld a, b
 	and $f
 	cp 1
@@ -35,26 +35,26 @@ _PrintNum::
 ; maximum 3 bytes
 .long
 	ld a, [de]
-	ld [hPrintNum2], a
+	ldh [hPrintNum2], a
 	inc de
 	ld a, [de]
-	ld [hPrintNum3], a
+	ldh [hPrintNum3], a
 	inc de
 	ld a, [de]
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	jr .start
 
 .word
 	ld a, [de]
-	ld [hPrintNum3], a
+	ldh [hPrintNum3], a
 	inc de
 	ld a, [de]
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	jr .start
 
 .byte
 	ld a, [de]
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 
 .start
 	push de
@@ -81,51 +81,51 @@ _PrintNum::
 
 .seven
 	ld a, HIGH(1000000 >> 8)
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	ld a, HIGH(1000000) ; mid
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, LOW(1000000)
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	call .PrintDigit
 	call .AdvancePointer
 
 .six
 	ld a, HIGH(100000 >> 8)
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	ld a, HIGH(100000) ; mid
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, LOW(100000)
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	call .PrintDigit
 	call .AdvancePointer
 
 .five
 	xor a ; HIGH(10000 >> 8)
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	ld a, HIGH(10000) ; mid
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, LOW(10000)
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	call .PrintDigit
 	call .AdvancePointer
 
 .four
 	xor a ; HIGH(1000 >> 8)
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	ld a, HIGH(1000) ; mid
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, LOW(1000)
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	call .PrintDigit
 	call .AdvancePointer
 
 .three
 	xor a ; HIGH(100 >> 8)
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	xor a ; HIGH(100) ; mid
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, LOW(100)
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	call .PrintDigit
 	call .AdvancePointer
 
@@ -133,11 +133,11 @@ _PrintNum::
 	dec e
 	jr nz, .two_skip
 	ld a, "0"
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 .two_skip
 
 	ld c, 0
-	ld a, [hPrintNum4]
+	ldh a, [hPrintNum4]
 .mod_10
 	cp 10
 	jr c, .modded_10
@@ -147,7 +147,7 @@ _PrintNum::
 .modded_10
 
 	ld b, a
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	or c
 	jr nz, .money
 	call .PrintLeadingZero
@@ -160,7 +160,7 @@ _PrintNum::
 	add c
 	ld [hl], a
 	pop af
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	inc e
 	dec e
 	jr nz, .money_leading_zero
@@ -180,7 +180,7 @@ _PrintNum::
 
 .PrintYen:
 	push af
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	and a
 	jr nz, .stop
 	bit 5, d
@@ -197,68 +197,68 @@ _PrintNum::
 	dec e
 	jr nz, .ok
 	ld a, "0"
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 .ok
 	ld c, 0
 .loop
-	ld a, [hPrintNum5]
+	ldh a, [hPrintNum5]
 	ld b, a
-	ld a, [hPrintNum2]
-	ld [hPrintNum8], a
+	ldh a, [hPrintNum2]
+	ldh [hPrintNum8], a
 	cp b
 	jr c, .skip1
 	sub b
-	ld [hPrintNum2], a
-	ld a, [hPrintNum6]
+	ldh [hPrintNum2], a
+	ldh a, [hPrintNum6]
 	ld b, a
-	ld a, [hPrintNum3]
-	ld [hPrintNum9], a
+	ldh a, [hPrintNum3]
+	ldh [hPrintNum9], a
 	cp b
 	jr nc, .skip2
-	ld a, [hPrintNum2]
+	ldh a, [hPrintNum2]
 	or 0
 	jr z, .skip3
 	dec a
-	ld [hPrintNum2], a
-	ld a, [hPrintNum3]
+	ldh [hPrintNum2], a
+	ldh a, [hPrintNum3]
 .skip2
 	sub b
-	ld [hPrintNum3], a
-	ld a, [hPrintNum7]
+	ldh [hPrintNum3], a
+	ldh a, [hPrintNum7]
 	ld b, a
-	ld a, [hPrintNum4]
-	ld [hPrintNum10], a
+	ldh a, [hPrintNum4]
+	ldh [hPrintNum10], a
 	cp b
 	jr nc, .skip4
-	ld a, [hPrintNum3]
+	ldh a, [hPrintNum3]
 	and a
 	jr nz, .skip5
-	ld a, [hPrintNum2]
+	ldh a, [hPrintNum2]
 	and a
 	jr z, .skip6
 	dec a
-	ld [hPrintNum2], a
+	ldh [hPrintNum2], a
 	xor a
 .skip5
 	dec a
-	ld [hPrintNum3], a
-	ld a, [hPrintNum4]
+	ldh [hPrintNum3], a
+	ldh a, [hPrintNum4]
 .skip4
 	sub b
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	inc c
 	jr .loop
 .skip6
-	ld a, [hPrintNum9]
-	ld [hPrintNum3], a
+	ldh a, [hPrintNum9]
+	ldh [hPrintNum3], a
 .skip3
-	ld a, [hPrintNum8]
-	ld [hPrintNum2], a
+	ldh a, [hPrintNum8]
+	ldh [hPrintNum2], a
 .skip1
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	or c
 	jr z, .PrintLeadingZero
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	and a
 	jr nz, .done
 	bit 5, d
@@ -270,7 +270,7 @@ _PrintNum::
 	ld a, "0"
 	add c
 	ld [hl], a
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	inc e
 	dec e
 	ret nz
@@ -292,7 +292,7 @@ _PrintNum::
 	jr nz, .inc
 	bit 6, d ; left alignment or right alignment?
 	jr z, .inc
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	and a
 	ret z
 .inc

--- a/engine/menus/debug.asm
+++ b/engine/menus/debug.asm
@@ -25,18 +25,18 @@
 ColorTest:
 ; A debug menu to test monster and trainer palettes at runtime.
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .asm_818b5
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 
 .asm_818b5
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call DisableLCD
 	call Function81948
 	call Function8197c
@@ -60,7 +60,7 @@ ColorTest:
 
 .asm_818f0
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function818f4:
@@ -124,13 +124,13 @@ Function81928:
 
 Function81948:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles0
 	ld bc, sScratch - vTiles0
 	xor a
 	call ByteFill
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles0
 	ld bc, sScratch - vTiles0
 	xor a
@@ -169,33 +169,33 @@ Function8197c:
 	ret
 
 Function819a7:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_DebugBG
 	ld de, wBGPals2
 	ld bc, 16 palettes
 	call CopyBytes
 	ld a, 1 << rBGPI_AUTO_INCREMENT
-	ld [rBGPI], a
+	ldh [rBGPI], a
 	ld hl, Palette_DebugBG
 	ld c, 8 palettes
 	xor a
 .asm_819c8
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	dec c
 	jr nz, .asm_819c8
 	ld a, 1 << rOBPI_AUTO_INCREMENT
-	ld [rOBPI], a
+	ldh [rOBPI], a
 	ld hl, Palette_DebugOB
 	ld c, 8 palettes
 .asm_819d6
 	ld a, [hli]
-	ld [rOBPD], a
+	ldh [rOBPD], a
 	dec c
 	jr nz, .asm_819d6
 	ld a, $94
@@ -207,7 +207,7 @@ Function819a7:
 	ld a, $29
 	ld [wc608 + 3], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_DebugBG:
@@ -289,7 +289,7 @@ Jumptable_81acf:
 
 Function81adb:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, DEBUGTEST_BLACK
@@ -331,7 +331,7 @@ Function81adb:
 	ld de, vTiles2 tile $31
 	predef GetMonBackpic
 	ld a, $31
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 2, 4
 	lb bc, 6, 6
 	predef PlaceGraphic
@@ -363,7 +363,7 @@ Function81adb:
 	callfar GetTrainerPic
 	xor a
 	ld [wTempEnemyMonSpecies], a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 2, 3
 	lb bc, 7, 7
 	predef PlaceGraphic
@@ -424,11 +424,11 @@ Function81bf4:
 	ret
 
 Function81c18:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .asm_81c2a
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
@@ -440,13 +440,13 @@ Function81c18:
 	ret
 
 Function81c33:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .asm_81c69
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld de, wc608
 	ld c, $1
@@ -458,11 +458,11 @@ Function81c33:
 	ld de, wc608 + 2
 	call Function81ca7
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ld a, $3
 	ld [wJumptableIndex], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .asm_81c69
@@ -519,10 +519,10 @@ Function81cbc:
 	ret
 
 Function81cc2:
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and B_BUTTON
 	jr nz, .asm_81cdf
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and A_BUTTON
 	jr nz, .asm_81ce5
 	ld a, [wcf64]
@@ -621,10 +621,10 @@ Function81d58:
 	ld hl, wc608 + 12
 
 Function81d63:
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_RIGHT
 	jr nz, Function81d70
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_LEFT
 	jr nz, Function81d77
 	ret
@@ -915,9 +915,9 @@ Function81f1d:
 .asm_81f22
 	push bc
 	xor a
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld b, $10
 .asm_81f2c
 	ld e, $8
@@ -930,18 +930,18 @@ Function81f1d:
 	ld a, $20
 
 .asm_81f38
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	rr d
 	dec e
 	jr nz, .asm_81f30
 	dec b
 	jr nz, .asm_81f2c
 	ld a, $20
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	ld de, 7000
 .asm_81f51
 	nop
@@ -1041,12 +1041,12 @@ TilesetColorTest:
 	ld [wcf64], a
 	ld [wcf65], a
 	ld [wcf66], a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call ClearSprites
 	call OverworldTextModeSwitch
 	call WaitBGMap2
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld de, DebugColorTestGFX + 1 tiles
 	ld hl, vTiles2 tile DEBUGTEST_UP_ARROW
 	lb bc, BANK(DebugColorTestGFX), 22
@@ -1056,7 +1056,7 @@ TilesetColorTest:
 	lb bc, BANK(DebugColorTestGFX), 1
 	call Request2bpp
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, DEBUGTEST_BLACK
@@ -1082,7 +1082,7 @@ TilesetColorTest:
 	call WaitBGMap2
 	ld [wJumptableIndex], a
 	ld a, $40
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 Function821d2:
@@ -1126,10 +1126,10 @@ Function82203:
 	ret
 
 Function8220f:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcf64]
 	ld l, a
 	ld h, $0
@@ -1144,7 +1144,7 @@ Function8220f:
 	ld de, wc608
 	call Function81ea5
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function82236:
@@ -1177,10 +1177,10 @@ Function82236:
 	call Function821d8
 	ld de, $24
 	call Function821d8
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld a, [wcf64]
 	ld bc, 1 palettes
@@ -1189,27 +1189,27 @@ Function82236:
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 3
 	call DelayFrames
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .asm_82299
 	call ClearSprites
-	ld a, [hWY]
+	ldh a, [hWY]
 	xor $d0
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 Function822a3:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld a, [wcf64]
 	ld bc, 1 palettes
@@ -1232,9 +1232,9 @@ Function822a3:
 	ld de, wc608 + 6
 	call Function81ca7
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	call DelayFrame
 	ret
 
@@ -1322,10 +1322,10 @@ Function8235d:
 	ld hl, wc608 + 12
 
 Function82368:
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_RIGHT
 	jr nz, .asm_82375
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_LEFT
 	jr nz, .asm_8237c
 	ret

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -41,7 +41,7 @@ PrintDayOfWeek:
 
 NewGame_ClearTileMapEtc:
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call ClearTileMap
 	call LoadFontsExtra
 	call LoadStandardFont
@@ -73,7 +73,7 @@ NewGame:
 	ld [wDefaultSpawnpoint], a
 
 	ld a, MAPSETUP_WARP
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	jp FinishContinueFunction
 
 AreYouABoyOrAreYouAGirl:
@@ -89,7 +89,7 @@ AreYouABoyOrAreYouAGirl:
 
 ResetWRAM:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call _ResetWRAM
 	ret
 
@@ -109,16 +109,16 @@ _ResetWRAM:
 	xor a
 	call ByteFill
 
-	ld a, [rLY]
-	ld [hSecondsBackup], a
+	ldh a, [rLY]
+	ldh [hSecondsBackup], a
 	call DelayFrame
-	ld a, [hRandomSub]
+	ldh a, [hRandomSub]
 	ld [wPlayerID], a
 
-	ld a, [rLY]
-	ld [hSecondsBackup], a
+	ldh a, [rLY]
+	ldh [hSecondsBackup], a
 	call DelayFrame
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	ld [wPlayerID + 1], a
 
 	call Random
@@ -335,7 +335,7 @@ Continue:
 	call LoadStandardMenuHeader
 	call DisplaySaveInfoOnContinue
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 20
 	call DelayFrames
 	call ConfirmContinue
@@ -369,7 +369,7 @@ Continue:
 	cp SPAWN_LANCE
 	jr z, .SpawnAfterE4
 	ld a, MAPSETUP_CONTINUE
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	jp FinishContinueFunction
 
 .FailToLoad:
@@ -389,7 +389,7 @@ PostCreditsSpawn:
 	xor a
 	ld [wSpawnAfterChampion], a
 	ld a, MAPSETUP_WARP
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ret
 
 Continue_MobileAdapterMenu:
@@ -507,7 +507,7 @@ DisplayContinueDataWithRTCError:
 
 Continue_LoadMenuHeader:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, .MenuHeader_Dex
 	ld a, [wStatusFlags]
 	bit STATUSFLAGS_POKEDEX_F, a
@@ -800,7 +800,7 @@ StorePlayerName:
 	ret
 
 ShrinkPlayer:
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, 32 ; fade time
@@ -874,24 +874,24 @@ IntroFadePalettes:
 
 Intro_WipeInFrontpic:
 	ld a, $77
-	ld [hWX], a
+	ldh [hWX], a
 	call DelayFrame
 	ld a, %11100100
 	call DmgToCgbBGPals
 .loop
 	call DelayFrame
-	ld a, [hWX]
+	ldh a, [hWX]
 	sub $8
 	cp -1
 	ret z
-	ld [hWX], a
+	ldh [hWX], a
 	jr .loop
 
 Intro_PrepTrainerPic:
 	ld de, vTiles2
 	farcall GetTrainerPic
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
 	predef PlaceGraphic
@@ -902,7 +902,7 @@ ShrinkFrame:
 	ld c, 7 * 7
 	predef DecompressGet2bpp
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 6, 4
 	lb bc, 7, 7
 	predef PlaceGraphic
@@ -958,10 +958,10 @@ CrystalIntroSequence:
 	farcall CrystalIntro
 
 StartTitleScreen:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call .TitleScreen
 	call DelayFrame
@@ -973,20 +973,20 @@ StartTitleScreen:
 	call ClearBGPalettes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, rLCDC
 	res rLCDC_SPRITE_SIZE, [hl] ; 8x8
 	call ClearScreen
 	call WaitBGMap2
 	xor a
-	ld [hLCDCPointer], a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hLCDCPointer], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
 	call UpdateTimePals
@@ -1031,7 +1031,7 @@ RunTitleScreen:
 	ret
 
 Unreferenced_Function6292:
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and $7
 	ret nz
 	ld hl, wLYOverrides + $5f
@@ -1066,11 +1066,11 @@ TitleScreenScene:
 TitleScreenEntrance:
 ; Animate the logo:
 ; Move each line by 4 pixels until our count hits 0.
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	and a
 	jr z, .done
 	sub 4
-	ld [hSCX], a
+	ldh [hSCX], a
 
 ; Lay out a base (all lines scrolling together).
 	ld e, a
@@ -1100,14 +1100,14 @@ TitleScreenEntrance:
 	ld hl, wJumptableIndex
 	inc [hl]
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 
 ; Play the title screen music.
 	ld de, MUSIC_TITLE
 	call PlayMusic
 
 	ld a, $88
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 TitleScreenTimer:
@@ -1149,7 +1149,7 @@ TitleScreenMain:
 ; To bring up the clock reset dialog:
 
 ; Hold Down + B + Select to initiate the sequence.
-	ld a, [hClockResetTrigger]
+	ldh a, [hClockResetTrigger]
 	cp $34
 	jr z, .check_clock_reset
 
@@ -1159,7 +1159,7 @@ TitleScreenMain:
 	jr nz, .check_start
 
 	ld a, $34
-	ld [hClockResetTrigger], a
+	ldh [hClockResetTrigger], a
 	jr .check_start
 
 ; Keep Select pressed, and hold Left + Up.
@@ -1169,7 +1169,7 @@ TitleScreenMain:
 	jr nz, .check_start
 
 	xor a
-	ld [hClockResetTrigger], a
+	ldh [hClockResetTrigger], a
 
 	ld a, [hl]
 	and D_LEFT + D_UP
@@ -1322,13 +1322,13 @@ GameInit::
 	call ClearBGPalettes
 	call ClearTileMap
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
-	ld [hJoyDown], a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hBGMapAddress], a
+	ldh [hJoyDown], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call WaitBGMap
 	jp CrystalIntroSequence

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -150,7 +150,7 @@ MainMenu_GetWhichMenu:
 	ret
 
 .next
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	cp $1
 	ld a, $1
 	ret nz
@@ -217,7 +217,7 @@ MainMenu_PrintCurrentTimeAndDay:
 	and a
 	ret z
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .PlaceBox
 	ld hl, wOptions
 	ld a, [hl]
@@ -227,7 +227,7 @@ MainMenu_PrintCurrentTimeAndDay:
 	pop af
 	ld [wOptions], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .PlaceBox:
@@ -257,7 +257,7 @@ MainMenu_PrintCurrentTimeAndDay:
 	decoord 1, 15
 	call .PlaceCurrentDay
 	decoord 4, 16
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld c, a
 	farcall PrintHour
 	ld [hl], ":"
@@ -313,7 +313,7 @@ MainMenu_PrintCurrentTimeAndDay:
 
 Function49ed0:
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call ClearTileMap
 	call LoadFontsExtra
 	call LoadStandardFont

--- a/engine/menus/menu.asm
+++ b/engine/menus/menu.asm
@@ -57,7 +57,7 @@ _InterpretMobileMenu::
 
 Draw2DMenu:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call Place2DMenuItemStrings
 	ret
@@ -249,17 +249,17 @@ _StaticMenuJoypad::
 _ScrollingMenuJoypad::
 	ld hl, w2DMenuFlags2
 	res 7, [hl]
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	call MenuJoypadLoop
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 MobileMenuJoypad:
 	ld hl, w2DMenuFlags2
 	res 7, [hl]
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	call Move2DMenuCursor
 	call Do2DMenuRTCJoypad
@@ -267,7 +267,7 @@ MobileMenuJoypad:
 	call _2DMenuInterpretJoypad
 .skip_joypad
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call GetMenuJoypad
 	ld c, a
 	ret
@@ -331,15 +331,15 @@ MenuJoypadLoop:
 	ret
 
 .BGMap_OAM:
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call WaitBGMap
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Do2DMenuRTCJoypad:
@@ -555,10 +555,10 @@ Place2DMenuCursor:
 	ret
 
 _PushWindow::
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wWindowStack)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wWindowStackPointer
 	ld e, [hl]
@@ -619,7 +619,7 @@ _PushWindow::
 	ld [hl], d
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wWindowStackSize
 	inc [hl]
 	ret
@@ -655,12 +655,12 @@ _PushWindow::
 
 _ExitMenu::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wWindowStack)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call GetWindowStackTop
 	ld a, l
@@ -687,7 +687,7 @@ _ExitMenu::
 
 .done
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wWindowStackSize
 	dec [hl]
 	ret

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -21,23 +21,23 @@ NamingScreen:
 	ld a, [hl]
 	push af
 	set NO_TEXT_SCROLL, [hl]
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
-	ld a, [hInMenu]
+	ldh [hMapAnims], a
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call .SetUpNamingScreen
 	call DelayFrame
 .loop
 	call NamingScreenJoypadLoop
 	jr nc, .loop
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
 	ld [wOptions], a
 	call ClearJoypad
@@ -51,7 +51,7 @@ NamingScreen:
 	call LoadNamingScreenGFX
 	call NamingScreen_InitText
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	call .GetNamingScreenSetup
 	call WaitBGMap
 	call WaitTop
@@ -332,14 +332,14 @@ NamingScreenJoypadLoop:
 	callfar ClearSpriteAnims
 	call ClearSprites
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	scf
 	ret
 
 .UpdateStringEntry:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 1, 5
 	call NamingScreen_IsTargetBox
 	jr nz, .got_coords
@@ -358,7 +358,7 @@ NamingScreenJoypadLoop:
 	ld l, a
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .RunJumptable:
@@ -867,16 +867,16 @@ LoadNamingScreenGFX:
 	ld [hli], a
 	ld [hl], NAMINGSCREEN_CURSOR
 	xor a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld [wGlobalAnimYOffset], a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld [wGlobalAnimXOffset], a
 	ld [wJumptableIndex], a
 	ld [wNamingScreenLetterCase], a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wNamingScreenCurrNameLength], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ret
 
 NamingScreenGFX_Border:
@@ -901,14 +901,14 @@ _ComposeMailMessage:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
-	ld a, [hInMenu]
+	ldh [hMapAnims], a
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call .InitBlankMail
 	call DelayFrame
 
@@ -917,9 +917,9 @@ _ComposeMailMessage:
 	jr nc, .loop
 
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 .InitBlankMail:
@@ -946,7 +946,7 @@ _ComposeMailMessage:
 	ld [hl], $0
 	call .InitCharset
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	call .initwNamingScreenMaxNameLength
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
@@ -1027,14 +1027,14 @@ INCBIN "gfx/icons/mail_big.2bpp"
 	callfar ClearSpriteAnims
 	call ClearSprites
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	scf
 	ret
 
 .Update:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 1, 1
 	lb bc, 4, 18
 	call ClearBox
@@ -1045,7 +1045,7 @@ INCBIN "gfx/icons/mail_big.2bpp"
 	hlcoord 2, 2
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .DoJumptable:

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -400,7 +400,7 @@ NamingScreenJoypadLoop:
 	ret
 
 .ReadButtons:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and A_BUTTON
 	jr nz, .a
@@ -1083,7 +1083,7 @@ INCBIN "gfx/icons/mail_big.2bpp"
 	ret
 
 .process_joypad
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and A_BUTTON
 	jr nz, .a

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -18,7 +18,7 @@ _OptionsMenu:
 .print_text_loop ; this next will display the settings of each option when the menu is opened
 	push bc
 	xor a
-	ld [hJoyLast], a
+	ldh [hJoyLast], a
 	call GetOptionPointer
 	pop bc
 	ld hl, wJumptableIndex
@@ -30,7 +30,7 @@ _OptionsMenu:
 	xor a
 	ld [wJumptableIndex], a
 	inc a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitBGMap
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
@@ -38,7 +38,7 @@ _OptionsMenu:
 
 .joypad_loop
 	call JoyTextDelay
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and START | B_BUTTON
 	jr nz, .ExitOptions
 	call OptionsControl
@@ -57,7 +57,7 @@ _OptionsMenu:
 	call PlaySFX
 	call WaitSFX
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 StringOptions:
@@ -106,7 +106,7 @@ GetOptionPointer:
 
 Options_TextSpeed:
 	call GetTextSpeed
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -187,7 +187,7 @@ GetTextSpeed:
 
 Options_BattleScene:
 	ld hl, wOptions
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -226,7 +226,7 @@ Options_BattleScene:
 
 Options_BattleStyle:
 	ld hl, wOptions
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -264,7 +264,7 @@ Options_BattleStyle:
 
 Options_Sound:
 	ld hl, wOptions
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -316,7 +316,7 @@ Options_Sound:
 
 Options_Print:
 	call GetPrinterSetting
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -411,7 +411,7 @@ GetPrinterSetting:
 
 Options_MenuAccount:
 	ld hl, wOptions2
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -449,7 +449,7 @@ Options_MenuAccount:
 
 Options_Frame:
 	ld hl, wTextBoxFrame
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .LeftPressed
 	bit D_RIGHT_F, a
@@ -479,7 +479,7 @@ UpdateFrame:
 	ret
 
 Options_Cancel:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jr nz, .Exit
 	and a
@@ -491,7 +491,7 @@ Options_Cancel:
 
 OptionsControl:
 	ld hl, wJumptableIndex
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	cp D_DOWN
 	jr z, .DownPressed
 	cp D_UP

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -325,10 +325,10 @@ FindStackTop:
 SavingDontTurnOffThePower:
 	; Prevent joypad interrupts
 	xor a
-	ld [hJoypadReleased], a
-	ld [hJoypadPressed], a
-	ld [hJoypadSum], a
-	ld [hJoypadDown], a
+	ldh [hJoypadReleased], a
+	ldh [hJoypadPressed], a
+	ldh [hJoypadSum], a
+	ldh [hJoypadDown], a
 	; Save the text speed setting to the stack
 	ld a, [wOptions]
 	push af

--- a/engine/menus/savemenu_copytilemapatonce.asm
+++ b/engine/menus/savemenu_copytilemapatonce.asm
@@ -1,51 +1,51 @@
 SaveMenu_CopyTilemapAtOnce:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jp z, WaitBGMap
 
 ; The following is a modified version of CopyTilemapAtOnce.
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
-	ld a, [hMapAnims]
+	ldh [hBGMapMode], a
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 .WaitLY:
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $60
 	jr c, .WaitLY
 
 	di
 	ld a, BANK(vBGMap2)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0, wAttrMap
 	call .CopyTilemapAtOnce
 	ld a, BANK(vBGMap0)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0
 	call .CopyTilemapAtOnce
 .WaitLY2:
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $60
 	jr c, .WaitLY2
 	ei
 
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .CopyTilemapAtOnce:
 	ld [hSPBuffer], sp ; $ffd9
 	ld sp, hl
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	ld l, 0
 	ld a, SCREEN_HEIGHT
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	ld b, 1 << 1
 	ld c, LOW(rSTAT)
 
@@ -64,14 +64,14 @@ endr
 
 	ld de, BG_MAP_WIDTH - SCREEN_WIDTH
 	add hl, de
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	dec a
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	jr nz, .loop
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret

--- a/engine/menus/savemenu_copytilemapatonce.asm
+++ b/engine/menus/savemenu_copytilemapatonce.asm
@@ -39,7 +39,7 @@ SaveMenu_CopyTilemapAtOnce:
 	ret
 
 .CopyTilemapAtOnce:
-	ld [hSPBuffer], sp ; $ffd9
+	ld [hSPBuffer], sp
 	ld sp, hl
 	ldh a, [hBGMapAddress + 1]
 	ld h, a

--- a/engine/menus/scrolling_menu.asm
+++ b/engine/menus/scrolling_menu.asm
@@ -1,16 +1,16 @@
 _InitScrollingMenu::
 	xor a
 	ld [wMenuJoypad], a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	inc a
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call InitScrollingMenuCursor
 	call ScrollingMenu_InitFlags
 	call ScrollingMenu_ValidateSwitchItem
 	call ScrollingMenu_InitDisplay
 	call ApplyTilemap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 _ScrollingMenu::
@@ -24,22 +24,22 @@ _ScrollingMenu::
 	call MenuClickSound
 	ld [wMenuJoypad], a
 	ld a, 0
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 .zero
 	call ScrollingMenu_InitDisplay
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 ScrollingMenu_InitDisplay:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wOptions
 	ld a, [hl]
 	push af
@@ -54,10 +54,10 @@ ScrollingMenu_InitDisplay:
 ScrollingMenuJoyAction:
 .loop
 	call ScrollingMenuJoypad
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_PAD
 	ld b, a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and BUTTONS
 	or b
 	bit A_BUTTON_F, a

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -78,13 +78,13 @@ StartMenu::
 	dw .ReturnRedraw
 
 .Exit:
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, 1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call LoadFontsExtra
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 .ReturnEnd:
 	call ExitMenu
 .ReturnEnd2:
@@ -95,7 +95,7 @@ StartMenu::
 .GetInput:
 ; Return carry on exit, and no-carry on selection.
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ._DrawMenuAccount
 	call SetUpMenu
 	ld a, $ff
@@ -120,13 +120,13 @@ StartMenu::
 .ExitMenuRunScript:
 	call ExitMenu
 	ld a, HMENURETURN_SCRIPT
-	ld [hMenuReturn], a
+	ldh [hMenuReturn], a
 	ret
 
 .ExitMenuRunScriptCloseText:
 	call ExitMenu
 	ld a, HMENURETURN_SCRIPT
-	ld [hMenuReturn], a
+	ldh [hMenuReturn], a
 	jr .ReturnEnd2
 
 .ExitMenuCallFuncCloseText:

--- a/engine/menus/trainer_card.asm
+++ b/engine/menus/trainer_card.asm
@@ -24,7 +24,7 @@ TrainerCard:
 	ld a, [wJumptableIndex]
 	bit 7, a
 	jr nz, .quit
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and B_BUTTON
 	jr nz, .quit
 	call .RunJumptable
@@ -251,7 +251,7 @@ TrainerCard_PrintTopHalfOfCard:
 	hlcoord 14, 1
 	lb bc, 5, 7
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	predef PlaceGraphic
 	ret
 
@@ -442,7 +442,7 @@ TrainerCard_Page1_PrintGameTime:
 	ld de, wGameTimeMinutes
 	lb bc, PRINTNUM_LEADINGZEROS | 1, 2
 	call PrintNum
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and $1f
 	ret nz
 	hlcoord 15, 12
@@ -452,7 +452,7 @@ TrainerCard_Page1_PrintGameTime:
 	ret
 
 TrainerCard_Page2_3_AnimateBadges:
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and %111
 	ret nz
 	ld a, [wTrainerCardBadgeFrameCounter]

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -11,10 +11,10 @@ Credits::
 .okay
 	ld [wJumptableIndex], a
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wGBCPalettes)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call ClearBGPalettes
 	call ClearTileMap
@@ -69,18 +69,18 @@ Credits::
 	call ByteFill
 
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 
 	call GetCreditsPalette
 	call SetPalettes
-	ld a, [hVBlank]
+	ldh a, [hVBlank]
 	push af
 	ld a, $5
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wCreditsPos], a
 	ld [wCreditsUnusedCD21], a
 	ld [wCreditsTimer], a
@@ -97,16 +97,16 @@ Credits::
 .exit_credits
 	call ClearBGPalettes
 	xor a
-	ld [hLCDCPointer], a
-	ld [hBGMapAddress], a
+	ldh [hLCDCPointer], a
+	ldh [hBGMapAddress], a
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Credits_HandleAButton:
-	ld a, [hJoypadDown]
+	ldh a, [hJoypadDown]
 	and A_BUTTON
 	ret z
 	ld a, [wJumptableIndex]
@@ -114,7 +114,7 @@ Credits_HandleAButton:
 	ret
 
 Credits_HandleBButton:
-	ld a, [hJoypadDown]
+	ldh a, [hJoypadDown]
 	and B_BUTTON
 	ret z
 	ld a, [wJumptableIndex]
@@ -177,7 +177,7 @@ Credits_LoopBack:
 
 Credits_PrepBGMapUpdate:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	jp Credits_Next
 
 Credits_UpdateGFXRequestPath:
@@ -194,13 +194,13 @@ Credits_UpdateGFXRequestPath:
 
 Credits_RequestGFX:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $8
 	ld [wRequested2bpp], a
 	jp Credits_Next
 
 Credits_LYOverride:
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $30
 	jr c, Credits_LYOverride
 	ld a, [wCreditsLYOverride]
@@ -240,7 +240,7 @@ ParseCredits:
 ; First, let's clear the current text display,
 ; starting from line 5.
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 5
 	ld bc, 20 * 12
 	ld a, " "
@@ -352,9 +352,9 @@ ParseCredits:
 	ld [wCreditsTimer], a
 
 	xor a
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 .done
 	jp Credits_Next
@@ -394,9 +394,9 @@ ParseCredits:
 
 ConstructCreditsTilemap:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $c
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 
 	ld a, $28
 	hlcoord 0, 0
@@ -438,8 +438,8 @@ ConstructCreditsTilemap:
 
 	call WaitBGMap2
 	xor a
-	ld [hBGMapMode], a
-	ld [hBGMapAddress], a
+	ldh [hBGMapMode], a
+	ldh [hBGMapAddress], a
 	hlcoord 0, 0
 	call .InitTopPortion
 	call WaitBGMap2

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -68,7 +68,7 @@ Credits::
 	xor a
 	call ByteFill
 
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 
 	call GetCreditsPalette

--- a/engine/movie/crystal_intro.asm
+++ b/engine/movie/crystal_intro.asm
@@ -1994,7 +1994,7 @@ Intro_ResetLYOverrides:
 
 	pop af
 	ldh [rSVBK], a
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	ret
 

--- a/engine/movie/crystal_intro.asm
+++ b/engine/movie/crystal_intro.asm
@@ -4,14 +4,14 @@ Copyright_GFPresents:
 	call ClearBGPalettes
 	call ClearTileMap
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
-	ld [hJoyDown], a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hBGMapAddress], a
+	ldh [hJoyDown], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call WaitBGMap
 	ld b, SCGB_GAMEFREAK_LOGO
 	call GetSGBLayout
@@ -27,7 +27,7 @@ Copyright_GFPresents:
 	call .GetGFLogoGFX
 .joy_loop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and BUTTONS
 	jr nz, .pressed_button
 	ld a, [wJumptableIndex]
@@ -54,10 +54,10 @@ Copyright_GFPresents:
 	lb bc, BANK(GameFreakLogo), 28
 	call Get1bpp
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, IntroLogoGFX
 	ld de, wDecompressScratch
@@ -75,7 +75,7 @@ Copyright_GFPresents:
 	call Request2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	farcall ClearSpriteAnims
 	depixel 10, 11, 4, 0
@@ -94,12 +94,12 @@ Copyright_GFPresents:
 	ld [wJumptableIndex], a
 	ld [wIntroSceneFrameCounter], a
 	ld [wIntroSceneTimer], a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	lb de, %11100100, %11100100
 	call DmgToCgbObjPals
 	ret
@@ -304,18 +304,18 @@ GameFreakLogoScene4:
 	ld hl, GameFreakLogoPalettes
 	add hl, de
 	add hl, de
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [hli]
 	ld [wOBPals2 + 12], a
 	ld a, [hli]
 	ld [wOBPals2 + 13], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .asm_e47a3
@@ -334,18 +334,18 @@ INCBIN "gfx/splash/logo1.1bpp"
 INCBIN "gfx/splash/logo2.1bpp"
 
 CrystalIntro:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wGBCPalettes)
-	ld [rSVBK], a
-	ld a, [hInMenu]
+	ldh [rSVBK], a
+	ldh a, [hInMenu]
 	push af
-	ld a, [hVBlank]
+	ldh a, [hVBlank]
 	push af
 	call .InitRAMAddrs
 .loop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and BUTTONS
 	jr nz, .ShutOffMusic
 	ld a, [wJumptableIndex]
@@ -365,27 +365,27 @@ CrystalIntro:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .InitRAMAddrs:
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld [wJumptableIndex], a
 	ret
 
@@ -442,14 +442,14 @@ IntroScene1:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap001
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroUnownsGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
@@ -459,10 +459,10 @@ IntroScene1:
 	ld hl, IntroTilemap002
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette2
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -472,14 +472,14 @@ IntroScene1:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -518,24 +518,24 @@ IntroScene3:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap003
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroBackgroundGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
 	ld hl, IntroTilemap004
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette1
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -545,14 +545,14 @@ IntroScene3:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call Intro_ResetLYOverrides
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -580,15 +580,15 @@ IntroScene5:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
-	ld [hLCDCPointer], a
+	ldh [hBGMapMode], a
+	ldh [hLCDCPointer], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap005
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroUnownsGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
@@ -598,10 +598,10 @@ IntroScene5:
 	ld hl, IntroTilemap006
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette2
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -611,14 +611,14 @@ IntroScene5:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -678,10 +678,10 @@ IntroScene7:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap003
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
@@ -691,7 +691,7 @@ IntroScene7:
 	call Intro_DecompressRequest2bpp_128Tiles
 
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroSuicuneRunGFX
 	ld de, vTiles0 tile $00
 	call Intro_DecompressRequest2bpp_255Tiles
@@ -704,10 +704,10 @@ IntroScene7:
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, IntroPalette1
 	ld de, wBGPals1
@@ -720,15 +720,15 @@ IntroScene7:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call Intro_ResetLYOverrides
 	farcall ClearSpriteAnims
 	depixel 13, 27, 4, 0
@@ -775,7 +775,7 @@ IntroScene8:
 IntroScene9:
 ; Set up the next scene (same bg).
 	xor a
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	call ClearSprites
 	hlcoord 0, 0, wAttrMap
 	; first 12 rows have palette 1
@@ -791,18 +791,18 @@ IntroScene9:
 	ld a, $3
 	call ByteFill
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	ld a, $c ; $980c
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
 	xor a
-	ld [hBGMapMode], a
-	ld [hBGMapAddress], a
+	ldh [hBGMapMode], a
+	ldh [hBGMapAddress], a
 	ld [wGlobalAnimXOffset], a
 	xor a
 	ld [wIntroSceneFrameCounter], a
@@ -848,25 +848,25 @@ IntroScene11:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
-	ld [hLCDCPointer], a
+	ldh [hBGMapMode], a
+	ldh [hLCDCPointer], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap007
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroUnownsGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
 	ld hl, IntroTilemap008
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette2
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -876,14 +876,14 @@ IntroScene11:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -972,14 +972,14 @@ IntroScene13:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap003
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroSuicuneRunGFX
 	ld de, vTiles0 tile $00
 	call Intro_DecompressRequest2bpp_255Tiles
@@ -989,10 +989,10 @@ IntroScene13:
 	ld hl, IntroTilemap004
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette1
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -1002,14 +1002,14 @@ IntroScene13:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	depixel 13, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_INTRO_SUICUNE
@@ -1027,9 +1027,9 @@ IntroScene13:
 
 IntroScene14:
 ; Suicune runs then jumps.
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	sub 10
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, wIntroSceneFrameCounter
 	ld a, [hl]
 	inc [hl]
@@ -1076,14 +1076,14 @@ IntroScene15:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap009
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroSuicuneJumpGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
@@ -1098,10 +1098,10 @@ IntroScene15:
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	call Intro_LoadTilemap
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette5
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -1111,15 +1111,15 @@ IntroScene15:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $90
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	depixel 8, 5
@@ -1142,11 +1142,11 @@ IntroScene16:
 	cp $80
 	jr nc, .done
 	call Intro_Scene16_AnimateSuicune
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	and a
 	ret z
 	add 8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 .done
 	call NextIntroScene
@@ -1158,24 +1158,24 @@ IntroScene17:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap011
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroSuicuneCloseGFX
 	ld de, vTiles1 tile $00
 	call Intro_DecompressRequest2bpp_255Tiles
 	ld hl, IntroTilemap012
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette4
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -1185,14 +1185,14 @@ IntroScene17:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -1208,11 +1208,11 @@ IntroScene18:
 	inc [hl]
 	cp $60
 	jr nc, .done
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	cp $60
 	ret z
 	add 8
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 .done
 	call NextIntroScene
@@ -1224,14 +1224,14 @@ IntroScene19:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap013
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroSuicuneBackGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
@@ -1246,10 +1246,10 @@ IntroScene19:
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	call Intro_LoadTilemap
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette5
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -1259,15 +1259,15 @@ IntroScene19:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $d8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	ld hl, wSpriteAnimDict
 	xor a
@@ -1296,9 +1296,9 @@ IntroScene20:
 	jr nc, .AppearUnown
 	cp $28
 	ret nc
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	inc a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 .AppearUnown:
@@ -1335,7 +1335,7 @@ IntroScene21:
 	ld c, 3
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wIntroSceneFrameCounter], a
 	ld [wIntroSceneTimer], a
 	call NextIntroScene
@@ -1401,24 +1401,24 @@ IntroScene26:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroTilemap015
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, IntroCrystalUnownsGFX
 	ld de, vTiles2 tile $00
 	call Intro_DecompressRequest2bpp_128Tiles
 	ld hl, IntroTilemap017
 	debgcoord 0, 0
 	call Intro_DecompressRequest2bpp_64Tiles
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, IntroPalette3
 	ld de, wBGPals1
 	ld bc, 16 palettes
@@ -1428,14 +1428,14 @@ IntroScene26:
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	call Intro_SetCGBPalUpdate
 	xor a
@@ -1503,10 +1503,10 @@ Intro_Scene24_ApplyPaletteFade:
 	adc h
 	ld h, a
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, wBGPals2
 	ld b, 8 ; number of BG pals
 .loop1
@@ -1522,9 +1522,9 @@ Intro_Scene24_ApplyPaletteFade:
 	dec b
 	jr nz, .loop1
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .FadePals:
@@ -1592,10 +1592,10 @@ CrystalIntro_UnownFade:
 
 	ld c, a
 	ld b, $0
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push hl
 	push bc
@@ -1646,9 +1646,9 @@ CrystalIntro_UnownFade:
 	ld [hli], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .BWFade:
@@ -1693,10 +1693,10 @@ Intro_Scene20_AppearUnown:
 	add a
 	add a
 	ld c, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push bc
 	ld de, wBGPals2
@@ -1724,9 +1724,9 @@ Intro_Scene20_AppearUnown:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .pal1
@@ -1757,10 +1757,10 @@ endr
 	ld c, a
 	ld b, $0
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push hl
 	ld hl, .FastFadePalettes
@@ -1787,9 +1787,9 @@ endr
 	ld [hli], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 .FastFadePalettes:
@@ -1809,10 +1809,10 @@ hue = hue + -1
 endr
 
 Intro_LoadTilemap:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wDecompressScratch
 	decoord 0, 0
@@ -1835,7 +1835,7 @@ Intro_LoadTilemap:
 	jr nz, .row
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Intro_Scene16_AnimateSuicune:
@@ -1848,7 +1848,7 @@ Intro_Scene16_AnimateSuicune:
 
 .PrepareForSuicuneSwap:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Intro_ColoredSuicuneFrameSwap:
@@ -1869,7 +1869,7 @@ Intro_ColoredSuicuneFrameSwap:
 	or b
 	jr nz, .loop
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Intro_RustleGrass:
@@ -1902,14 +1902,14 @@ Intro_RustleGrass:
 
 Intro_SetCGBPalUpdate:
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 Intro_ClearBGPals:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBGPals2
 	ld bc, 16 palettes
@@ -1917,18 +1917,18 @@ Intro_ClearBGPals:
 	call ByteFill
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	call DelayFrame
 	call DelayFrame
 	ret
 
 Intro_DecompressRequest2bpp_128Tiles:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push de
 	ld de, wDecompressScratch
@@ -1940,14 +1940,14 @@ Intro_DecompressRequest2bpp_128Tiles:
 	call Request2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Intro_DecompressRequest2bpp_255Tiles:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push de
 	ld de, wDecompressScratch
@@ -1959,14 +1959,14 @@ Intro_DecompressRequest2bpp_255Tiles:
 	call Request2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Intro_DecompressRequest2bpp_64Tiles:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	push de
 	ld de, wDecompressScratch
@@ -1978,14 +1978,14 @@ Intro_DecompressRequest2bpp_64Tiles:
 	call Request2bpp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Intro_ResetLYOverrides:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wLYOverrides
 	ld bc, wLYOverridesEnd - wLYOverrides
@@ -1993,16 +1993,16 @@ Intro_ResetLYOverrides:
 	call ByteFill
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 	ret
 
 Intro_PerspectiveScrollBG:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	; Scroll the grass every frame.
 	; Scroll the trees every other frame and at half speed.
 	; This creates an illusion of perspective.
@@ -2024,9 +2024,9 @@ Intro_PerspectiveScrollBG:
 	ld bc, $31
 	call ByteFill
 	ld a, [wLYOverrides + 0]
-	ld [hSCX], a
+	ldh [hSCX], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 IntroSuicuneRunGFX:

--- a/engine/movie/evolution_animation.asm
+++ b/engine/movie/evolution_animation.asm
@@ -4,7 +4,7 @@ EvolutionAnimation:
 	push bc
 	ld a, [wCurSpecies]
 	push af
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	push af
 	ld a, [wBaseDexNo]
 	push af
@@ -14,7 +14,7 @@ EvolutionAnimation:
 	pop af
 	ld [wBaseDexNo], a
 	pop af
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	pop af
 	ld [wCurSpecies], a
 	pop bc
@@ -30,7 +30,7 @@ EvolutionAnimation:
 
 .EvolutionAnimation:
 	ld a, %11100100
-	ld [rOBP0], a
+	ldh [rOBP0], a
 
 	ld de, MUSIC_NONE
 	call PlayMusic
@@ -46,7 +46,7 @@ EvolutionAnimation:
 	ld [wLowHealthAlarm], a
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wEvolutionOldSpecies]
 	ld [wPlayerHPPal], a
 
@@ -74,7 +74,7 @@ EvolutionAnimation:
 	ld [wCurSpecies], a
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .check_statused
 	jr c, .skip_cry
 
@@ -205,7 +205,7 @@ EvolutionAnimation:
 .ReplaceFrontpic:
 	push bc
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 7, 2
 	lb bc, 7, 7
 	ld de, SCREEN_WIDTH - 7
@@ -222,7 +222,7 @@ EvolutionAnimation:
 	dec b
 	jr nz, .loop1
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call WaitBGMap
 	pop bc
 	ret
@@ -231,7 +231,7 @@ EvolutionAnimation:
 	call DelayFrame
 	push bc
 	call JoyTextDelay
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	pop bc
 	and B_BUTTON
 	jr nz, .pressed_b
@@ -326,7 +326,7 @@ EvolutionAnimation:
 	push bc
 	callfar PlaySpriteAnimations
 	; a = (([hVBlankCounter] + 4) / 2) % NUM_PALETTES
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and %1110
 	srl a
 	inc a

--- a/engine/movie/gbc_only.asm
+++ b/engine/movie/gbc_only.asm
@@ -1,5 +1,5 @@
 GBCOnlyScreen:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret nz
 
@@ -10,13 +10,13 @@ GBCOnlyScreen:
 
 	ld hl, GBCOnlyGFX
 	ld de, wGBCOnlyDecompressBuffer
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 0 ; this has the same effect as selecting bank 1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Decompress
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld de, wGBCOnlyDecompressBuffer
 	ld hl, vTiles2

--- a/engine/movie/init_hof_credits.asm
+++ b/engine/movie/init_hof_credits.asm
@@ -14,8 +14,8 @@ InitDisplayForHallOfFame:
 	xor a
 	call ByteFill
 	xor a
-	ld [hSCY], a
-	ld [hSCX], a
+	ldh [hSCY], a
+	ldh [hSCX], a
 	call EnableLCD
 	ld hl, .SavingRecordDontTurnOff
 	call PrintText
@@ -53,18 +53,18 @@ InitDisplayForRedCredits:
 	dec c
 	jr nz, .load_white_palettes
 	xor a
-	ld [hSCY], a
-	ld [hSCX], a
+	ldh [hSCY], a
+	ldh [hSCX], a
 	call EnableLCD
 	call WaitBGMap2
 	call SetPalettes
 	ret
 
 ResetDisplayBetweenHallOfFameMons:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wDecompressScratch
 	ld bc, wScratchAttrMap - wDecompressScratch
 	ld a, " "
@@ -75,5 +75,5 @@ ResetDisplayBetweenHallOfFameMons:
 	ld c, 4 tiles
 	call Request2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -5,7 +5,7 @@ _TitleScreen:
 
 ; Turn BG Map update off
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 ; Reset timing variables
 	ld hl, wJumptableIndex
@@ -19,7 +19,7 @@ _TitleScreen:
 
 ; VRAM bank 1
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 ; Decompress running Suicune gfx
 	ld hl, TitleSuicuneGFX
@@ -86,7 +86,7 @@ _TitleScreen:
 
 ; Back to VRAM bank 0
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 
 ; Decompress logo
 	ld hl, TitleLogoGFX
@@ -126,11 +126,11 @@ _TitleScreen:
 	call InitializeBackground
 
 ; Save WRAM bank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 ; WRAM bank 5
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Update palette colors
 	ld hl, TitleScreenPalettes
@@ -145,14 +145,14 @@ _TitleScreen:
 
 ; Restore WRAM bank
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; LY/SCX trickery starts here
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wLYOverrides)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Make alternating lines come in from opposite sides
 
@@ -178,34 +178,34 @@ _TitleScreen:
 
 ; Let LCD Stat know we're messing around with SCX
 	ld a, rSCX - $ff00
-	ld [hLCDCPointer], a
+	ldh [hLCDCPointer], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Reset audio
 	call ChannelsOff
 	call EnableLCD
 
 ; Set sprite size to 8x16
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	set rLCDC_SPRITE_SIZE, a
-	ld [rLCDC], a
+	ldh [rLCDC], a
 
 	ld a, +112
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, 8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, 7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, -112
-	ld [hWY], a
+	ldh [hWY], a
 
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 ; Update BG Map 0 (bank 0)
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	xor a
 	ld [wd002], a
@@ -237,12 +237,12 @@ SuicuneFrameIterator:
 	add hl, de
 	ld d, [hl]
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadSuicuneFrame
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $3
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 	ret
 
 .Frames:

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -177,7 +177,7 @@ _TitleScreen:
 	call ByteFill
 
 ; Let LCD Stat know we're messing around with SCX
-	ld a, rSCX - $ff00
+	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 
 	pop af

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -115,10 +115,10 @@ RunTradeAnimScript:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld hl, wVramState
 	ld a, [hl]
 	push af
@@ -141,7 +141,7 @@ RunTradeAnimScript:
 	pop af
 	ld [wVramState], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 .TradeAnimLayout:
@@ -153,17 +153,17 @@ RunTradeAnimScript:
 	call DisableLCD
 	call LoadFontsBattleExtra
 	callfar ClearSpriteAnims
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .NotCGB
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles0
 	ld bc, sScratch - vTiles0
 	xor a
 	call ByteFill
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 
 .NotCGB:
 	hlbgcoord 0, 0
@@ -184,12 +184,12 @@ RunTradeAnimScript:
 	ld a, BANK(TradeArrowGFX)
 	call FarCopyBytes
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall GetTrademonFrontpic
 	call EnableLCD
 	call LoadTradeBallAndCableGFX
@@ -349,11 +349,11 @@ TradeAnim_InitTubeAnim:
 	call TradeAnim_TubeAnimJumptable
 
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $70
-	ld [hWY], a
+	ldh [hWY], a
 	call EnableLCD
 	call LoadTradeBubbleGFX
 
@@ -390,9 +390,9 @@ TradeAnim_InitTubeAnim:
 
 TradeAnim_TubeToOT2:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp $50
 	ret nz
 	ld a, TRADEANIMSTATE_1
@@ -402,9 +402,9 @@ TradeAnim_TubeToOT2:
 
 TradeAnim_TubeToOT3:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp $a0
 	ret nz
 	ld a, TRADEANIMSTATE_2
@@ -414,9 +414,9 @@ TradeAnim_TubeToOT3:
 
 TradeAnim_TubeToOT4:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	and a
 	ret nz
 	call TradeAnim_IncrementJumptableIndex
@@ -424,9 +424,9 @@ TradeAnim_TubeToOT4:
 
 TradeAnim_TubeToPlayer3:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	sub $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp $b0
 	ret nz
 	ld a, TRADEANIMSTATE_1
@@ -436,9 +436,9 @@ TradeAnim_TubeToPlayer3:
 
 TradeAnim_TubeToPlayer4:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	sub $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp $60
 	ret nz
 	xor a ; TRADEANIMSTATE_0
@@ -448,9 +448,9 @@ TradeAnim_TubeToPlayer4:
 
 TradeAnim_TubeToPlayer5:
 	call TradeAnim_FlashBGPals
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	sub $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	and a
 	ret nz
 	call TradeAnim_IncrementJumptableIndex
@@ -475,9 +475,9 @@ TradeAnim_TubeToPlayer8:
 	ld a, " "
 	call ByteFill
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call EnableLCD
 	call LoadTradeBallAndCableGFX
 	call WaitBGMap
@@ -592,7 +592,7 @@ TradeAnim_PlaceTrademonStatsOnTubeAnim:
 	call ClearBGPalettes
 	call WaitTop
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call ClearTileMap
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH
@@ -622,7 +622,7 @@ TradeAnim_PlaceTrademonStatsOnTubeAnim:
 	call WaitBGMap
 	call WaitTop
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call ClearTileMap
 	ret
 
@@ -630,7 +630,7 @@ TradeAnim_EnterLinkTube1:
 	call ClearTileMap
 	call WaitTop
 	ld a, $a0
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	hlcoord 8, 2
 	ld de, TradeLinkTubeTilemap
@@ -649,11 +649,11 @@ TradeAnim_EnterLinkTube1:
 	ret
 
 TradeAnim_EnterLinkTube2:
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	and a
 	jr z, .done
 	add $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 .done
@@ -663,100 +663,100 @@ TradeAnim_EnterLinkTube2:
 	ret
 
 TradeAnim_ExitLinkTube:
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	cp $a0
 	jr z, .done
 	sub $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 .done
 	call ClearTileMap
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
 TradeAnim_SetupGivemonScroll:
 	ld a, $8f
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $88
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
 TradeAnim_DoGivemonScroll:
-	ld a, [hWX]
+	ldh a, [hWX]
 	cp $7
 	jr z, .done
 	sub $4
-	ld [hWX], a
-	ld a, [hSCX]
+	ldh [hWX], a
+	ldh a, [hSCX]
 	sub $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	ret
 
 .done
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
 TradeAnim_FrontpicScrollStart:
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
 TradeAnim_TextboxScrollStart:
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
 TradeAnim_ScrollOutRight:
 	call WaitTop
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call WaitBGMap
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	call DelayFrame
 	call WaitTop
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call ClearTileMap
 	call TradeAnim_IncrementJumptableIndex
 	ret
 
 TradeAnim_ScrollOutRight2:
-	ld a, [hWX]
+	ldh a, [hWX]
 	cp $a1
 	jr nc, .done
 	add $4
-	ld [hWX], a
+	ldh [hWX], a
 	ret
 
 .done
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call WaitBGMap
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call TradeAnim_AdvanceScriptPointer
 	ret
 
@@ -843,7 +843,7 @@ TradeAnim_ShowFrontpic:
 	call TradeAnim_BlankTileMap
 	hlcoord 7, 2
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	call WaitBGMap
@@ -927,7 +927,7 @@ TrademonStats_MonTemplate:
 	call WaitTop
 	call TradeAnim_BlankTileMap
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 3, 0
 	ld b, $6
 	ld c, $d
@@ -947,7 +947,7 @@ TrademonStats_Egg:
 	call WaitTop
 	call TradeAnim_BlankTileMap
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 3, 0
 	ld b, 6
 	ld c, 13
@@ -967,7 +967,7 @@ TrademonStats_WaitBGMap:
 	call WaitBGMap
 	call WaitTop
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ret
 
 TrademonStats_PrintSpeciesNumber:
@@ -1312,7 +1312,7 @@ TradeAnim_CopyBoxFromDEtoHL:
 	ret
 
 TradeAnim_NormalPals:
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ld a, %11100100 ; 3,2,1,0
 	jr z, .not_sgb
@@ -1346,7 +1346,7 @@ TradeAnim_FlashBGPals:
 	ld a, [wcf65]
 	and $7
 	ret nz
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	xor %00111100
 	call DmgToCgbBGPals
 	ret

--- a/engine/movie/unused_title.asm
+++ b/engine/movie/unused_title.asm
@@ -5,7 +5,7 @@ UnusedTitleScreen:
 
 ; Turn BG Map update off
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 ; Reset timing variables
 	ld hl, wJumptableIndex
@@ -34,11 +34,11 @@ UnusedTitleScreen:
 	ld bc, BG_MAP_WIDTH * BG_MAP_HEIGHT
 .copy
 	ld a, 0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld a, [hli]
 	ld [de], a
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld a, [hli]
 	ld [de], a
 	inc de
@@ -53,17 +53,17 @@ UnusedTitleScreen:
 	call CopyBytes
 
 	call EnableLCD
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	set rLCDC_SPRITES_ENABLE, a
 	set rLCDC_SPRITE_SIZE, a
-	ld [rLCDC], a
+	ldh [rLCDC], a
 
 	call DelayFrame
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, UnusedTitleBG_Palettes
 	ld de, wBGPals1
@@ -86,10 +86,10 @@ UnusedTitleScreen:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	ld de, MUSIC_TITLE
 	call PlayMusic
@@ -158,7 +158,7 @@ Function10ed51:
 	call _TitleScreen
 .loop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	ld b, a
 	and 1
 	jr nz, .done

--- a/engine/overworld/decorations.asm
+++ b/engine/overworld/decorations.asm
@@ -363,7 +363,7 @@ PopulateDecoCategoryMenu:
 	ld hl, .ScrollingMenuHeader
 	call CopyMenuHeader
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call InitScrollingMenu
 	xor a
 	ld [wMenuScrollPosition], a

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -115,13 +115,13 @@ EnterMap:
 	farcall RunMapSetupScript
 	call DisableEvents
 
-	ld a, [hMapEntryMethod]
+	ldh a, [hMapEntryMethod]
 	cp MAPSETUP_CONNECTION
 	jr nz, .dont_enable
 	call EnableEvents
 .dont_enable
 
-	ld a, [hMapEntryMethod]
+	ldh a, [hMapEntryMethod]
 	cp MAPSETUP_RELOADMAP
 	jr nz, .dontresetpoison
 	xor a
@@ -129,7 +129,7 @@ EnterMap:
 .dontresetpoison
 
 	xor a ; end map entry
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ld a, 2 ; HandleMap
 	ld [wMapStatus], a
 	ret
@@ -512,7 +512,7 @@ OWPlayerInput:
 	ret
 
 CheckAPressOW:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	ret z
 	call TryObjectEvent
@@ -539,14 +539,14 @@ TryObjectEvent:
 
 .IsObject:
 	call PlayTalkObject
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	call GetObjectStruct
 	ld hl, OBJECT_MAP_OBJECT_INDEX
 	add hl, bc
 	ld a, [hl]
-	ld [hLastTalked], a
+	ldh [hLastTalked], a
 
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	call GetMapObject
 	ld hl, MAPOBJECT_COLOR
 	add hl, bc
@@ -809,9 +809,9 @@ PlayerMovement:
 
 CheckMenuOW:
 	xor a
-	ld [hMenuReturn], a
-	ld [hMenuReturn + 1], a
-	ld a, [hJoyPressed]
+	ldh [hMenuReturn], a
+	ldh [hMenuReturn + 1], a
+	ldh a, [hJoyPressed]
 
 	bit SELECT_F, a
 	jr nz, .Select
@@ -1239,7 +1239,7 @@ ChooseWildEncounter_BugContest::
 	ld c, a
 	inc c
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	call SimpleDivide
 	add d
 
@@ -1260,7 +1260,7 @@ TryWildEncounter_BugContest:
 	farcall ApplyMusicEffectOnEncounterRate
 	farcall ApplyCleanseTagEffectOnEncounterRate
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	cp b
 	ret c
 	ld a, 1
@@ -1351,7 +1351,7 @@ HandleCmdQueue::
 	ld hl, wCmdQueue
 	xor a
 .loop
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, [hl]
 	and a
 	jr z, .skip
@@ -1364,7 +1364,7 @@ HandleCmdQueue::
 .skip
 	ld de, CMDQUEUE_ENTRY_SIZE
 	add hl, de
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp CMDQUEUE_CAPACITY
 	jr nz, .loop
@@ -1505,7 +1505,7 @@ CmdQueue_Type4:
 	dw .one
 
 .zero
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld hl, 4
 	add hl, bc
 	ld [hl], a
@@ -1521,24 +1521,24 @@ CmdQueue_Type4:
 	jr z, .add
 	ld hl, 2
 	add hl, bc
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	sub [hl]
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 .add
 	ld hl, 2
 	add hl, bc
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	add [hl]
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 .finish
 	ld hl, 4
 	add hl, bc
 	ld a, [hl]
-	ld [hSCY], a
+	ldh [hSCY], a
 	call _DelCmdQueue
 	ret
 

--- a/engine/overworld/init_map.asm
+++ b/engine/overworld/init_map.asm
@@ -1,31 +1,31 @@
 ReanchorBGMap_NoOAMUpdate::
 	call DelayFrame
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 
 	ld a, $1
-	ld [hOAMUpdate], a
-	ld a, [hBGMapMode]
+	ldh [hOAMUpdate], a
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	call .ReanchorBGMap
 
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ld hl, wVramState
 	set 6, [hl]
 	ret
 
 .ReanchorBGMap:
 	xor a
-	ld [hLCDCPointer], a
-	ld [hBGMapMode], a
+	ldh [hLCDCPointer], a
+	ldh [hBGMapMode], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call OverworldTextModeSwitch
 	ld a, HIGH(vBGMap1)
 	call .LoadBGMapAddrIntoHRAM
@@ -33,10 +33,10 @@ ReanchorBGMap_NoOAMUpdate::
 	farcall LoadOW_BGPal7
 	farcall ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	xor a
-	ld [hBGMapMode], a
-	ld [hWY], a
+	ldh [hBGMapMode], a
+	ldh [hWY], a
 	farcall HDMATransfer_FillBGMap0WithBlack ; no need to farcall
 	ld a, HIGH(vBGMap0)
 	call .LoadBGMapAddrIntoHRAM
@@ -45,59 +45,59 @@ ReanchorBGMap_NoOAMUpdate::
 	ld a, HIGH(vBGMap0)
 	ld [wBGMapAnchor + 1], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	call ApplyBGMapAnchorToObjects
 	ret
 
 .LoadBGMapAddrIntoHRAM:
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	xor a
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ret
 
 LoadFonts_NoOAMUpdate::
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	call .LoadGFX
 
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 .LoadGFX:
 	call LoadFontsExtra
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call SafeUpdateSprites
 	call LoadStandardFont
 	ret
 
 HDMATransfer_FillBGMap0WithBlack:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, "■"
 	ld hl, wDecompressScratch
 	ld bc, wScratchAttrMap - wDecompressScratch
 	call ByteFill
 	ld a, HIGH(wDecompressScratch)
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, LOW(wDecompressScratch)
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, HIGH(vBGMap0 % $8000)
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, LOW(vBGMap0 % $8000)
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $3f
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 	call DelayFrame
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret

--- a/engine/overworld/map_objects.asm
+++ b/engine/overworld/map_objects.asm
@@ -555,26 +555,26 @@ MapObjectMovementPattern:
 
 .RandomWalkY:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00000001
 	jp .RandomWalkContinue
 
 .RandomWalkX:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00000001
 	or  %00000010
 	jp .RandomWalkContinue
 
 .RandomWalkXY:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00000011
 	jp .RandomWalkContinue
 
 .RandomSpin1:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00001100
 	ld hl, OBJECT_FACING
 	add hl, bc
@@ -588,7 +588,7 @@ MapObjectMovementPattern:
 	and %00001100
 	ld d, a
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00001100
 	cp d
 	jr nz, .keep
@@ -1026,7 +1026,7 @@ MapObjectMovementPattern:
 	add hl, bc
 	ld [hl], OBJECT_ACTION_STEP
 	ld hl, wCenteredObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr z, .load_6
 	ld hl, OBJECT_STEP_TYPE
@@ -1045,13 +1045,13 @@ MapObjectMovementPattern:
 	call Function462a
 RandomStepDuration_Slow:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %01111111
 	jr SetRandomStepDuration
 
 RandomStepDuration_Fast:
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and %00011111
 SetRandomStepDuration:
 	ld hl, OBJECT_STEP_DURATION
@@ -1923,7 +1923,7 @@ ApplyMovementToFollower:
 	ret z
 	ld a, [wObjectFollow_Leader]
 	ld d, a
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp d
 	ret nz
 	ld a, e
@@ -2059,7 +2059,7 @@ ShakeScreen:
 
 DespawnEmote:
 	push bc
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld c, a
 	call .DeleteEmote
 	pop bc
@@ -2119,7 +2119,7 @@ CopyTempObjectData:
 	ld [hli], a
 	ld a, [de]
 	ld [hli], a
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld [hli], a
 	push hl
 	ld hl, OBJECT_NEXT_MAP_X
@@ -2143,7 +2143,7 @@ Function55e0::
 	ld bc, wObjectStructs
 	xor a
 .loop
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call DoesObjectHaveASprite
 	jr z, .ok
 	call Function565c
@@ -2152,7 +2152,7 @@ Function55e0::
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop
@@ -2166,7 +2166,7 @@ Function5602:
 	ld a, [wBattleScriptFlags]
 	bit 7, a
 	jr z, .ok
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	and a
 	jr z, .ok
 	call Function5629 ; respawn opponent
@@ -2202,13 +2202,13 @@ Function5645:
 	xor a
 	ld bc, wObjectStructs
 .loop
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call SetFacing_Standing
 	ld hl, OBJECT_STRUCT_LENGTH
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop
@@ -2317,7 +2317,7 @@ Function56cd:
 	jr c, .ok3
 	sub BG_MAP_WIDTH
 .ok3
-	ld [hUsedSpriteIndex], a
+	ldh [hUsedSpriteIndex], a
 	ld a, [wPlayerBGMapOffsetY]
 	ld e, a
 	ld hl, OBJECT_SPRITE_Y_OFFSET
@@ -2346,7 +2346,7 @@ Function56cd:
 	jr c, .ok6
 	sub BG_MAP_HEIGHT
 .ok6
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 	ld hl, OBJECT_PALETTE
 	add hl, bc
 	bit BIG_OBJECT_F, [hl]
@@ -2359,18 +2359,18 @@ Function56cd:
 	ld e, a
 .ok7
 	ld a, d
-	ld [hFFBF], a
+	ldh [hFFBF], a
 .loop
-	ld a, [hFFBF]
+	ldh a, [hFFBF]
 	ld d, a
-	ld a, [hUsedSpriteTile]
+	ldh a, [hUsedSpriteTile]
 	add e
 	dec a
 	cp SCREEN_HEIGHT
 	jr nc, .ok9
 	ld b, a
 .next
-	ld a, [hUsedSpriteIndex]
+	ldh a, [hUsedSpriteIndex]
 	add d
 	dec a
 	cp SCREEN_WIDTH
@@ -2415,7 +2415,7 @@ HandleNPCStep::
 	ld bc, wObjectStructs
 	xor a
 .loop
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call DoesObjectHaveASprite
 	jr z, .next
 	call Function437b
@@ -2424,7 +2424,7 @@ HandleNPCStep::
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop
@@ -2508,7 +2508,7 @@ StartFollow::
 SetLeaderIfVisible:
 	call CheckObjectVisibility
 	ret c
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld [wObjectFollow_Leader], a
 	ret
 
@@ -2534,7 +2534,7 @@ SetFollowerIfVisible:
 	ld hl, OBJECT_STEP_TYPE
 	add hl, bc
 	ld [hl], STEP_TYPE_00
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld [wObjectFollow_Follower], a
 	ret
 
@@ -2691,15 +2691,15 @@ _UpdateSprites::
 	bit 0, a
 	ret z
 	xor a
-	ld [hUsedSpriteIndex], a
-	ld a, [hOAMUpdate]
+	ldh [hUsedSpriteIndex], a
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, 1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call InitSprites
 	call .fill
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 .fill
@@ -2709,7 +2709,7 @@ _UpdateSprites::
 	jr z, .ok
 	ld b, 28 * SPRITEOAMSTRUCT_LENGTH
 .ok
-	ld a, [hUsedSpriteIndex]
+	ldh a, [hUsedSpriteIndex]
 	cp b
 	ret nc
 	ld l, a
@@ -2855,7 +2855,7 @@ InitSprites:
 	add hl, bc
 	ld a, [hl]
 	and $ff ^ (1 << 7)
-	ld [hFFC1], a
+	ldh [hFFC1], a
 	xor a
 	bit 7, [hl]
 	jr nz, .skip1
@@ -2884,7 +2884,7 @@ InitSprites:
 	jr z, .skip4
 	or PRIORITY
 .skip4
-	ld [hFFC2], a
+	ldh [hFFC2], a
 	ld hl, OBJECT_SPRITE_X
 	add hl, bc
 	ld a, [hl]
@@ -2895,7 +2895,7 @@ InitSprites:
 	ld e, a
 	ld a, [wPlayerBGMapOffsetX]
 	add e
-	ld [hFFBF], a
+	ldh [hFFBF], a
 	ld hl, OBJECT_SPRITE_Y
 	add hl, bc
 	ld a, [hl]
@@ -2906,7 +2906,7 @@ InitSprites:
 	ld e, a
 	ld a, [wPlayerBGMapOffsetY]
 	add e
-	ld [hFFC0], a
+	ldh [hFFC0], a
 	ld hl, OBJECT_FACING_STEP
 	add hl, bc
 	ld a, [hl]
@@ -2922,28 +2922,28 @@ InitSprites:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [hUsedSpriteIndex]
+	ldh a, [hUsedSpriteIndex]
 	ld c, a
 	ld b, HIGH(wVirtualOAM)
 	ld a, [hli]
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 	add c
 	cp LOW(wVirtualOAMEnd)
 	jr nc, .full
 .addsprite
-	ld a, [hFFC0]
+	ldh a, [hFFC0]
 	add [hl]
 	inc hl
 	ld [bc], a ; y
 	inc c
-	ld a, [hFFBF]
+	ldh a, [hFFBF]
 	add [hl]
 	inc hl
 	ld [bc], a ; x
 	inc c
 	ld e, [hl]
 	inc hl
-	ld a, [hFFC1]
+	ldh a, [hFFC1]
 	bit ABSOLUTE_TILE_ID_F, e
 	jr z, .nope1
 	xor a
@@ -2955,19 +2955,19 @@ InitSprites:
 	ld a, e
 	bit RELATIVE_ATTRIBUTES_F, a
 	jr z, .nope2
-	ld a, [hFFC2]
+	ldh a, [hFFC2]
 	or e
 .nope2
 	and OBP_NUM | X_FLIP | Y_FLIP | PRIORITY
 	or d
 	ld [bc], a ; attributes
 	inc c
-	ld a, [hUsedSpriteTile]
+	ldh a, [hUsedSpriteTile]
 	dec a
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 	jr nz, .addsprite
 	ld a, c
-	ld [hUsedSpriteIndex], a
+	ldh [hUsedSpriteIndex], a
 .done
 	xor a
 	ret

--- a/engine/overworld/map_setup.asm
+++ b/engine/overworld/map_setup.asm
@@ -1,5 +1,5 @@
 RunMapSetupScript::
-	ld a, [hMapEntryMethod]
+	ldh a, [hMapEntryMethod]
 	and $f
 	dec a
 	ld c, a
@@ -114,12 +114,12 @@ DontScrollText:
 
 ActivateMapAnims:
 	ld a, $1
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 SuspendMapAnims:
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 LoadObjectsRunCallback_02:

--- a/engine/overworld/movement.asm
+++ b/engine/overworld/movement.asm
@@ -237,7 +237,7 @@ Movement_48:
 Movement_remove_object:
 	call DeleteMapObject
 	ld hl, wObjectFollow_Leader
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr nz, .not_leading
 	ld [hl], -1
@@ -680,7 +680,7 @@ NormalStep:
 
 .skip_grass
 	ld hl, wCenteredObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr z, .player
 
@@ -704,7 +704,7 @@ TurningStep:
 	ld [hl], OBJECT_ACTION_SPIN
 
 	ld hl, wCenteredObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr z, .player
 
@@ -728,7 +728,7 @@ SlideStep:
 	ld [hl], OBJECT_ACTION_STAND
 
 	ld hl, wCenteredObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr z, .player
 
@@ -760,7 +760,7 @@ JumpStep:
 	call SpawnShadow
 
 	ld hl, wCenteredObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp [hl]
 	jr z, .player
 

--- a/engine/overworld/npc_movement.asm
+++ b/engine/overworld/npc_movement.asm
@@ -238,7 +238,7 @@ CheckFacingObject::
 .asm_6ff1
 	ld bc, wObjectStructs ; redundant
 	ld a, 0
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call IsNPCAtCoord
 	ret nc
 	ld hl, OBJECT_DIRECTION_WALKING
@@ -263,7 +263,7 @@ WillObjectBumpIntoSomeoneElse:
 	jr IsNPCAtCoord
 
 Unreferenced_Function7015:
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	call GetObjectStruct
 	call .CheckWillBeFacingNPC
 	call IsNPCAtCoord
@@ -302,7 +302,7 @@ IsNPCAtCoord:
 	ld bc, wObjectStructs
 	xor a
 .loop
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	call DoesObjectHaveASprite
 	jr z, .next
 
@@ -333,9 +333,9 @@ IsNPCAtCoord:
 	jr nz, .ok
 
 .ok2
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld l, a
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	cp l
 	jr nz, .setcarry
 
@@ -350,9 +350,9 @@ IsNPCAtCoord:
 	ld a, [hl]
 	cp e
 	jr nz, .next
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld l, a
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	cp l
 	jr nz, .setcarry
 
@@ -361,7 +361,7 @@ IsNPCAtCoord:
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop
@@ -469,7 +469,7 @@ Unreferenced_Function7113:
 	ld bc, wObjectStructs
 	xor a
 .loop
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	call DoesObjectHaveASprite
 	jr z, .next
 	ld hl, OBJECT_MOVEMENTTYPE
@@ -492,7 +492,7 @@ Unreferenced_Function7113:
 	ld a, [hl]
 	cp d
 	jr nz, .check_current_coords
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	cp $0
 	jr z, .next
 	jr .yes
@@ -515,7 +515,7 @@ Unreferenced_Function7113:
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop

--- a/engine/overworld/overworld.asm
+++ b/engine/overworld/overworld.asm
@@ -1,17 +1,17 @@
 GetEmote2bpp:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	call Get2bpp
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 _ReplaceKrisSprite::
 	call GetPlayerSprite
 	ld a, [wUsedSprites]
-	ld [hUsedSpriteIndex], a
+	ldh [hUsedSpriteIndex], a
 	ld a, [wUsedSprites + 1]
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 	call GetUsedSprite
 	ret
 
@@ -533,10 +533,10 @@ GetUsedSprites:
 	ld a, [hli]
 	and a
 	jr z, .done
-	ld [hUsedSpriteIndex], a
+	ldh [hUsedSpriteIndex], a
 
 	ld a, [hli]
-	ld [hUsedSpriteTile], a
+	ldh [hUsedSpriteTile], a
 
 	bit 7, a
 	jr z, .dont_set
@@ -558,9 +558,9 @@ GetUsedSprites:
 	ret
 
 GetUsedSprite:
-	ld a, [hUsedSpriteIndex]
+	ldh a, [hUsedSpriteIndex]
 	call SafeGetSprite
-	ld a, [hUsedSpriteTile]
+	ldh a, [hUsedSpriteTile]
 	call .GetTileAddr
 	push hl
 	push de
@@ -589,7 +589,7 @@ endr
 	bit 6, a
 	jr nz, .done
 
-	ld a, [hUsedSpriteIndex]
+	ldh a, [hUsedSpriteIndex]
 	call _DoesSpriteHaveFacings
 	jr c, .done
 
@@ -618,7 +618,7 @@ endr
 	ret
 
 .CopyToVram:
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, [wSpriteFlags]
 	bit 5, a
@@ -627,10 +627,10 @@ endr
 	ld a, $0
 
 .bankswitch
-	ld [rVBK], a
+	ldh [rVBK], a
 	call Get2bpp
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 LoadEmote::

--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -13,7 +13,7 @@ DoPlayerMovement::
 
 .GetDPad:
 
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	ld [wCurInput], a
 
 ; Standing downhill instead moves down.
@@ -617,7 +617,7 @@ ENDM
 ; Returns 1 if there is no NPC in front
 ; Returns 2 if there is a movable NPC in front
 	ld a, 0
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 ; Load the next X coordinate into d
 	ld a, [wPlayerStandingMapX]
 	ld d, a

--- a/engine/overworld/player_object.asm
+++ b/engine/overworld/player_object.asm
@@ -1,7 +1,7 @@
 BlankScreen:
 	call DisableSpriteUpdates
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearBGPalettes
 	call ClearSprites
 	hlcoord 0, 0
@@ -41,10 +41,10 @@ SpawnPlayer:
 .ok
 	ld [hl], e
 	ld a, PLAYER_OBJECT
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld bc, wMapObjects
 	ld a, PLAYER_OBJECT
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ld de, wObjectStructs
 	call CopyMapObjectToObjectStruct
 	ld a, PLAYER
@@ -93,7 +93,7 @@ WriteObjectXY::
 	ld hl, OBJECT_NEXT_MAP_Y
 	add hl, bc
 	ld e, [hl]
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld b, a
 	call CopyDECoordsToMapObject
 	and a
@@ -136,12 +136,12 @@ CopyObjectStruct::
 	ld a, 1
 	ld de, OBJECT_STRUCT_LENGTH
 .loop
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ld a, [hl]
 	and a
 	jr z, .done
 	add hl, de
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	inc a
 	cp NUM_OBJECT_STRUCTS
 	jr nz, .loop
@@ -167,12 +167,12 @@ CopyMapObjectToObjectStruct:
 	ret
 
 .CopyMapObjectToTempObject:
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld [hl], a
 
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld [wTempObjectCopyMapObjectIndex], a
 
 	ld hl, MAPOBJECT_SPRITE
@@ -227,7 +227,7 @@ InitializeVisibleSprites:
 	ld bc, wMapObjects + OBJECT_LENGTH
 	ld a, 1
 .loop
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld hl, MAPOBJECT_SPRITE
 	add hl, bc
 	ld a, [hl]
@@ -275,7 +275,7 @@ InitializeVisibleSprites:
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECTS
 	jr nz, .loop
@@ -314,7 +314,7 @@ CheckObjectEnteringVisibleRange::
 	ld bc, wMapObjects + OBJECT_LENGTH
 	ld a, 1
 .loop_v
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld hl, MAPOBJECT_SPRITE
 	add hl, bc
 	ld a, [hl]
@@ -349,7 +349,7 @@ CheckObjectEnteringVisibleRange::
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECTS
 	jr nz, .loop_v
@@ -370,7 +370,7 @@ CheckObjectEnteringVisibleRange::
 	ld bc, wMapObjects + OBJECT_LENGTH
 	ld a, 1
 .loop_h
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld hl, MAPOBJECT_SPRITE
 	add hl, bc
 	ld a, [hl]
@@ -405,7 +405,7 @@ CheckObjectEnteringVisibleRange::
 	add hl, bc
 	ld b, h
 	ld c, l
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	inc a
 	cp NUM_OBJECTS
 	jr nz, .loop_h
@@ -514,14 +514,14 @@ CopyTempObjectToObjectStruct:
 	ret
 
 TrainerWalkToPlayer:
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	call InitMovementBuffer
 	ld a, movement_step_sleep
 	call AppendToMovementBuffer
 	ld a, [wd03f]
 	dec a
 	jr z, .TerminateStep
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	ld b, a
 	ld c, PLAYER
 	ld d, 1
@@ -678,7 +678,7 @@ FollowNotExact::
 	ld hl, OBJECT_SPRITE_Y
 	add hl, de
 	ld [hl], a
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	ld hl, OBJECT_RANGE
 	add hl, de
 	ld [hl], a

--- a/engine/overworld/player_step.asm
+++ b/engine/overworld/player_step.asm
@@ -39,12 +39,12 @@ ScrollScreen::
 	ld d, a
 	ld a, [wPlayerStepVectorY]
 	ld e, a
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add d
-	ld [hSCX], a
-	ld a, [hSCY]
+	ldh [hSCX], a
+	ldh a, [hSCY]
 	add e
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret
 
 HandlePlayerStep:

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -407,14 +407,14 @@ Script_waitbutton:
 Script_buttonsound:
 ; script command 0x55
 
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call WaitBGMap
 	call ButtonSound
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 Script_yesorno:
@@ -933,7 +933,7 @@ Script_setlasttalked:
 
 	call GetScriptByte
 	call GetScriptObject
-	ld [hLastTalked], a
+	ldh [hLastTalked], a
 	ret
 
 Script_applymovement:
@@ -977,25 +977,25 @@ Script_applymovement2:
 ; parameters: data
 ; apply movement to last talked
 
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	ld c, a
 	jp ApplyMovement
 
 Script_faceplayer:
 ; script command 0x6b
 
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	and a
 	ret z
 	ld d, $0
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	ld e, a
 	farcall GetRelativeFacing
 	ld a, d
 	add a
 	add a
 	ld e, a
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	ld d, a
 	call ApplyObjectFacing
 	ret
@@ -1008,14 +1008,14 @@ Script_faceobject:
 	call GetScriptObject
 	cp LAST_TALKED
 	jr c, .ok
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 .ok
 	ld e, a
 	call GetScriptByte
 	call GetScriptObject
 	cp LAST_TALKED
 	jr nz, .ok2
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 .ok2
 	ld d, a
 	push de
@@ -1038,7 +1038,7 @@ Script_turnobject:
 	call GetScriptObject
 	cp LAST_TALKED
 	jr nz, .ok
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 .ok
 	ld d, a
 	call GetScriptByte
@@ -1113,7 +1113,7 @@ Script_appear:
 	call GetScriptByte
 	call GetScriptObject
 	call _CopyObjectStruct
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld b, 0 ; clear
 	call ApplyEventActionAppearDisappear
 	ret
@@ -1126,10 +1126,10 @@ Script_disappear:
 	call GetScriptObject
 	cp LAST_TALKED
 	jr nz, .ok
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 .ok
 	call DeleteObjectStruct
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld b, 1 ; set
 	call ApplyEventActionAppearDisappear
 	farcall _UpdateSprites
@@ -1198,7 +1198,7 @@ Script_writeobjectxy:
 	call GetScriptObject
 	cp LAST_TALKED
 	jr nz, .ok
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 .ok
 	ld b, a
 	farcall WriteObjectXY
@@ -1240,7 +1240,7 @@ Script_showemote:
 	call GetScriptObject
 	cp LAST_TALKED
 	jr z, .ok
-	ld [hLastTalked], a
+	ldh [hLastTalked], a
 .ok
 	call GetScriptByte
 	ld [wScriptDelay], a
@@ -1398,7 +1398,7 @@ Script_reloadmap:
 	xor a
 	ld [wBattleScriptFlags], a
 	ld a, MAPSETUP_RELOADMAP
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ld a, $1
 	call LoadMapStatus
 	call StopScript
@@ -1777,7 +1777,7 @@ Script_random:
 	push bc
 	call Random
 	pop bc
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	cp b
 	jr nc, .loop
 	jr .finish
@@ -1786,7 +1786,7 @@ Script_random:
 	push bc
 	call Random
 	pop bc
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 
 .finish
 	push af
@@ -2187,9 +2187,9 @@ Script_checkcoins:
 
 LoadCoinAmountToMem:
 	call GetScriptByte
-	ld [hMoneyTemp + 1], a
+	ldh [hMoneyTemp + 1], a
 	call GetScriptByte
-	ld [hMoneyTemp], a
+	ldh [hMoneyTemp], a
 	ld bc, hMoneyTemp
 	ret
 
@@ -2476,7 +2476,7 @@ Script_warp:
 	ld a, -1
 	ld [wDefaultSpawnpoint], a
 	ld a, MAPSETUP_WARP
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ld a, 1
 	call LoadMapStatus
 	call StopScript
@@ -2489,7 +2489,7 @@ Script_warp:
 	ld a, -1
 	ld [wDefaultSpawnpoint], a
 	ld a, MAPSETUP_BADWARP
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ld a, 1
 	call LoadMapStatus
 	call StopScript
@@ -2585,7 +2585,7 @@ Script_reloadmappart::
 ; script command 0x7c
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call OverworldTextModeSwitch
 	call GetMovementPermissions
 	farcall ReloadMapPart
@@ -2610,7 +2610,7 @@ Script_newloadmap:
 ; parameters: which_method
 
 	call GetScriptByte
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ld a, 1
 	call LoadMapStatus
 	call StopScript

--- a/engine/overworld/select_menu.asm
+++ b/engine/overworld/select_menu.asm
@@ -159,7 +159,7 @@ UseRegisteredItem:
 	jr nz, ._cantuse
 	scf
 	ld a, HMENURETURN_SCRIPT
-	ld [hMenuReturn], a
+	ldh [hMenuReturn], a
 	ret
 
 .CantUse:

--- a/engine/overworld/time.asm
+++ b/engine/overworld/time.asm
@@ -350,7 +350,7 @@ CalcSecsMinsHoursDaysSince:
 	inc hl
 	inc hl
 	inc hl
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld c, a
 	sub [hl]
 	jr nc, .skip
@@ -361,7 +361,7 @@ CalcSecsMinsHoursDaysSince:
 	ld [wSecondsSince], a ; seconds since
 
 _CalcMinsHoursDaysSince:
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld c, a
 	sbc [hl]
 	jr nc, .skip
@@ -372,7 +372,7 @@ _CalcMinsHoursDaysSince:
 	ld [wMinutesSince], a ; minutes since
 
 _CalcHoursDaysSince:
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld c, a
 	sbc [hl]
 	jr nc, .skip
@@ -396,11 +396,11 @@ _CalcDaysSince:
 CopyDayHourMinSecToHL:
 	ld a, [wCurDay]
 	ld [hli], a
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [hli], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [hli], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [hli], a
 	ret
 
@@ -412,15 +412,15 @@ CopyDayToHL:
 CopyDayHourToHL:
 	ld a, [wCurDay]
 	ld [hli], a
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [hli], a
 	ret
 
 CopyDayHourMinToHL:
 	ld a, [wCurDay]
 	ld [hli], a
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [hli], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [hli], a
 	ret

--- a/engine/overworld/warp_connection.asm
+++ b/engine/overworld/warp_connection.asm
@@ -242,14 +242,14 @@ LoadMapTimeOfDay:
 	ld [wBGMapAnchor + 1], a
 	xor a ; LOW(vBGMap0)
 	ld [wBGMapAnchor], a
-	ld [hSCY], a
-	ld [hSCX], a
+	ldh [hSCY], a
+	ldh [hSCX], a
 	farcall ApplyBGMapAnchorToObjects
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	xor a
 	ld bc, vBGMap1 - vBGMap0
@@ -257,7 +257,7 @@ LoadMapTimeOfDay:
 	call ByteFill
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld a, "■"
 	ld bc, vBGMap1 - vBGMap0
@@ -268,13 +268,13 @@ LoadMapTimeOfDay:
 .PushAttrMap:
 	decoord 0, 0
 	call .copy
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
 	decoord 0, 0, wAttrMap
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 .copy
 	hlbgcoord 0, 0
 	ld c, SCREEN_WIDTH
@@ -293,16 +293,16 @@ LoadMapTimeOfDay:
 	dec b
 	jr nz, .row
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 LoadGraphics:
 	call LoadTileset
 	call LoadTilesetGFX
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	xor a
-	ld [hTileAnimFrame], a
+	ldh [hTileAnimFrame], a
 	farcall RefreshSprites
 	call LoadFontsExtra
 	farcall LoadOverworldFont

--- a/engine/phone/phone.asm
+++ b/engine/phone/phone.asm
@@ -94,7 +94,7 @@ GetRemainingSpaceInPhoneList:
 INCLUDE "data/phone/permanent_numbers.asm"
 
 FarPlaceString:
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
@@ -170,7 +170,7 @@ ChooseRandomCaller:
 ; Sample a random number between 0 and 31.
 	ld c, a
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	swap a
 	and $1f
 ; Compute that number modulo the number of available callers.

--- a/engine/phone/phonering_copytilemapatonce.asm
+++ b/engine/phone/phonering_copytilemapatonce.asm
@@ -1,5 +1,5 @@
 PhoneRing_CopyTilemapAtOnce:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jp z, WaitBGMap
 	ld a, [wSpriteUpdatesEnabled]
@@ -7,48 +7,48 @@ PhoneRing_CopyTilemapAtOnce:
 	jp z, WaitBGMap
 
 ; What follows is a modified version of CopyTilemapAtOnce.
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
-	ld a, [hMapAnims]
+	ldh [hBGMapMode], a
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 .wait
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK - 1
 	jr c, .wait
 
 	di
 	ld a, BANK(vBGMap2)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0, wAttrMap
 	call .CopyTilemapAtOnce
 	ld a, BANK(vBGMap0)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0
 	call .CopyTilemapAtOnce
 .wait2
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK - 1
 	jr c, .wait2
 	ei
 
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .CopyTilemapAtOnce:
 	ld [hSPBuffer], sp
 	ld sp, hl
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	ld l, 0
 	ld a, SCREEN_HEIGHT
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	ld b, 1 << 1 ; not in v/hblank
 	ld c, LOW(rSTAT)
 
@@ -67,14 +67,14 @@ endr
 
 	ld de, BG_MAP_WIDTH - SCREEN_WIDTH
 	add hl, de
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	dec a
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	jr nz, .loop
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret

--- a/engine/pokedex/new_pokedex_entry.asm
+++ b/engine/pokedex/new_pokedex_entry.asm
@@ -1,8 +1,8 @@
 NewPokedexEntry:
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call LowVolume
 	call ClearBGPalettes
 	call ClearTileMap
@@ -10,9 +10,9 @@ NewPokedexEntry:
 	call ClearSprites
 	ld a, [wPokedexStatus]
 	push af
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
 	ld [wPokedexStatus], a
 	farcall _NewPokedexEntry
@@ -25,12 +25,12 @@ NewPokedexEntry:
 	ld [wPokedexStatus], a
 	call MaxVolume
 	call RotateThreePalettesRight
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	add -POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 	call .ReturnFromDexRegistration
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 .ReturnFromDexRegistration:

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -19,12 +19,12 @@ POKEDEX_SCX EQU 5
 GLOBAL POKEDEX_SCX
 
 Pokedex:
-	ld a, [hWX]
+	ldh a, [hWX]
 	ld l, a
-	ld a, [hWY]
+	ldh a, [hWY]
 	ld h, a
 	push hl
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	push af
 	ld hl, wOptions
 	ld a, [hl]
@@ -34,13 +34,13 @@ Pokedex:
 	push af
 	xor a
 	ld [wVramState], a
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call InitPokedex
 	call DelayFrame
 
@@ -62,18 +62,18 @@ Pokedex:
 	ld [wLastDexMode], a
 
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wVramState], a
 	pop af
 	ld [wOptions], a
 	pop af
-	ld [hSCX], a
+	ldh [hSCX], a
 	pop hl
 	ld a, l
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, h
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 InitPokedex:
@@ -216,7 +216,7 @@ Pokedex_Exit:
 
 Pokedex_InitMainScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	xor a
 	hlcoord 0, 0, wAttrMap
@@ -233,7 +233,7 @@ Pokedex_InitMainScreen:
 	call Pokedex_ResetBGMapMode
 	call Pokedex_DrawMainScreenBG
 	ld a, POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 
 	ld a, [wCurrentDexMode]
 	cp DEXMODE_OLD
@@ -241,9 +241,9 @@ Pokedex_InitMainScreen:
 	jr z, .okay
 	ld a, $47
 .okay
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	call WaitBGMap
 
 	call Pokedex_ResetBGMapMode
@@ -280,7 +280,7 @@ Pokedex_UpdateMainScreen:
 	ret nc
 	call Pokedex_UpdateCursorOAM
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pokedex_PrintListing
 	call Pokedex_SetBGMapMode3
 	call Pokedex_ResetBGMapMode
@@ -301,9 +301,9 @@ Pokedex_UpdateMainScreen:
 	ld a, DEXSTATE_OPTION_SCR
 	ld [wJumptableIndex], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $a7
-	ld [hWX], a
+	ldh [hWX], a
 	call DelayFrame
 	ret
 
@@ -312,9 +312,9 @@ Pokedex_UpdateMainScreen:
 	ld a, DEXSTATE_SEARCH_SCR
 	ld [wJumptableIndex], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $a7
-	ld [hWX], a
+	ldh [hWX], a
 	call DelayFrame
 	ret
 
@@ -328,7 +328,7 @@ Pokedex_InitDexEntryScreen:
 	xor a ; page 1
 	ld [wPokedexStatus], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call Pokedex_LoadCurrentFootprint
 	call Pokedex_DrawDexEntryScreenBG
@@ -339,7 +339,7 @@ Pokedex_InitDexEntryScreen:
 	call Pokedex_DrawFootprint
 	call WaitBGMap
 	ld a, $a7
-	ld [hWX], a
+	ldh [hWX], a
 	call Pokedex_GetSelectedMon
 	ld [wCurPartySpecies], a
 	ld a, SCGB_POKEDEX
@@ -399,7 +399,7 @@ Pokedex_ReinitDexEntryScreen:
 	xor a ; page 1
 	ld [wPokedexStatus], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pokedex_DrawDexEntryScreenBG
 	call Pokedex_InitArrowCursor
 	call Pokedex_LoadCurrentFootprint
@@ -435,12 +435,12 @@ DexEntryScreen_MenuActionJumptable:
 .Area:
 	call Pokedex_BlackOutBG
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call Pokedex_GetSelectedMon
 	ld a, [wDexCurrentLocation]
 	ld e, a
@@ -448,11 +448,11 @@ DexEntryScreen_MenuActionJumptable:
 	call Pokedex_BlackOutBG
 	call DelayFrame
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	call Pokedex_RedisplayDexEntry
 	call Pokedex_LoadSelectedMonTiles
@@ -475,7 +475,7 @@ DexEntryScreen_MenuActionJumptable:
 .Print:
 	call Pokedex_ApplyPrintPals
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, [wPrevDexEntryBackup]
 	push af
 	ld a, [wPrevDexEntryJumptableIndex]
@@ -496,7 +496,7 @@ DexEntryScreen_MenuActionJumptable:
 	call EnableLCD
 	call WaitBGMap
 	ld a, POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 	call Pokedex_ApplyUsualPals
 	ret
 
@@ -509,7 +509,7 @@ Pokedex_RedisplayDexEntry:
 
 Pokedex_InitOptionScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call Pokedex_DrawOptionScreenBG
 	call Pokedex_InitArrowCursor
@@ -612,7 +612,7 @@ Pokedex_UpdateOptionScreen:
 
 Pokedex_InitSearchScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call Pokedex_DrawSearchScreenBG
 	call Pokedex_InitArrowCursor
@@ -685,7 +685,7 @@ Pokedex_UpdateSearchScreen:
 	call Pokedex_OrderMonsByMode
 	call Pokedex_DisplayTypeNotFoundMessage
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pokedex_DrawSearchScreenBG
 	call Pokedex_InitArrowCursor
 	call Pokedex_PlaceSearchScreenTypeStrings
@@ -716,7 +716,7 @@ Pokedex_UpdateSearchScreen:
 
 Pokedex_InitSearchResultsScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	xor a
 	hlcoord 0, 0, wAttrMap
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
@@ -732,11 +732,11 @@ Pokedex_InitSearchResultsScreen:
 	call Pokedex_ResetBGMapMode
 	call Pokedex_DrawSearchResultsScreenBG
 	ld a, POKEDEX_SCX
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $4a
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	call WaitBGMap
 	call Pokedex_ResetBGMapMode
 	farcall DrawPokedexSearchResultsWindow
@@ -761,7 +761,7 @@ Pokedex_UpdateSearchResultsScreen:
 	ret nc
 	call Pokedex_UpdateSearchResultsCursorOAM
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pokedex_PrintListing
 	call Pokedex_SetBGMapMode3
 	call Pokedex_ResetBGMapMode
@@ -790,9 +790,9 @@ Pokedex_UpdateSearchResultsScreen:
 	ld a, DEXSTATE_SEARCH_SCR
 	ld [wJumptableIndex], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $a7
-	ld [hWX], a
+	ldh [hWX], a
 	ret
 
 Pokedex_InitUnownMode:
@@ -869,14 +869,14 @@ Pokedex_UnownModeHandleDPadInput:
 .update
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop af
 	call Pokedex_UnownModeEraseCursor
 	call Pokedex_LoadUnownFrontpicTiles
 	call Pokedex_UnownModePlaceCursor
 	farcall PrintUnownWord
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ret
@@ -1707,7 +1707,7 @@ INCLUDE "data/pokemon/dex_order_new.asm"
 
 Pokedex_DisplayModeDescription:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 12
 	lb bc, 4, 18
 	call Pokedex_PlaceBorder
@@ -1719,7 +1719,7 @@ Pokedex_DisplayModeDescription:
 	hlcoord 1, 14
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .Modes:
@@ -1746,7 +1746,7 @@ Pokedex_DisplayModeDescription:
 
 Pokedex_DisplayChangingModesMessage:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 12
 	lb bc, 4, 18
 	call Pokedex_PlaceBorder
@@ -1754,7 +1754,7 @@ Pokedex_DisplayChangingModesMessage:
 	hlcoord 1, 14
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 64
 	call DelayFrames
 	ld de, SFX_CHANGE_DEX_MODE
@@ -1840,7 +1840,7 @@ Pokedex_NextSearchMonType:
 
 Pokedex_PlaceSearchScreenTypeStrings:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 9, 3
 	lb bc, 4, 8
 	ld a, " "
@@ -1852,7 +1852,7 @@ Pokedex_PlaceSearchScreenTypeStrings:
 	hlcoord 9, 6
 	call Pokedex_PlaceTypeString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Pokedex_PlaceTypeString:
@@ -1950,7 +1950,7 @@ INCLUDE "data/types/search_types.asm"
 
 Pokedex_DisplayTypeNotFoundMessage:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 12
 	lb bc, 4, 18
 	call Pokedex_PlaceBorder
@@ -1958,7 +1958,7 @@ Pokedex_DisplayTypeNotFoundMessage:
 	hlcoord 1, 14
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, $80
 	call DelayFrames
 	ret
@@ -2306,16 +2306,16 @@ Pokedex_FillBox:
 
 Pokedex_BlackOutBG:
 ; Make BG palettes black so that the BG becomes all black.
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1
 	ld bc, 8 palettes
 	xor a
 	call ByteFill
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 Pokedex_ApplyPrintPals:
 	ld a, $ff
@@ -2368,7 +2368,7 @@ Pokedex_LoadSelectedMonTiles:
 	ld hl, vTiles2
 	ld de, sScratch
 	ld c, 7 * 7
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld b, a
 	call Get2bpp
 	call CloseSRAM
@@ -2470,10 +2470,10 @@ PokedexSlowpokeLZ:
 INCBIN "gfx/pokedex/slowpoke.2bpp.lz"
 
 Pokedex_CheckSGB:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	or a
 	ret nz
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	dec a
 	ret
 
@@ -2516,7 +2516,7 @@ Pokedex_LoadUnownFrontpicTiles:
 
 _NewPokedexEntry:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall DrawDexEntryScreenRightEdge
 	call Pokedex_ResetBGMapMode
 	call DisableLCD
@@ -2548,20 +2548,20 @@ _NewPokedexEntry:
 
 Pokedex_SetBGMapMode3:
 	ld a, $3
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 	ret
 
 Pokedex_SetBGMapMode4:
 	ld a, $4
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 	ret
 
 Pokedex_SetBGMapMode_3ifDMG_4ifCGB:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .DMG
 	call Pokedex_SetBGMapMode4
@@ -2571,5 +2571,5 @@ Pokedex_SetBGMapMode_3ifDMG_4ifCGB:
 
 Pokedex_ResetBGMapMode:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret

--- a/engine/pokedex/pokedex_3.asm
+++ b/engine/pokedex/pokedex_3.asm
@@ -119,16 +119,16 @@ DrawPokedexSearchResultsWindow:
 	next "D!@"
 
 DrawDexEntryScreenRightEdge:
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld l, a
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	push hl
 	inc hl
 	ld a, l
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, h
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 19, 0
 	ld [hl], $66
 	hlcoord 19, 1
@@ -145,9 +145,9 @@ DrawDexEntryScreenRightEdge:
 	call WaitBGMap2
 	pop hl
 	ld a, l
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, h
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ret
 
 Bank77_FillColumn:

--- a/engine/pokegear/pokegear.asm
+++ b/engine/pokegear/pokegear.asm
@@ -27,10 +27,10 @@ PokeGear:
 	ld a, [hl]
 	push af
 	set NO_TEXT_SCROLL, [hl]
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ld a, [wVramState]
 	push af
 	xor a
@@ -55,16 +55,16 @@ PokeGear:
 	pop af
 	ld [wVramState], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wOptions], a
 	call ClearBGPalettes
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call ExitPokegearRadio_HandleMusic
 	ret
 
@@ -74,17 +74,17 @@ PokeGear:
 	call ClearSprites
 	call DisableLCD
 	xor a
-	ld [hSCY], a
-	ld [hSCX], a
+	ldh [hSCY], a
+	ldh [hSCX], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	call Pokegear_LoadGFX
 	farcall ClearSpriteAnims
 	call InitPokegearModeIndicatorArrow
 	ld a, 8
 	call SkipMusic
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	call TownMap_InitCursorAndPlayerIconPositions
 	xor a
 	ld [wJumptableIndex], a ; POKEGEARSTATE_CLOCKINIT
@@ -102,7 +102,7 @@ PokeGear:
 	ld b, SCGB_POKEGEAR_PALS
 	call GetSGBLayout
 	call SetPalettes
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 	ld a, %11100100
@@ -237,7 +237,7 @@ Pokegear_InitJumptableIndices:
 
 InitPokegearTilemap:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, $4f
@@ -263,22 +263,22 @@ InitPokegearTilemap:
 	and a
 	jr nz, .kanto_0
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call .UpdateBGMap
 	ld a, $90
 	jr .finish
 
 .kanto_0
 	xor a ; LOW(vBGMap1)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call .UpdateBGMap
 	xor a
 .finish
-	ld [hWY], a
+	ldh [hWY], a
 	; swap region maps
 	ld a, [wPokegearMapRegion]
 	maskbits NUM_REGIONS
@@ -287,11 +287,11 @@ InitPokegearTilemap:
 	ret
 
 .UpdateBGMap:
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld a, $2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 3
 	call DelayFrames
 .dmg
@@ -507,19 +507,19 @@ PokegearClock_Joypad:
 
 .UpdateClock:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Pokegear_UpdateClock
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Pokegear_UpdateClock:
 	hlcoord 3, 5
 	lb bc, 5, 14
 	call ClearBox
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld b, a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld c, a
 	decoord 6, 8
 	farcall PrintHoursMins
@@ -899,7 +899,7 @@ PokegearPhone_MakePhoneCall:
 	ld hl, wOptions
 	res NO_TEXT_SCROLL, [hl]
 	xor a
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ld de, SFX_CALL
 	call PlaySFX
 	ld hl, .dotdotdot
@@ -918,7 +918,7 @@ PokegearPhone_MakePhoneCall:
 	ld hl, wOptions
 	set NO_TEXT_SCROLL, [hl]
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call PokegearPhone_UpdateCursor
 	ld hl, wJumptableIndex
 	inc [hl]
@@ -945,7 +945,7 @@ PokegearPhone_MakePhoneCall:
 	db "@"
 
 PokegearPhone_FinishPhoneCall:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON
 	ret z
 	farcall HangUp
@@ -999,14 +999,14 @@ PokegearPhone_GetDPad:
 
 .done_joypad_same_page
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PokegearPhone_UpdateCursor
 	call WaitBGMap
 	ret
 
 .done_joypad_update_page
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PokegearPhone_UpdateDisplayList
 	call WaitBGMap
 	ret
@@ -1120,7 +1120,7 @@ PokegearPhoneContactSubmenu:
 	ld de, .CallCancelStrings
 .got_menu_data
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	push hl
 	push de
 	ld a, [de]
@@ -1187,12 +1187,12 @@ PokegearPhoneContactSubmenu:
 
 .a_b
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PokegearPhone_UpdateDisplayList
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop hl
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and B_BUTTON
 	jr nz, .Cancel
 	ld a, [wPokegearPhoneSubmenuCursor]
@@ -1219,7 +1219,7 @@ PokegearPhoneContactSubmenu:
 	jr c, .CancelDelete
 	call PokegearPhone_DeletePhoneNumber
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PokegearPhone_UpdateDisplayList
 	ld hl, PokegearText_WhomToCall
 	call PrintText
@@ -1283,7 +1283,7 @@ PokegearPhoneContactSubmenu:
 	dw .Cancel
 
 ; unused
-	ld a, [hHours]
+	ldh a, [hHours]
 	cp 12
 	jr c, .am
 	sub 12
@@ -1449,11 +1449,11 @@ UpdateRadioStation:
 	and a
 	ret z
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 2, 9
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 ; unused
@@ -1740,7 +1740,7 @@ NoRadioStation:
 	ld [wPokegearRadioChannelAddr], a
 	ld [wPokegearRadioChannelAddr + 1], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 NoRadioMusic:
@@ -1752,7 +1752,7 @@ NoRadioMusic:
 
 NoRadioName:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 1, 8
 	lb bc, 3, 18
 	call ClearBox
@@ -1777,10 +1777,10 @@ _TownMap:
 	push af
 	set NO_TEXT_SCROLL, [hl]
 
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 
 	ld a, [wVramState]
 	push af
@@ -1796,12 +1796,12 @@ _TownMap:
 	ld a, 8
 	call SkipMusic
 	ld a, LCDC_DEFAULT
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	call TownMap_GetCurrentLandmark
 	ld [wTownMapPlayerIconLandmark], a
 	ld [wTownMapCursorLandmark], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .InitTilemap
 	call WaitBGMap2
 	ld a, [wTownMapPlayerIconLandmark]
@@ -1815,7 +1815,7 @@ _TownMap:
 	ld b, SCGB_POKEGEAR_PALS
 	call GetSGBLayout
 	call SetPalettes
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld a, %11100100
@@ -1839,7 +1839,7 @@ _TownMap:
 	pop af
 	ld [wVramState], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wOptions], a
 	call ClearBGPalettes
@@ -1949,7 +1949,7 @@ PlayRadio:
 	call DelayFrames
 .loop
 	call JoyTextDelay
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON
 	jr nz, .stop
 	ld a, [wPokegearRadioChannelAddr]
@@ -2047,7 +2047,7 @@ _FlyMap:
 	push af
 	ld [hl], $1
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall ClearSpriteAnims
 	call LoadTownMapGFX
 	ld de, FlyMapLabelBorderGFX
@@ -2089,14 +2089,14 @@ _FlyMap:
 .exit
 	ld [wTownMapPlayerIconLandmark], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call ClearBGPalettes
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ld a, [wTownMapPlayerIconLandmark]
 	ld e, a
 	ret
@@ -2145,7 +2145,7 @@ FlyMapScroll:
 	call TownMapBubble
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 TownMapBubble:
@@ -2367,9 +2367,9 @@ Pokedex_GetArea:
 	ld [wTownMapPlayerIconLandmark], a
 	call ClearSprites
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ld de, PokedexNestIconGFX
 	ld hl, vTiles0 tile $7f
 	lb bc, BANK(PokedexNestIconGFX), 1
@@ -2393,7 +2393,7 @@ Pokedex_GetArea:
 	call GetSGBLayout
 	call SetPalettes
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	xor a ; JOHTO_REGION
 	call .GetAndPlaceNest
 .loop
@@ -2402,7 +2402,7 @@ Pokedex_GetArea:
 	ld a, [hl]
 	and A_BUTTON | B_BUTTON
 	jr nz, .a_b
-	ld a, [hJoypadDown]
+	ldh a, [hJoypadDown]
 	and SELECT
 	jr nz, .select
 	call .LeftRightInput
@@ -2433,12 +2433,12 @@ Pokedex_GetArea:
 	ret
 
 .left
-	ld a, [hWY]
+	ldh a, [hWY]
 	cp $90
 	ret z
 	call ClearSprites
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	xor a ; JOHTO_REGION
 	call .GetAndPlaceNest
 	ret
@@ -2447,18 +2447,18 @@ Pokedex_GetArea:
 	ld a, [wStatusFlags]
 	bit STATUSFLAGS_HALL_OF_FAME_F, a
 	ret z
-	ld a, [hWY]
+	ldh a, [hWY]
 	and a
 	ret z
 	call ClearSprites
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, KANTO_REGION
 	call .GetAndPlaceNest
 	ret
 
 .BlinkNestIcons:
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	ld e, a
 	and $f
 	ret nz
@@ -2637,16 +2637,16 @@ TownMapBGUpdate:
 
 ; BG Map address
 	ld a, l
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, h
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 ; Only update palettes on CGB
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .tiles
 ; BG Map mode 2 (palettes)
 	ld a, 2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 ; The BG Map is updated in thirds, so we wait
 
 ; 3 frames to update the whole screen's palettes.
@@ -2657,7 +2657,7 @@ TownMapBGUpdate:
 	call WaitBGMap
 ; Turn off BG Map update
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 FillJohtoMap:
@@ -2829,7 +2829,7 @@ Unreferenced_Function92311:
 	push af
 	ld [hl], $1
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall ClearSpriteAnims
 	call LoadTownMapGFX
 	ld de, FlyMapLabelBorderGFX
@@ -2884,14 +2884,14 @@ Unreferenced_Function92311:
 .finished_a_b
 	ld [wTownMapPlayerIconLandmark], a
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call ClearBGPalettes
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	xor a ; LOW(vBGMap0)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ld a, [wTownMapPlayerIconLandmark]
 	ld e, a
 	ret
@@ -2938,11 +2938,11 @@ Unreferenced_Function92311:
 	ld a, $90
 	ld b, $98
 .finish
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, b
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	call TownMapBubble
 	call WaitBGMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret

--- a/engine/pokegear/radio.asm
+++ b/engine/pokegear/radio.asm
@@ -1528,15 +1528,15 @@ BuenasPassword1:
 
 .PlayPassword:
 	call StartRadioStation
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld de, BuenasPasswordChannelName
 	hlcoord 2, 9
 	call PlaceString
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, BuenaRadioText1
 	ld a, BUENAS_PASSWORD_2
 	jp NextRadioLine
@@ -1770,12 +1770,12 @@ BuenasPassword19:
 	jp NextRadioLine
 
 BuenasPassword20:
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	farcall NoRadioMusic
 	farcall NoRadioName
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wDailyFlags2
 	res DAILYFLAGS2_BUENAS_PASSWORD_F, [hl]
 	ld a, BUENAS_PASSWORD
@@ -1799,7 +1799,7 @@ BuenasPassword21:
 
 BuenasPasswordCheckTime:
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	cp NITE_HOUR
 	ret
 

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -7,12 +7,12 @@ _DepositPKMN:
 	push af
 	xor a
 	ld [wVramState], a
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call BillsPC_InitRAM
 	xor a
 	ld [wBillsPC_LoadedBox], a
@@ -28,7 +28,7 @@ _DepositPKMN:
 .done
 	call ClearSprites
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wVramState], a
 	pop af
@@ -50,7 +50,7 @@ _DepositPKMN:
 
 .Init:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call CopyBoxmonSpecies
 	call BillsPC_BoxName
@@ -82,11 +82,11 @@ _DepositPKMN:
 	ret z
 	call BillsPC_UpdateSelectionCursor
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BillsPC_RefreshTextboxes
 	call PCMonInfo
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ret
@@ -113,7 +113,7 @@ _DepositPKMN:
 
 .WhatsUp:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call BillsPC_GetSelectedPokemonSpecies
 	ld [wCurPartySpecies], a
@@ -263,12 +263,12 @@ _WithdrawPKMN:
 	push af
 	xor a
 	ld [wVramState], a
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call BillsPC_InitRAM
 	ld a, NUM_BOXES + 1
 	ld [wBillsPC_LoadedBox], a
@@ -284,7 +284,7 @@ _WithdrawPKMN:
 .done
 	call ClearSprites
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wVramState], a
 	pop af
@@ -308,7 +308,7 @@ _WithdrawPKMN:
 	ld a, NUM_BOXES + 1
 	ld [wBillsPC_LoadedBox], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call CopyBoxmonSpecies
 	call BillsPC_BoxName
@@ -340,11 +340,11 @@ _WithdrawPKMN:
 	ret z
 	call BillsPC_UpdateSelectionCursor
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BillsPC_RefreshTextboxes
 	call PCMonInfo
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ret
@@ -370,7 +370,7 @@ _WithdrawPKMN:
 
 .PrepSubmenu:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call BillsPC_GetSelectedPokemonSpecies
 	ld [wCurPartySpecies], a
@@ -501,12 +501,12 @@ _MovePKMNWithoutMail:
 	push af
 	xor a
 	ld [wVramState], a
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call BillsPC_InitRAM
 	ld a, [wCurBox]
 	and $f
@@ -525,7 +525,7 @@ _MovePKMNWithoutMail:
 .asm_e2793
 	call ClearSprites
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wVramState], a
 	pop af
@@ -549,7 +549,7 @@ _MovePKMNWithoutMail:
 
 .Init:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call CopyBoxmonSpecies
 	ld de, PCString_ChooseaPKMN
@@ -582,11 +582,11 @@ _MovePKMNWithoutMail:
 	ret z
 	call BillsPC_UpdateSelectionCursor
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BillsPC_RefreshTextboxes
 	call PCMonInfo
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ret
@@ -621,7 +621,7 @@ _MovePKMNWithoutMail:
 
 .PrepSubmenu:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 	call BillsPC_GetSelectedPokemonSpecies
 	ld [wCurPartySpecies], a
@@ -703,7 +703,7 @@ _MovePKMNWithoutMail:
 
 .PrepInsertCursor:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call CopyBoxmonSpecies
 	ld de, PCString_MoveToWhere
 	call BillsPC_PlaceString
@@ -731,10 +731,10 @@ _MovePKMNWithoutMail:
 	ret z
 	call BillsPC_UpdateInsertCursor
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BillsPC_RefreshTextboxes
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	call DelayFrame
 	ret
@@ -2232,7 +2232,7 @@ _ChangeBox:
 	call BillsPC_ClearTilemap
 .loop
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call BillsPC_PrintBoxName
 	call BillsPC_PlaceChooseABoxString
 	ld hl, _ChangeBox_MenuHeader
@@ -2255,7 +2255,7 @@ _ChangeBox:
 
 BillsPC_ClearTilemap:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, " "
@@ -2527,5 +2527,5 @@ BillsPC_PlaceChangeBoxString:
 	hlcoord 1, 16
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -70,7 +70,7 @@ _DepositPKMN:
 	ret
 
 .HandleJoypad:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and B_BUTTON
 	jr nz, .b_button
@@ -328,7 +328,7 @@ _WithdrawPKMN:
 	ret
 
 .Joypad:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and B_BUTTON
 	jr nz, .b_button
@@ -1660,7 +1660,7 @@ BillsPC_StatsScreen:
 	ret
 
 StatsScreenDPad:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and A_BUTTON | B_BUTTON | D_RIGHT | D_LEFT
 	ld [wMenuJoypad], a

--- a/engine/pokemon/bills_pc_top.asm
+++ b/engine/pokemon/bills_pc_top.asm
@@ -21,7 +21,7 @@ _BillsPC:
 
 .LogIn:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadStandardMenuHeader
 	call ClearPCItemScreen
 	ld hl, wOptions
@@ -53,7 +53,7 @@ _BillsPC:
 	call SetPalettes
 	xor a
 	ld [wWhichIndexSet], a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DoNthMenu
 	jr c, .cancel
 	ld a, [wMenuCursorBuffer]
@@ -237,7 +237,7 @@ BillsPC_ChangeBoxMenu:
 ClearPCItemScreen:
 	call DisableSpriteUpdates
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearBGPalettes
 	call ClearSprites
 	hlcoord 0, 0

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -654,9 +654,9 @@ Hatch_UpdateFrontpicBGMapCenter:
 	pop bc
 	pop hl
 	ld a, b
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ld a, c
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	pop af
@@ -708,7 +708,7 @@ EggHatch_AnimationSequence:
 	call DelayFrames
 	xor a
 	ld [wFrameCounter], a
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 .outerloop
 	ld hl, wFrameCounter
@@ -720,14 +720,14 @@ EggHatch_AnimationSequence:
 .loop
 ; wobble e times
 	ld a, 2
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, -2
 	ld [wGlobalAnimXOffset], a
 	call EggHatch_DoAnimFrame
 	ld c, 2
 	call DelayFrames
 	ld a, -2
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, 2
 	ld [wGlobalAnimXOffset], a
 	call EggHatch_DoAnimFrame
@@ -744,7 +744,7 @@ EggHatch_AnimationSequence:
 	ld de, SFX_EGG_HATCH
 	call PlaySFX
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld [wGlobalAnimXOffset], a
 	call ClearSprites
 	call Hatch_InitShellFragments

--- a/engine/pokemon/evolve.asm
+++ b/engine/pokemon/evolve.asm
@@ -211,13 +211,13 @@ EvolveAfterBattle_MasterLoop:
 	call DelayFrames
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	lb bc, 12, 20
 	call ClearBox
 
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call ClearSprites
 
 	farcall EvolutionAnimation

--- a/engine/pokemon/experience.asm
+++ b/engine/pokemon/experience.asm
@@ -11,15 +11,15 @@ CalcLevel:
 	call CalcExpAtLevel
 	push hl
 	ld hl, wTempMonExp + 2
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld c, a
 	ld a, [hld]
 	sub c
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld c, a
 	ld a, [hld]
 	sbc c
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld c, a
 	ld a, [hl]
 	sbc c
@@ -42,121 +42,121 @@ CalcExpAtLevel:
 ; Cube the level
 	call .LevelSquared
 	ld a, d
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 
 ; Multiply by a
 	ld a, [hl]
 	and $f0
 	swap a
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 ; Divide by b
 	ld a, [hli]
 	and $f
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
 ; Push the cubic term to the stack
-	ld a, [hQuotient + 0]
+	ldh a, [hQuotient + 0]
 	push af
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	push af
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	push af
 ; Square the level and multiply by the lower 7 bits of c
 	call .LevelSquared
 	ld a, [hl]
 	and $7f
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 ; Push the absolute value of the quadratic term to the stack
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	push af
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	push af
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	push af
 	ld a, [hli]
 	push af
 ; Multiply the level by d
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, d
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, [hli]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 ; Subtract e
 	ld b, [hl]
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	sub b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld b, $0
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	sbc b
-	ld [hMultiplicand + 1], a
-	ld a, [hProduct + 1]
+	ldh [hMultiplicand + 1], a
+	ldh a, [hProduct + 1]
 	sbc b
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 ; If bit 7 of c is set, c is negative; otherwise, it's positive
 	pop af
 	and $80
 	jr nz, .subtract
 ; Add c*n**2 to (d*n - e)
 	pop bc
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	add b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	pop bc
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	adc b
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	pop bc
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	adc b
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 	jr .done_quadratic
 
 .subtract
 ; Subtract c*n**2 from (d*n - e)
 	pop bc
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	sub b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	pop bc
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	sbc b
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	pop bc
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	sbc b
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 
 .done_quadratic
 ; Add (a/b)*n**3 to (d*n - e +/- c*n**2)
 	pop bc
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	add b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	pop bc
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	adc b
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	pop bc
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	adc b
-	ld [hMultiplicand], a
+	ldh [hMultiplicand], a
 	ret
 
 .LevelSquared:
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, d
-	ld [hMultiplicand + 2], a
-	ld [hMultiplier], a
+	ldh [hMultiplicand + 2], a
+	ldh [hMultiplier], a
 	jp Multiply
 
 INCLUDE "data/growth_rates.asm"

--- a/engine/pokemon/health.asm
+++ b/engine/pokemon/health.asm
@@ -59,13 +59,13 @@ ComputeHPBarPixels:
 	jr z, .zero
 	push hl
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld a, b
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, c
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, 6 * 8
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
 	; We need de to be under 256 because hDivisor is only 1 byte.
 	ld a, d
@@ -76,22 +76,22 @@ ComputeHPBarPixels:
 	rr e
 	srl d
 	rr e
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld b, a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	srl b
 	rr a
 	srl b
 	rr a
-	ld [hDividend + 3], a
+	ldh [hDividend + 3], a
 	ld a, b
-	ld [hDividend + 2], a
+	ldh [hDividend + 2], a
 .divide
 	ld a, e
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld e, a
 	pop hl
 	and a

--- a/engine/pokemon/mail.asm
+++ b/engine/pokemon/mail.asm
@@ -375,7 +375,7 @@ MailboxPC:
 	ld hl, .TopMenuHeader
 	call CopyMenuHeader
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call InitScrollingMenu
 	call UpdateSprites
 

--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -40,7 +40,7 @@ ReadAnyMail:
 	farcall LoadMailPalettes
 	call SetPalettes
 	xor a
-	ld [hJoyPressed], a
+	ldh [hJoyPressed], a
 	call .loop
 	call ClearBGPalettes
 	call DisableLCD
@@ -49,7 +49,7 @@ ReadAnyMail:
 
 .loop
 	call GetJoypad
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON | START
 	jr z, .loop
 	and START

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -757,19 +757,19 @@ MonMenu_Softboiled_MilkDrink:
 	ld a, MON_MAXHP
 	call GetPartyParamLocation
 	ld a, [hli]
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, [hl]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, 5
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
 	ld a, MON_HP + 1
 	call GetPartyParamLocation
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	sub [hl]
 	dec hl
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	sbc [hl]
 	ret
 
@@ -1103,7 +1103,7 @@ SetUpMoveScreenBG:
 	call ClearTileMap
 	call ClearSprites
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall LoadStatsScreenPageTilesGFX
 	farcall ClearSpriteAnims2
 	ld a, [wCurPartyMon]
@@ -1147,7 +1147,7 @@ SetUpMoveScreenBG:
 
 SetUpMoveList:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld [wMoveSwapBuffer], a
 	ld [wMonType], a
 	predef CopyMonToTempMon
@@ -1189,7 +1189,7 @@ PrepareToPlaceMoveData:
 
 PlaceMoveData:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 10
 	ld de, String_MoveType_Top
 	call PlaceString
@@ -1227,7 +1227,7 @@ PlaceMoveData:
 	hlcoord 1, 14
 	predef PrintMoveDesc
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 String_MoveType_Top:

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -2,7 +2,7 @@ INCLUDE "data/mon_menu.asm"
 
 MonSubmenu:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call GetMonSubmenuItems
 	farcall FreezeMonIcons
 	ld hl, .MenuHeader
@@ -11,7 +11,7 @@ MonSubmenu:
 	call PopulateMonMenu
 
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MonMenuLoop
 	ld [wMenuSelection], a
 
@@ -49,7 +49,7 @@ MonMenuLoop:
 	call StaticMenuJoypad
 	ld de, SFX_READ_TEXT_2
 	call PlaySFX
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit A_BUTTON_F, a
 	jr nz, .select
 	bit B_BUTTON_F, a
@@ -248,7 +248,7 @@ BattleMonMenu:
 	ld hl, MenuHeader_0x24ed4
 	call CopyMenuHeader
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call UpdateSprites
 	call PlaceVerticalMenuItems
@@ -263,7 +263,7 @@ BattleMonMenu:
 	call StaticMenuJoypad
 	ld de, SFX_READ_TEXT_2
 	call PlaySFX
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit B_BUTTON_F, a
 	jr z, .clear_carry
 	ret z

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -16,7 +16,7 @@ TryAddMonToParty:
 	; Increase the party count
 	ld [de], a
 	ld a, [de] ; Why are we doing this?
-	ld [hMoveMon], a ; HRAM backup
+	ldh [hMoveMon], a ; HRAM backup
 	add e
 	ld e, a
 	jr nc, .loadspecies
@@ -39,7 +39,7 @@ TryAddMonToParty:
 	ld hl, wOTPartyMonOT
 
 .loadOTname
-	ld a, [hMoveMon] ; Restore index from backup
+	ldh a, [hMoveMon] ; Restore index from backup
 	dec a
 	call SkipNames
 	ld d, h
@@ -55,7 +55,7 @@ TryAddMonToParty:
 	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	ld hl, wPartyMonNicknames
-	ld a, [hMoveMon]
+	ldh a, [hMoveMon]
 	dec a
 	call SkipNames
 	ld d, h
@@ -72,7 +72,7 @@ TryAddMonToParty:
 	ld hl, wOTPartyMon1Species
 
 .initializeStats
-	ld a, [hMoveMon]
+	ldh a, [hMoveMon]
 	dec a
 	ld bc, PARTYMON_STRUCT_LENGTH
 	call AddNTimes
@@ -153,13 +153,13 @@ endr
 	ld d, a
 	callfar CalcExpAtLevel
 	pop de
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld [de], a
 	inc de
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [de], a
 	inc de
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [de], a
 	inc de
 
@@ -260,10 +260,10 @@ endr
 	ld c, a
 	ld b, FALSE
 	call CalcMonStatC
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [de], a
 	inc de
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [de], a
 	inc de
 	jr .initstats
@@ -887,11 +887,11 @@ RetrieveBreedmon:
 	pop bc
 	ld hl, $8
 	add hl, bc
-	ld a, [hMultiplicand]
+	ldh a, [hMultiplicand]
 	ld [hli], a
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	ld [hli], a
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	ld [hl], a
 	and a
 	ret
@@ -995,13 +995,13 @@ SendMonIntoBox:
 	ld d, a
 	callfar CalcExpAtLevel
 	pop de
-	ld a, [hProduct + 1]
+	ldh a, [hProduct + 1]
 	ld [de], a
 	inc de
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld [de], a
 	inc de
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld [de], a
 	inc de
 
@@ -1407,10 +1407,10 @@ CalcMonStats:
 .loop
 	inc c
 	call CalcMonStatC
-	ld a, [hMultiplicand + 1]
+	ldh a, [hMultiplicand + 1]
 	ld [de], a
 	inc de
-	ld a, [hMultiplicand + 2]
+	ldh a, [hMultiplicand + 2]
 	ld [de], a
 	inc de
 	ld a, c
@@ -1545,22 +1545,22 @@ CalcMonStatC:
 	inc d
 
 .no_overflow_2
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, d
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	xor a
-	ld [hMultiplicand + 0], a
+	ldh [hMultiplicand + 0], a
 	ld a, [wCurPartyLevel]
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
-	ld a, [hProduct + 1]
-	ld [hDividend + 0], a
-	ld a, [hProduct + 2]
-	ld [hDividend + 1], a
-	ld a, [hProduct + 3]
-	ld [hDividend + 2], a
+	ldh a, [hProduct + 1]
+	ldh [hDividend + 0], a
+	ldh a, [hProduct + 2]
+	ldh [hDividend + 1], a
+	ldh a, [hProduct + 3]
+	ldh [hDividend + 2], a
 	ld a, 100
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld a, 3
 	ld b, a
 	call Divide
@@ -1570,42 +1570,42 @@ CalcMonStatC:
 	jr nz, .not_hp
 	ld a, [wCurPartyLevel]
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	jr nc, .no_overflow_3
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	inc a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 
 .no_overflow_3
 	ld a, STAT_MIN_HP
 
 .not_hp
 	ld b, a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	add b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	jr nc, .no_overflow_4
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	inc a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 
 .no_overflow_4
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	cp HIGH(MAX_STAT_VALUE + 1) + 1
 	jr nc, .max_stat
 	cp HIGH(MAX_STAT_VALUE + 1)
 	jr c, .stat_value_okay
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	cp LOW(MAX_STAT_VALUE + 1)
 	jr c, .stat_value_okay
 
 .max_stat
 	ld a, HIGH(MAX_STAT_VALUE)
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 1], a
 	ld a, LOW(MAX_STAT_VALUE)
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 
 .stat_value_okay
 	pop bc

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -46,7 +46,7 @@ WritePartyMenuTilemap:
 	push af
 	set NO_TEXT_SCROLL, [hl]
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 	ld a, " "
@@ -590,7 +590,7 @@ InitPartyMenuGFX:
 	ret z
 	ld c, a
 	xor a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 .loop
 	push bc
 	push hl
@@ -598,9 +598,9 @@ InitPartyMenuGFX:
 	ld a, BANK(LoadMenuMonIcon)
 	ld e, MONICON_PARTYMENU
 	rst FarCall
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	inc a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	pop hl
 	pop bc
 	dec c
@@ -682,7 +682,7 @@ PartyMenuSelect:
 	cp b
 	jr z, .exitmenu ; CANCEL
 	ld [wPartyMenuCursor], a
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	ld b, a
 	bit B_BUTTON_F, b
 	jr nz, .exitmenu ; B button

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -23,10 +23,10 @@ _MobileStatsScreenInit:
 	jr StatsScreenInit_gotaddress
 
 StatsScreenInit_gotaddress:
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a ; disable overworld tile animations
+	ldh [hMapAnims], a ; disable overworld tile animations
 	ld a, [wBoxAlignment] ; whether sprite is to be mirrorred
 	push af
 	ld a, [wJumptableIndex]
@@ -54,7 +54,7 @@ StatsScreenInit_gotaddress:
 	pop af
 	ld [wBoxAlignment], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 StatsScreenMain:
@@ -264,7 +264,7 @@ StatsScreen_GetJoypad:
 	jr .clear_flags
 
 .notbreedmon
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 .clear_flags
 	and a
 	ret
@@ -375,7 +375,7 @@ StatsScreen_JoypadAction:
 StatsScreen_InitUpperHalf:
 	call .PlaceHPBar
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, [wBaseDexNo]
 	ld [wDeciramBuffer], a
 	ld [wCurSpecies], a
@@ -486,7 +486,7 @@ StatsScreen_LoadGFX:
 	ld [wTempSpecies], a
 	ld [wCurSpecies], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call .ClearBox
 	call .PageTilemap
 	call .LoadPals
@@ -636,15 +636,15 @@ StatsScreen_LoadGFX:
 	farcall CalcExpAtLevel
 	ld hl, wTempMonExp + 2
 	ld hl, wTempMonExp + 2
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	sub [hl]
 	dec hl
 	ld [wBuffer3], a
-	ld a, [hQuotient + 1]
+	ldh a, [hQuotient + 1]
 	sbc [hl]
 	dec hl
 	ld [wBuffer2], a
-	ld a, [hQuotient]
+	ldh a, [hQuotient]
 	sbc [hl]
 	ld [wBuffer1], a
 	ret
@@ -926,16 +926,16 @@ StatsScreen_LoadTextBoxSpaceGFX:
 	push bc
 	push af
 	call DelayFrame
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld de, TextBoxSpaceGFX
 	lb bc, BANK(TextBoxSpaceGFX), 1
 	ld hl, vTiles2 tile " "
 	call Get2bpp
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	pop af
 	pop bc
 	pop de
@@ -948,7 +948,7 @@ Unreferenced_4e32a:
 
 EggStatsScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wCurHPPal
 	call SetHPPal
 	ld b, SCGB_STATS_SCREEN_HP_PALS

--- a/engine/printer/print_party.asm
+++ b/engine/printer/print_party.asm
@@ -135,7 +135,7 @@ PrintPartyMonPage1:
 	call ClearTileMap
 	call ClearSprites
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadFontsBattleExtra
 
 	ld de, GBPrinterHPIcon
@@ -234,7 +234,7 @@ PrintPartyMonPage2:
 	call ClearTileMap
 	call ClearSprites
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadFontsBattleExtra
 	xor a
 	ld [wMonType], a

--- a/engine/printer/printer.asm
+++ b/engine/printer/printer.asm
@@ -49,15 +49,15 @@ PrintDexEntry:
 	call Request1bpp
 
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	call Printer_PlayMusic
 
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $9
-	ld [rIE], a
+	ldh [rIE], a
 
 	call Printer_StartTransmission
 	ld a, $10
@@ -83,7 +83,7 @@ PrintDexEntry:
 	ld c, 12
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	call Printer_StartTransmission
 	ld a, $3
@@ -96,13 +96,13 @@ PrintDexEntry:
 
 .skip_second_page
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 
 	call Printer_ExitPrinter
 	ld c, 8
@@ -132,16 +132,16 @@ PrintPCBox:
 	ld [wWhichBoxToPrint], a
 
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	ld [wFinishedPrintingBox], a
 	call Printer_PlayMusic
 
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %1001
-	ld [rIE], a
+	ldh [rIE], a
 
 	ld hl, hVBlank
 	ld a, [hl]
@@ -149,7 +149,7 @@ PrintPCBox:
 	ld [hl], %0100
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PrintPCBox_Page1
 	ld a, $10 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -160,7 +160,7 @@ PrintPCBox:
 	ld c, 12
 	call DelayFrames
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PrintPCBox_Page2
 	ld a, $0 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -172,7 +172,7 @@ PrintPCBox:
 	call DelayFrames
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PrintPCBox_Page3
 	ld a, $0 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -184,20 +184,20 @@ PrintPCBox:
 	call DelayFrames
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call PrintPCBox_Page4
 	ld a, $3 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
 	call Printer_ResetRegistersAndStartDataSend
 .cancel
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	call Printer_ExitPrinter
 
 	pop af
@@ -213,20 +213,20 @@ PrintUnownStamp:
 	ld a, [wPrinterQueueLength]
 	push af
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	call Printer_PlayMusic
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, $9
-	ld [rIE], a
+	ldh [rIE], a
 	ld hl, hVBlank
 	ld a, [hl]
 	push af
 	ld [hl], $4
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadTileMapToTempTileMap
 	farcall PlaceUnownPrinterFrontpic
 	ld a, $0 ; to be loaded to wcbfa
@@ -257,13 +257,13 @@ PrintUnownStamp:
 
 .done
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 	call Call_LoadTempTileMapToTileMap
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	pop af
 	ld [wPrinterQueueLength], a
 	ret
@@ -277,18 +277,18 @@ PrintMail:
 	ld a, [wPrinterQueueLength]
 	push af
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	call Printer_PlayMusic
 
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %1001
-	ld [rIE], a
+	ldh [rIE], a
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	ld a, $13 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -302,14 +302,14 @@ PrintMail:
 	call SendScreenToPrinter
 
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 	call Printer_CopyBufferToTileMap
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 
 	pop af
 	ld [wPrinterQueueLength], a
@@ -319,18 +319,18 @@ PrintPartymon:
 	ld a, [wPrinterQueueLength]
 	push af
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	call Printer_PlayMusic
 
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %1001
-	ld [rIE], a
+	ldh [rIE], a
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall PrintPartyMonPage1
 	ld a, $10 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -351,7 +351,7 @@ PrintPartymon:
 	call DelayFrames
 
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall PrintPartyMonPage2
 	ld a, $3 ; to be loaded to wcbfa
 	call Printer_PrepareTileMapForPrint
@@ -362,14 +362,14 @@ PrintPartymon:
 	call SendScreenToPrinter
 .cancel
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 
 	call Printer_CopyBufferToTileMap
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	call Printer_ExitPrinter
 
 	pop af
@@ -383,15 +383,15 @@ _PrintDiploma:
 	farcall PlaceDiplomaOnScreen
 
 	xor a
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	call Printer_PlayMusic
 
-	ld a, [rIE]
+	ldh a, [rIE]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %1001
-	ld [rIE], a
+	ldh [rIE], a
 
 	ld hl, hVBlank
 	ld a, [hl]
@@ -412,7 +412,7 @@ _PrintDiploma:
 
 	call LoadTileMapToTempTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
 	farcall PrintDiplomaPage2
 
@@ -426,13 +426,13 @@ _PrintDiploma:
 	call SendScreenToPrinter
 .cancel
 	pop af
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Printer_CleanUpAfterSend
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	pop af
-	ld [rIE], a
+	ldh [rIE], a
 	call Printer_ExitPrinter
 
 	pop af
@@ -440,7 +440,7 @@ _PrintDiploma:
 	ret
 
 CheckCancelPrint:
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and B_BUTTON
 	jr nz, .pressed_b
 	and a
@@ -457,11 +457,11 @@ CheckCancelPrint:
 	ld a, $16 ; cancel
 	ld [wPrinterOpcode], a
 	ld a, $88
-	ld [rSB], a
+	ldh [rSB], a
 	ld a, $1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, $81
-	ld [rSC], a
+	ldh [rSC], a
 .loop2
 	ld a, [wPrinterOpcode]
 	and a
@@ -469,7 +469,7 @@ CheckCancelPrint:
 
 .cancel
 	ld a, $1
-	ld [hPrinter], a
+	ldh [hPrinter], a
 	scf
 	ret
 
@@ -489,10 +489,10 @@ Printer_CopyBufferToTileMap:
 
 Printer_ResetJoypadRegisters:
 	xor a
-	ld [hJoyReleased], a
-	ld [hJoyPressed], a
-	ld [hJoyDown], a
-	ld [hJoyLast], a
+	ldh [hJoyReleased], a
+	ldh [hJoyPressed], a
+	ldh [hJoyDown], a
+	ldh [hJoyLast], a
 	ret
 
 Printer_PlayMusic:
@@ -551,7 +551,7 @@ PlacePrinterStatusString:
 	ret z
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 5
 	lb bc, 10, 18
 	call TextBox
@@ -571,7 +571,7 @@ PlacePrinterStatusString:
 	ld de, String_PressBToCancel
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	xor a
 	ld [wPrinterStatus], a
 	ret
@@ -582,7 +582,7 @@ Unreferenced_Function847bd:
 	ret z
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 2, 4
 	lb bc, 13, 16
 	call ClearBox
@@ -602,7 +602,7 @@ Unreferenced_Function847bd:
 	ld de, String_PressBToCancel
 	call PlaceString
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	xor a
 	ld [wPrinterStatus], a
 	ret

--- a/engine/printer/printer_serial.asm
+++ b/engine/printer/printer_serial.asm
@@ -4,8 +4,8 @@ Printer_StartTransmission:
 	xor a
 	call Printer_ByteFill
 	xor a
-	ld [rSB], a
-	ld [rSC], a
+	ldh [rSB], a
+	ldh [rSC], a
 	ld [wPrinterOpcode], a
 	ld hl, wPrinterConnectionOpen
 	set 0, [hl]
@@ -278,11 +278,11 @@ Printer_WaitHandshake:
 	ld a, $1
 	ld [wPrinterOpcode], a
 	ld a, $88
-	ld [rSB], a
+	ldh [rSB], a
 	ld a, $1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, $81
-	ld [rSC], a
+	ldh [rSC], a
 	ret
 
 Printer_CopyPacket:
@@ -588,7 +588,7 @@ Printer_Send0x00_2:
 	ret
 
 Printer_ReceiveTwoPrinterHandshakeAndSend0x00:
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld [wPrinterHandshake], a
 	ld a, $0
 	call Printer_SerialSend
@@ -596,7 +596,7 @@ Printer_ReceiveTwoPrinterHandshakeAndSend0x00:
 	ret
 
 Printer_ReceiveTwoPrinterStatusFlagsAndExitSendLoop:
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld [wPrinterStatusFlags], a
 	xor a
 	ld [wPrinterOpcode], a
@@ -621,16 +621,16 @@ Printer_Send0x08:
 	ret
 
 Printer_SerialSend:
-	ld [rSB], a
+	ldh [rSB], a
 	ld a, $1 ; switch to internal clock
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, $81 ; start transfer
-	ld [rSC], a
+	ldh [rSC], a
 	ret
 
 Printer_ReceiveTwoPrinterStatusFlagsAndExitSendLoop_2:
 ; identical to Printer_ReceiveTwoPrinterStatusFlagsAndExitSendLoop, but referenced less
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld [wPrinterStatusFlags], a
 	xor a
 	ld [wPrinterOpcode], a

--- a/engine/rtc/reset_password.asm
+++ b/engine/rtc/reset_password.asm
@@ -73,7 +73,7 @@ ClockResetPassword:
 	call .updateIDdisplay
 .loop2
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	ld b, a
 	and A_BUTTON
 	jr nz, .confirm

--- a/engine/rtc/restart_clock.asm
+++ b/engine/rtc/restart_clock.asm
@@ -66,9 +66,9 @@ RestartClock:
 	call UpdateTime
 	call GetWeekday
 	ld [wBuffer4], a
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [wBuffer5], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [wBuffer6], a
 
 .loop

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -24,7 +24,7 @@ StartRTC:
 
 GetTimeOfDay::
 ; get time of day based on the current hour
-	ld a, [hHours] ; hour
+	ldh a, [hHours] ; hour
 	ld hl, TimesOfDay
 
 .check
@@ -65,11 +65,11 @@ StageRTCTimeForSave:
 	ld hl, wRTC
 	ld a, [wCurDay]
 	ld [hli], a
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [hli], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [hli], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [hli], a
 	ret
 

--- a/engine/rtc/timeset.asm
+++ b/engine/rtc/timeset.asm
@@ -3,10 +3,10 @@ TIMESET_DOWN_ARROW EQUS "\"♀\"" ; $f5
 
 InitClock:
 ; Ask the player to set the time.
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 
 	ld a, $0
 	ld [wSpriteUpdatesEnabled], a
@@ -24,7 +24,7 @@ InitClock:
 	ld b, SCGB_DIPLOMA
 	call GetSGBLayout
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadStandardFont
 	ld de, TimeSetBackgroundGFX
 	ld hl, vTiles2 tile $00
@@ -117,22 +117,22 @@ InitClock:
 	call PrintText
 	call WaitPressAorB_BlinkCursor
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 .ClearScreen:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 0, 0
 	ld bc, SCREEN_HEIGHT * SCREEN_WIDTH
 	xor a
 	call ByteFill
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 SetHour:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jr nz, .Confirm
 
@@ -223,7 +223,7 @@ UnreferencedFunction907f1:
 	ret
 
 SetMinutes:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jr nz, .a_button
 	ld hl, hJoyLast
@@ -391,10 +391,10 @@ TimeSetDownArrowGFX:
 INCBIN "gfx/new_game/down_arrow.1bpp"
 
 SetDayOfWeek:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ld de, TimeSetUpArrowGFX
 	ld hl, vTiles0 tile TIMESET_UP_ARROW
 	lb bc, BANK(TimeSetUpArrowGFX), 1
@@ -440,11 +440,11 @@ SetDayOfWeek:
 	call InitDayOfWeek
 	call LoadStandardFont
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 .GetJoypadAction:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jr z, .not_A
 	scf
@@ -487,7 +487,7 @@ SetDayOfWeek:
 
 .finish_dpad
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	hlcoord 10, 4
 	ld b, 2
 	ld c, 9
@@ -563,9 +563,9 @@ InitialSetDSTFlag:
 .Text:
 	start_asm
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld b, a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld c, a
 	decoord 1, 14
 	farcall PrintHoursMins
@@ -591,9 +591,9 @@ InitialClearDSTFlag:
 .Text:
 	start_asm
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld b, a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld c, a
 	decoord 1, 14
 	farcall PrintHoursMins

--- a/engine/tilesets/tileset_anims.asm
+++ b/engine/tilesets/tileset_anims.asm
@@ -9,10 +9,10 @@ _AnimateTileset::
 	ld a, [wTilesetAnim + 1]
 	ld d, a
 
-	ld a, [hTileAnimFrame]
+	ldh a, [hTileAnimFrame]
 	ld l, a
 	inc a
-	ld [hTileAnimFrame], a
+	ldh [hTileAnimFrame], a
 
 	ld h, 0
 	add hl, hl
@@ -277,7 +277,7 @@ TilesetAerodactylWordRoomAnim:
 DoneTileAnimation:
 ; Reset the animation command loop.
 	xor a
-	ld [hTileAnimFrame], a
+	ldh [hTileAnimFrame], a
 
 WaitTileAnimation:
 ; Do nothing this frame.
@@ -636,7 +636,7 @@ AnimateFlowerTile:
 	ld e, a
 
 ; CGB has different color mappings for flowers.
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and 1
 
 	add e
@@ -856,12 +856,12 @@ AnimateWaterPalette:
 ; Transition between color values 0-2 for color 0 in palette 3.
 
 ; No palette changes on DMG.
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
 ; We don't want to mess with non-standard palettes.
-	ld a, [rBGP] ; BGP
+	ldh a, [rBGP] ; BGP
 	cp %11100100
 	ret nz
 
@@ -874,12 +874,12 @@ AnimateWaterPalette:
 ; Ready for BGPD input...
 
 	ld a, (1 << rBGPI_AUTO_INCREMENT) palette PAL_BG_WATER
-	ld [rBGPI], a
+	ldh [rBGPI], a
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Update color 0 in order 0 1 2 1
 	ld a, l
@@ -891,38 +891,38 @@ AnimateWaterPalette:
 .color1
 	ld hl, wBGPals1 palette PAL_BG_WATER color 1
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	jr .end
 
 .color0
 	ld hl, wBGPals1 palette PAL_BG_WATER color 0
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	jr .end
 
 .color2
 	ld hl, wBGPals1 palette PAL_BG_WATER color 2
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 
 .end
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 FlickeringCaveEntrancePalette:
 ; No palette changes on DMG.
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 ; We don't want to mess with non-standard palettes.
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	cp %11100100
 	ret nz
 ; We only want to be here if we're in a dark cave.
@@ -930,14 +930,14 @@ FlickeringCaveEntrancePalette:
 	cp %11111111 ; 3,3,3,3
 	ret nz
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 ; Ready for BGPD input...
 	ld a, (1 << rBGPI_AUTO_INCREMENT) palette PAL_BG_YELLOW
-	ld [rBGPI], a
-	ld a, [hVBlankCounter]
+	ldh [rBGPI], a
+	ldh a, [hVBlankCounter]
 	and %10
 	jr nz, .bit1set
 	ld hl, wBGPals1 palette PAL_BG_YELLOW
@@ -948,12 +948,12 @@ FlickeringCaveEntrancePalette:
 
 .okay
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 	ld a, [hli]
-	ld [rBGPD], a
+	ldh [rBGPD], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 TowerPillarTilePointer1:  dw vTiles2 tile $2d, TowerPillarTile1

--- a/engine/tilesets/timeofday_pals.asm
+++ b/engine/tilesets/timeofday_pals.asm
@@ -43,11 +43,11 @@ _TimeOfDayPals::
 	ld hl, wBGPals1 palette PAL_BG_TEXT
 
 ; save wram bank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	ld b, a
 
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; push palette
 	ld c, NUM_PAL_COLORS
@@ -62,7 +62,7 @@ _TimeOfDayPals::
 
 ; restore wram bank
 	ld a, b
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; update sgb pals
 	ld b, SCGB_MAPPALS
@@ -72,11 +72,11 @@ _TimeOfDayPals::
 	ld hl, wOBPals1 - 1 ; last byte in wBGPals1
 
 ; save wram bank
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	ld d, a
 
 	ld a, BANK(wOBPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; pop palette
 	ld e, NUM_PAL_COLORS
@@ -91,7 +91,7 @@ _TimeOfDayPals::
 
 ; restore wram bank
 	ld a, d
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; update palettes
 	call _UpdateTimePals
@@ -158,10 +158,10 @@ FadeBlackQuickly:
 	ret
 
 FillWhiteBGColor:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBGPals1
 	ld a, [hli]
@@ -182,7 +182,7 @@ endr
 	jr nz, .loop
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 ReplaceTimeOfDayPals:
@@ -306,7 +306,7 @@ ConvertTimePalsDecHL:
 
 GetTimePalFade:
 ; check cgb
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 

--- a/home.asm
+++ b/home.asm
@@ -61,7 +61,7 @@ Unreferenced_Function2ebb::
 	bit 1, a
 	ret z
 
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	bit B_BUTTON_F, a
 	ret
 
@@ -146,7 +146,7 @@ INCLUDE "home/math.asm"
 INCLUDE "home/print_text.asm"
 
 CallPointerAt::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [hli]
 	rst Bankswitch

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -6,16 +6,16 @@ MapSetup_Sound_Off::
 	push bc
 	push af
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_MapSetup_Sound_Off)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	call _MapSetup_Sound_Off
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	pop af
@@ -30,16 +30,16 @@ UpdateSound::
 	push bc
 	push af
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_UpdateSound)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	call _UpdateSound
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	pop af
@@ -50,14 +50,14 @@ UpdateSound::
 
 _LoadMusicByte::
 ; wCurMusicByte = [a:de]
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	ld a, [de]
 	ld [wCurMusicByte], a
 	ld a, BANK(LoadMusicByte)
 
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	ret
 
@@ -69,10 +69,10 @@ PlayMusic::
 	push bc
 	push af
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_PlayMusic) ; and BANK(_MapSetup_Sound_Off)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	ld a, e
@@ -87,7 +87,7 @@ PlayMusic::
 
 .end
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	pop af
 	pop bc
@@ -103,10 +103,10 @@ PlayMusic2::
 	push bc
 	push af
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_PlayMusic)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	push de
@@ -117,7 +117,7 @@ PlayMusic2::
 	call _PlayMusic
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	pop af
@@ -134,12 +134,12 @@ PlayCry::
 	push bc
 	push af
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	; Cries are stuck in one bank.
 	ld a, BANK(PokemonCries)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	ld hl, PokemonCries
@@ -162,13 +162,13 @@ endr
 	ld [wCryLength + 1], a
 
 	ld a, BANK(_PlayCry)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	call _PlayCry
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	pop af
@@ -196,10 +196,10 @@ PlaySFX::
 	jr c, .done
 
 .play
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_PlaySFX)
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	ld a, e
@@ -207,7 +207,7 @@ PlaySFX::
 	call _PlaySFX
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 .done
@@ -525,11 +525,11 @@ TerminateExpBarSound::
 	xor a
 	ld [wChannel5Flags1], a
 	ld [wSoundInput], a
-	ld [rNR10], a
-	ld [rNR11], a
-	ld [rNR12], a
-	ld [rNR13], a
-	ld [rNR14], a
+	ldh [rNR10], a
+	ldh [rNR11], a
+	ldh [rNR12], a
+	ldh [rNR13], a
+	ldh [rNR14], a
 	ret
 
 ChannelsOff::

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -1,6 +1,6 @@
 UserPartyAttr::
 	push af
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr nz, .ot
 	pop af
@@ -11,7 +11,7 @@ UserPartyAttr::
 
 OpponentPartyAttr::
 	push af
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .ot
 	pop af
@@ -52,22 +52,22 @@ ResetDamage::
 
 SetPlayerTurn::
 	xor a
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 SetEnemyTurn::
 	ld a, 1
-	ld [hBattleTurn], a
+	ldh [hBattleTurn], a
 	ret
 
 UpdateOpponentInParty::
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, UpdateEnemyMonInParty
 	jr UpdateBattleMonInParty
 
 UpdateUserInParty::
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, UpdateBattleMonInParty
 	jr UpdateEnemyMonInParty
@@ -120,14 +120,14 @@ INCLUDE "home/battle_vars.asm"
 
 FarCopyRadioText::
 	inc hl
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
 	ld d, a
 	ld a, [hli]
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	ld a, e
 	ld l, a
@@ -137,7 +137,7 @@ FarCopyRadioText::
 	ld bc, 2 * SCREEN_WIDTH
 	call CopyBytes
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	ret
 
@@ -169,7 +169,7 @@ BattleTextBox::
 StdBattleTextBox::
 ; Open a textbox and print battle text at 20:hl.
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, BANK(BattleText)

--- a/home/battle_vars.asm
+++ b/home/battle_vars.asm
@@ -23,7 +23,7 @@ GetBattleVarAddr::
 
 ; Enemy turn uses the second byte instead.
 ; This lets battle variable calls be side-neutral.
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	jr z, .getvar
 	inc hl

--- a/home/copy.asm
+++ b/home/copy.asm
@@ -1,7 +1,7 @@
 ; Functions to copy data from ROM.
 
 Get2bpp_2::
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jp z, Copy2bpp
 
@@ -10,7 +10,7 @@ Get2bpp_2::
 	ret
 
 Get1bpp_2::
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jp z, Copy1bpp
 
@@ -19,10 +19,10 @@ Get1bpp_2::
 	ret
 
 FarCopyBytesDouble_DoubleBankSwitch::
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	call FarCopyBytesDouble
@@ -33,11 +33,11 @@ FarCopyBytesDouble_DoubleBankSwitch::
 
 OldDMATransfer::
 	dec c
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
-	ld a, [hROMBank]
+	ldh [hBGMapMode], a
+	ldh a, [hROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
@@ -45,16 +45,16 @@ OldDMATransfer::
 .loop
 ; load the source and target MSB and LSB
 	ld a, d
-	ld [rHDMA1], a ; source MSB
+	ldh [rHDMA1], a ; source MSB
 	ld a, e
 	and $f0
-	ld [rHDMA2], a ; source LSB
+	ldh [rHDMA2], a ; source LSB
 	ld a, h
 	and $1f
-	ld [rHDMA3], a ; target MSB
+	ldh [rHDMA3], a ; target MSB
 	ld a, l
 	and $f0
-	ld [rHDMA4], a ; target LSB
+	ldh [rHDMA4], a ; target LSB
 ; stop when c < 8
 	ld a, c
 	cp $8
@@ -64,7 +64,7 @@ OldDMATransfer::
 	ld c, a
 ; DMA transfer state
 	ld a, $f
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 	call DelayFrame
 ; add $100 to hl and de
 	ld a, l
@@ -84,13 +84,13 @@ OldDMATransfer::
 .done
 	ld a, c
 	and $7f ; pretty silly, considering at most bits 0-2 would be set
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 	call DelayFrame
 	pop af
 	rst Bankswitch
 
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 ReplaceKrisSprite::
@@ -135,10 +135,10 @@ DecompressRequest2bpp::
 FarCopyBytes::
 ; copy bc bytes from a:hl to de
 
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	call CopyBytes
@@ -151,10 +151,10 @@ FarCopyBytesDouble::
 ; Copy bc bytes from a:hl to bc*2 bytes at de,
 ; doubling each byte in the process.
 
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 ; switcheroo, de <> hl
@@ -186,29 +186,29 @@ FarCopyBytesDouble::
 
 Request2bpp::
 ; Load 2bpp at b:de to occupy c tiles of hl.
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
 
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	push af
 	ld a, $8
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 
 	ld a, [wLinkMode]
 	cp LINK_MOBILE
 	jr nz, .NotMobile
-	ld a, [hMobile]
+	ldh a, [hMobile]
 	and a
 	jr nz, .NotMobile
 	ld a, $6
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 
 .NotMobile:
 	ld a, e
@@ -233,17 +233,17 @@ Request2bpp::
 	jr nz, .wait
 
 	pop af
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 
 	pop af
 	rst Bankswitch
 
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .iterate
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	ld [wRequested2bpp], a
 
 .wait2
@@ -260,29 +260,29 @@ Request2bpp::
 
 Request1bpp::
 ; Load 1bpp at b:de to occupy c tiles of hl.
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
 
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	push af
 
 	ld a, $8
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	ld a, [wLinkMode]
 	cp LINK_MOBILE
 	jr nz, .NotMobile
-	ld a, [hMobile]
+	ldh a, [hMobile]
 	and a
 	jr nz, .NotMobile
 	ld a, $6
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 
 .NotMobile:
 	ld a, e
@@ -307,17 +307,17 @@ Request1bpp::
 	jr nz, .wait
 
 	pop af
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 
 	pop af
 	rst Bankswitch
 
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .iterate
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	ld [wRequested1bpp], a
 
 .wait2
@@ -333,7 +333,7 @@ Request1bpp::
 	jr .loop
 
 Get2bpp::
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jp nz, Request2bpp
 
@@ -362,7 +362,7 @@ Copy2bpp::
 	jp FarCopyBytes
 
 Get1bpp::
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	jp nz, Request1bpp
 

--- a/home/copy2.asm
+++ b/home/copy2.asm
@@ -54,31 +54,31 @@ ByteFill::
 GetFarByte::
 ; retrieve a single byte from a:hl, and return it in a.
 	; bankswitch to new bank
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	; get byte from new bank
 	ld a, [hl]
-	ld [hBuffer], a
+	ldh [hBuffer], a
 
 	; bankswitch to previous bank
 	pop af
 	rst Bankswitch
 
 	; return retrieved value in a
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	ret
 
 GetFarHalfword::
 ; retrieve a halfword from a:hl, and return it in hl.
 	; bankswitch to new bank
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	; get halfword from new bank, put it in hl
@@ -92,40 +92,40 @@ GetFarHalfword::
 	ret
 
 FarCopyWRAM::
-	ld [hBuffer], a
-	ld a, [rSVBK]
+	ldh [hBuffer], a
+	ldh a, [rSVBK]
 	push af
-	ld a, [hBuffer]
-	ld [rSVBK], a
+	ldh a, [hBuffer]
+	ldh [rSVBK], a
 
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 GetFarWRAMByte::
-	ld [hBuffer], a
-	ld a, [rSVBK]
+	ldh [hBuffer], a
+	ldh a, [rSVBK]
 	push af
-	ld a, [hBuffer]
-	ld [rSVBK], a
+	ldh a, [hBuffer]
+	ldh [rSVBK], a
 	ld a, [hl]
-	ld [hBuffer], a
+	ldh [hBuffer], a
 	pop af
-	ld [rSVBK], a
-	ld a, [hBuffer]
+	ldh [rSVBK], a
+	ldh a, [hBuffer]
 	ret
 
 GetFarWRAMWord::
-	ld [hBuffer], a
-	ld a, [rSVBK]
+	ldh [hBuffer], a
+	ldh a, [rSVBK]
 	push af
-	ld a, [hBuffer]
-	ld [rSVBK], a
+	ldh a, [hBuffer]
+	ldh [rSVBK], a
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret

--- a/home/copy_tilemap.asm
+++ b/home/copy_tilemap.asm
@@ -1,35 +1,35 @@
 LoadTileMapToTempTileMap::
 ; Load wTileMap into wTempTileMap
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wTempTileMap)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	hlcoord 0, 0
 	decoord 0, 0, wTempTileMap
 	ld bc, wTileMapEnd - wTileMap
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Call_LoadTempTileMapToTileMap::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadTempTileMapToTileMap
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 LoadTempTileMapToTileMap::
 ; Load wTempTileMap into wTileMap
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wTempTileMap)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	hlcoord 0, 0, wTempTileMap
 	decoord 0, 0
 	ld bc, wTileMapEnd - wTileMap
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret

--- a/home/cry.asm
+++ b/home/cry.asm
@@ -55,7 +55,7 @@ LoadCry::
 	call GetCryIndex
 	ret c
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(PokemonCries)
 	rst Bankswitch

--- a/home/decompress.asm
+++ b/home/decompress.asm
@@ -2,7 +2,7 @@ FarDecompress::
 ; Decompress graphics data from a:hl to de.
 
 	ld [wLZBank], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [wLZBank]
 	rst Bankswitch

--- a/home/double_speed.asm
+++ b/home/double_speed.asm
@@ -19,9 +19,9 @@ NormalSpeed::
 SwitchSpeed::
 	set 0, [hl]
 	xor a
-	ld [rIF], a
-	ld [rIE], a
+	ldh [rIF], a
+	ldh [rIE], a
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 	stop ; rgbasm adds a nop after this instruction by default
 	ret

--- a/home/fade.asm
+++ b/home/fade.asm
@@ -13,15 +13,15 @@ Unreferenced_Function48c::
 
 .okay
 	ld a, [hli]
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld a, [hli]
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	ld a, [hli]
-	ld [rOBP1], a
+	ldh [rOBP1], a
 	ret
 
 RotateFourPalettesRight::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld hl, IncGradGBPalTable_00
@@ -34,7 +34,7 @@ RotateFourPalettesRight::
 	jr RotatePalettesRight
 
 RotateThreePalettesRight::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld hl, IncGradGBPalTable_05
@@ -63,7 +63,7 @@ RotatePalettesRight::
 	ret
 
 RotateFourPalettesLeft::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld hl, IncGradGBPalTable_04 - 1
@@ -76,7 +76,7 @@ RotateFourPalettesLeft::
 	jr RotatePalettesLeft
 
 RotateThreePalettesLeft::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 	ld hl, IncGradGBPalTable_07 - 1

--- a/home/farcall.asm
+++ b/home/farcall.asm
@@ -2,10 +2,10 @@ FarCall_de::
 ; Call a:de.
 ; Preserves other registers.
 
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 	call .de
 	jr ReturnFarCall
@@ -18,10 +18,10 @@ FarCall_hl::
 ; Call a:hl.
 ; Preserves other registers.
 
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 	call FarJump_hl
 

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -11,15 +11,15 @@ ResetGameTime::
 GameTimer::
 	nop
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wGameTime)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call UpdateGameTimer
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 UpdateGameTimer::

--- a/home/handshake.asm
+++ b/home/handshake.asm
@@ -29,14 +29,14 @@ AskSerial::
 
 ; handshake
 	ld a, $88
-	ld [rSB], a
+	ldh [rSB], a
 
 ; switch to internal clock
 	ld a, %00000001
-	ld [rSC], a
+	ldh [rSC], a
 
 ; start transfer
 	ld a, %10000001
-	ld [rSC], a
+	ldh [rSC], a
 
 	ret

--- a/home/init.asm
+++ b/home/init.asm
@@ -2,12 +2,12 @@ Reset::
 	di
 	call MapSetup_Sound_Off
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	call ClearPalettes
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, 1 ; VBlank int
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 
 	ld hl, wcfbe
@@ -28,40 +28,40 @@ _Start::
 	ld a, $1
 
 .load
-	ld [hCGB], a
+	ldh [hCGB], a
 	ld a, $1
-	ld [hSystemBooted], a
+	ldh [hSystemBooted], a
 
 Init::
 	di
 
 	xor a
-	ld [rIF], a
-	ld [rIE], a
-	ld [rRP], a
-	ld [rSCX], a
-	ld [rSCY], a
-	ld [rSB], a
-	ld [rSC], a
-	ld [rWX], a
-	ld [rWY], a
-	ld [rBGP], a
-	ld [rOBP0], a
-	ld [rOBP1], a
-	ld [rTMA], a
-	ld [rTAC], a
+	ldh [rIF], a
+	ldh [rIE], a
+	ldh [rRP], a
+	ldh [rSCX], a
+	ldh [rSCY], a
+	ldh [rSB], a
+	ldh [rSC], a
+	ldh [rWX], a
+	ldh [rWY], a
+	ldh [rBGP], a
+	ldh [rOBP0], a
+	ldh [rOBP1], a
+	ldh [rTMA], a
+	ldh [rTAC], a
 	ld [WRAM1_Begin], a
 
 	ld a, %100 ; Start timer at 4096Hz
-	ld [rTAC], a
+	ldh [rTAC], a
 
 .wait
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK + 1
 	jr nz, .wait
 
 	xor a
-	ld [rLCDC], a
+	ldh [rLCDC], a
 
 ; Clear WRAM bank 0
 	ld hl, WRAM0_Begin
@@ -77,22 +77,22 @@ Init::
 	ld sp, wStack
 
 ; Clear HRAM
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	push af
-	ld a, [hSystemBooted]
+	ldh a, [hSystemBooted]
 	push af
 	xor a
 	ld hl, HRAM_Begin
 	ld bc, HRAM_End - HRAM_Begin
 	call ByteFill
 	pop af
-	ld [hSystemBooted], a
+	ldh [hSystemBooted], a
 	pop af
-	ld [hCGB], a
+	ldh [hCGB], a
 
 	call ClearWRAM
 	ld a, 1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call ClearVRAM
 	call ClearSprites
 	call ClearsScratch
@@ -103,21 +103,21 @@ Init::
 	call WriteOAMDMACodeToHRAM
 
 	xor a
-	ld [hMapAnims], a
-	ld [hSCX], a
-	ld [hSCY], a
-	ld [rJOYP], a
+	ldh [hMapAnims], a
+	ldh [hSCX], a
+	ldh [hSCY], a
+	ldh [rJOYP], a
 
 	ld a, $8 ; HBlank int enable
-	ld [rSTAT], a
+	ldh [rSTAT], a
 
 	ld a, $90
-	ld [hWY], a
-	ld [rWY], a
+	ldh [hWY], a
+	ldh [rWY], a
 
 	ld a, 7
-	ld [hWX], a
-	ld [rWX], a
+	ldh [hWX], a
+	ldh [rWX], a
 
 	ld a, LCDC_DEFAULT ; %11100011
 	; LCD on
@@ -128,17 +128,17 @@ Init::
 	; OBJ 8x8
 	; OBJ on
 	; BG on
-	ld [rLCDC], a
+	ldh [rLCDC], a
 
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 
 	farcall InitCGBPals
 
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	xor a ; LOW(vBGMap1)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 
 	farcall StartClock
 
@@ -146,16 +146,16 @@ Init::
 	ld [MBC3LatchClock], a
 	ld [MBC3SRamEnable], a
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .no_double_speed
 	call NormalSpeed
 .no_double_speed
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %1111 ; VBlank, LCDStat, Timer, Serial interrupts
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 
 	call DelayFrame
@@ -171,11 +171,11 @@ ClearVRAM::
 ; Wipe VRAM banks 0 and 1
 
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 	call .clear
 
 	xor a ; 0
-	ld [rVBK], a
+	ldh [rVBK], a
 .clear
 	ld hl, VRAM_Begin
 	ld bc, VRAM_End - VRAM_Begin
@@ -190,7 +190,7 @@ ClearWRAM::
 	ld a, 1
 .bank_loop
 	push af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	xor a
 	ld hl, WRAM1_Begin
 	ld bc, WRAM1_End - WRAM1_Begin

--- a/home/item.asm
+++ b/home/item.asm
@@ -16,7 +16,7 @@ TossItem::
 	push hl
 	push de
 	push bc
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_TossItem)
 	rst Bankswitch
@@ -33,7 +33,7 @@ TossItem::
 
 ReceiveItem::
 	push bc
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_ReceiveItem)
 	rst Bankswitch
@@ -54,7 +54,7 @@ CheckItem::
 	push hl
 	push de
 	push bc
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_CheckItem)
 	rst Bankswitch

--- a/home/joypad.asm
+++ b/home/joypad.asm
@@ -8,9 +8,9 @@ JoypadInt::
 ClearJoypad::
 	xor a
 ; Pressed this frame (delta)
-	ld [hJoyPressed], a
+	ldh [hJoyPressed], a
 ; Currently pressed
-	ld [hJoyDown], a
+	ldh [hJoyDown], a
 	ret
 
 Joypad::
@@ -38,10 +38,10 @@ Joypad::
 ; We can only get four inputs at a time.
 ; We take d-pad first for no particular reason.
 	ld a, R_DPAD
-	ld [rJOYP], a
+	ldh [rJOYP], a
 ; Read twice to give the request time to take.
-	ld a, [rJOYP]
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
+	ldh a, [rJOYP]
 
 ; The Joypad register output is in the lo nybble (inversed).
 ; We make the hi nybble of our new container d-pad input.
@@ -55,10 +55,10 @@ Joypad::
 ; Buttons make 8 total inputs (A, B, Select, Start).
 ; We can fit this into one byte.
 	ld a, R_BUTTONS
-	ld [rJOYP], a
+	ldh [rJOYP], a
 ; Wait for input to stabilize.
 rept 6
-	ld a, [rJOYP]
+	ldh a, [rJOYP]
 endr
 ; Buttons take the lo nybble.
 	cpl
@@ -68,30 +68,30 @@ endr
 
 ; Reset the joypad register since we're done with it.
 	ld a, $30
-	ld [rJOYP], a
+	ldh [rJOYP], a
 
 ; To get the delta we xor the last frame's input with the new one.
-	ld a, [hJoypadDown] ; last frame
+	ldh a, [hJoypadDown] ; last frame
 	ld e, a
 	xor b
 	ld d, a
 ; Released this frame:
 	and e
-	ld [hJoypadReleased], a
+	ldh [hJoypadReleased], a
 ; Pressed this frame:
 	ld a, d
 	and b
-	ld [hJoypadPressed], a
+	ldh [hJoypadPressed], a
 
 ; Add any new presses to the list of collective presses:
 	ld c, a
-	ld a, [hJoypadSum]
+	ldh a, [hJoypadSum]
 	or c
-	ld [hJoypadSum], a
+	ldh [hJoypadSum], a
 
 ; Currently pressed:
 	ld a, b
-	ld [hJoypadDown], a
+	ldh [hJoypadDown], a
 
 ; Now that we have the input, we can do stuff with it.
 
@@ -130,28 +130,28 @@ GetJoypad::
 	jr z, .auto
 
 ; To get deltas, take this and last frame's input.
-	ld a, [hJoypadDown] ; real input
+	ldh a, [hJoypadDown] ; real input
 	ld b, a
-	ld a, [hJoyDown] ; last frame mirror
+	ldh a, [hJoyDown] ; last frame mirror
 	ld e, a
 
 ; Released this frame:
 	xor b
 	ld d, a
 	and e
-	ld [hJoyReleased], a
+	ldh [hJoyReleased], a
 
 ; Pressed this frame:
 	ld a, d
 	and b
-	ld [hJoyPressed], a
+	ldh [hJoyPressed], a
 
 ; It looks like the collective presses got commented out here.
 	ld c, a
 
 ; Currently pressed:
 	ld a, b
-	ld [hJoyDown], a ; frame input
+	ldh [hJoyDown], a ; frame input
 
 .quit
 	pop bc
@@ -167,7 +167,7 @@ GetJoypad::
 ; A value of $ff will immediately end the stream.
 
 ; Read from the input stream.
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [wAutoInputBank]
 	rst Bankswitch
@@ -224,8 +224,8 @@ GetJoypad::
 	pop af
 	rst Bankswitch
 	ld a, b
-	ld [hJoyPressed], a ; pressed
-	ld [hJoyDown], a ; input
+	ldh [hJoyPressed], a ; pressed
+	ldh [hJoyDown], a ; input
 	jr .quit
 
 StartAutoInput::
@@ -241,9 +241,9 @@ StartAutoInput::
 	ld [wAutoInputLength], a
 ; Reset input mirrors.
 	xor a
-	ld [hJoyPressed], a ; pressed this frame
-	ld [hJoyReleased], a ; released this frame
-	ld [hJoyDown], a ; currently pressed
+	ldh [hJoyPressed], a ; pressed this frame
+	ldh [hJoyReleased], a ; released this frame
+	ldh [hJoyDown], a ; currently pressed
 
 	ld a, AUTO_INPUT
 	ld [wInputType], a
@@ -269,11 +269,11 @@ JoyTitleScreenInput::
 	call JoyTextDelay
 	pop bc
 
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	cp D_UP | SELECT | B_BUTTON
 	jr z, .keycombo
 
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and START | A_BUTTON
 	jr nz, .keycombo
 
@@ -291,33 +291,33 @@ JoyWaitAorB::
 .loop
 	call DelayFrame
 	call GetJoypad
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON
 	ret nz
 	call RTC
 	jr .loop
 
 WaitButton::
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, 1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call WaitBGMap
 	call JoyWaitAorB
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 JoyTextDelay::
 	call GetJoypad
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	and a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	jr z, .ok
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 .ok
-	ld [hJoyLast], a
-	ld a, [hJoyPressed]
+	ldh [hJoyLast], a
+	ldh a, [hJoyPressed]
 	and a
 	jr z, .checkframedelay
 	ld a, 15
@@ -329,7 +329,7 @@ JoyTextDelay::
 	and a
 	jr z, .restartframedelay
 	xor a
-	ld [hJoyLast], a
+	ldh [hJoyLast], a
 	ret
 
 .restartframedelay
@@ -338,14 +338,14 @@ JoyTextDelay::
 	ret
 
 WaitPressAorB_BlinkCursor::
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	push af
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	push af
 	xor a
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, 6
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 
 .loop
 	push hl
@@ -354,20 +354,20 @@ WaitPressAorB_BlinkCursor::
 	pop hl
 
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and A_BUTTON | B_BUTTON
 	jr z, .loop
 
 	pop af
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	pop af
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ret
 
 SimpleWaitPressAorB::
 .loop
 	call JoyTextDelay
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and A_BUTTON | B_BUTTON
 	jr z, .loop
 	ret
@@ -388,10 +388,10 @@ ButtonSound::
 	jp DelayFrames
 
 .wait_input
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ld a, [wInputType]
 	or a
 	jr z, .input_wait_loop
@@ -400,22 +400,22 @@ ButtonSound::
 .input_wait_loop
 	call .blink_cursor
 	call JoyTextDelay
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON
 	jr nz, .received_input
 	call RTC
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrame
 	jr .input_wait_loop
 
 .received_input
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 .blink_cursor
-	ld a, [hVBlankCounter]
+	ldh a, [hVBlankCounter]
 	and %00010000 ; bit 4, a
 	jr z, .cursor_off
 	ld a, "▼"
@@ -436,37 +436,37 @@ BlinkCursor::
 	cp b
 	pop bc
 	jr nz, .place_arrow
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	dec a
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ret nz
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	dec a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ret nz
 	ld a, "─"
 	ld [hl], a
 	ld a, -1
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, 6
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ret
 
 .place_arrow
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	and a
 	ret z
 	dec a
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ret nz
 	dec a
-	ld [hMapObjectIndexBuffer], a
-	ld a, [hObjectStructIndexBuffer]
+	ldh [hMapObjectIndexBuffer], a
+	ldh a, [hObjectStructIndexBuffer]
 	dec a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ret nz
 	ld a, 6
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ld a, "▼"
 	ld [hl], a
 	ret

--- a/home/lcd.asm
+++ b/home/lcd.asm
@@ -2,7 +2,7 @@
 
 Unreferenced_Function547::
 	ldh a, [hLCDCPointer]
-	cp rSCX - $ff00
+	cp LOW(rSCX)
 	ret nz
 	ld c, a
 	ld a, [wLYOverrides]

--- a/home/lcd.asm
+++ b/home/lcd.asm
@@ -1,7 +1,7 @@
 ; LCD handling
 
 Unreferenced_Function547::
-	ld a, [hLCDCPointer]
+	ldh a, [hLCDCPointer]
 	cp rSCX - $ff00
 	ret nz
 	ld c, a
@@ -11,18 +11,18 @@ Unreferenced_Function547::
 
 LCD::
 	push af
-	ld a, [hLCDCPointer]
+	ldh a, [hLCDCPointer]
 	and a
 	jr z, .done
 
 ; At this point it's assumed we're in WRAM bank 5!
 	push bc
-	ld a, [rLY]
+	ldh a, [rLY]
 	ld c, a
 	ld b, HIGH(wLYOverrides)
 	ld a, [bc]
 	ld b, a
-	ld a, [hLCDCPointer]
+	ldh a, [hLCDCPointer]
 	ld c, a
 	ld a, b
 	ld [$ff00+c], a
@@ -36,37 +36,37 @@ DisableLCD::
 ; Turn the LCD off
 
 ; Don't need to do anything if the LCD is already off
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	ret z
 
 	xor a
-	ld [rIF], a
-	ld a, [rIE]
+	ldh [rIF], a
+	ldh a, [rIE]
 	ld b, a
 
 ; Disable VBlank
 	res 0, a ; vblank
-	ld [rIE], a
+	ldh [rIE], a
 
 .wait
 ; Wait until VBlank would normally happen
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK + 1
 	jr nz, .wait
 
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	and $ff ^ (1 << rLCDC_ENABLE)
-	ld [rLCDC], a
+	ldh [rLCDC], a
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, b
-	ld [rIE], a
+	ldh [rIE], a
 	ret
 
 EnableLCD::
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	set rLCDC_ENABLE, a
-	ld [rLCDC], a
+	ldh [rLCDC], a
 	ret

--- a/home/map.asm
+++ b/home/map.asm
@@ -49,7 +49,7 @@ GetMapSceneID::
 ; Searches the scene script table for the map group and number loaded in bc, and returns the wram pointer in de.
 ; If the map is not in the scene script table, returns carry.
 	push bc
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(MapScenes)
 	rst Bankswitch
@@ -97,7 +97,7 @@ OverworldTextModeSwitch::
 	ret
 
 LoadMapPart::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, [wTilesetBlocksBank]
@@ -207,10 +207,10 @@ endr
 
 ReturnToMapFromSubmenu::
 	ld a, MAPSETUP_SUBMENU
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	farcall RunMapSetupScript
 	xor a
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	ret
 
 CheckWarpTile::
@@ -236,7 +236,7 @@ GetDestinationWarpNumber::
 	farcall CheckWarpCollision
 	ret nc
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	call SwitchToMapScriptsBank
@@ -306,7 +306,7 @@ GetDestinationWarpNumber::
 	ret
 
 CopyWarpData::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	call SwitchToMapScriptsBank
@@ -708,14 +708,14 @@ LoadBlockData::
 	ret
 
 ChangeMap::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld hl, wOverworldMapBlocks
 	ld a, [wMapWidth]
-	ld [hConnectedMapWidth], a
+	ldh [hConnectedMapWidth], a
 	add $6
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	ld c, a
 	ld b, 0
 	add hl, bc
@@ -734,7 +734,7 @@ ChangeMap::
 	ld b, a
 .row
 	push hl
-	ld a, [hConnectedMapWidth]
+	ldh a, [hConnectedMapWidth]
 	ld c, a
 .col
 	ld a, [de]
@@ -743,7 +743,7 @@ ChangeMap::
 	dec c
 	jr nz, .col
 	pop hl
-	ld a, [hConnectionStripLength]
+	ldh a, [hConnectionStripLength]
 	add l
 	ld l, a
 	jr nc, .okay
@@ -775,9 +775,9 @@ FillMapConnections::
 	ld a, [wNorthConnectionStripLocation + 1]
 	ld d, a
 	ld a, [wNorthConnectionStripLength]
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	ld a, [wNorthConnectedMapWidth]
-	ld [hConnectedMapWidth], a
+	ldh [hConnectedMapWidth], a
 	call FillNorthConnectionStrip
 
 .South:
@@ -798,9 +798,9 @@ FillMapConnections::
 	ld a, [wSouthConnectionStripLocation + 1]
 	ld d, a
 	ld a, [wSouthConnectionStripLength]
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	ld a, [wSouthConnectedMapWidth]
-	ld [hConnectedMapWidth], a
+	ldh [hConnectedMapWidth], a
 	call FillSouthConnectionStrip
 
 .West:
@@ -823,7 +823,7 @@ FillMapConnections::
 	ld a, [wWestConnectionStripLength]
 	ld b, a
 	ld a, [wWestConnectedMapWidth]
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	call FillWestConnectionStrip
 
 .East:
@@ -846,7 +846,7 @@ FillMapConnections::
 	ld a, [wEastConnectionStripLength]
 	ld b, a
 	ld a, [wEastConnectedMapWidth]
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	call FillEastConnectionStrip
 
 .Done:
@@ -859,7 +859,7 @@ FillSouthConnectionStrip::
 	push de
 
 	push hl
-	ld a, [hConnectionStripLength]
+	ldh a, [hConnectionStripLength]
 	ld b, a
 .x
 	ld a, [hli]
@@ -869,7 +869,7 @@ FillSouthConnectionStrip::
 	jr nz, .x
 	pop hl
 
-	ld a, [hConnectedMapWidth]
+	ldh a, [hConnectedMapWidth]
 	ld e, a
 	ld d, 0
 	add hl, de
@@ -891,7 +891,7 @@ FillEastConnectionStrip::
 .loop
 	ld a, [wMapWidth]
 	add 6
-	ld [hConnectedMapWidth], a
+	ldh [hConnectedMapWidth], a
 
 	push de
 
@@ -907,13 +907,13 @@ FillEastConnectionStrip::
 	inc de
 	pop hl
 
-	ld a, [hConnectionStripLength]
+	ldh a, [hConnectionStripLength]
 	ld e, a
 	ld d, 0
 	add hl, de
 	pop de
 
-	ld a, [hConnectedMapWidth]
+	ldh a, [hConnectedMapWidth]
 	add e
 	ld e, a
 	jr nc, .okay
@@ -953,7 +953,7 @@ CallMapScript::
 RunMapCallback::
 ; Will run the first callback found with execution index equal to a.
 	ld b, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call .FindCallback
@@ -1018,7 +1018,7 @@ ExecuteCallbackScript::
 	ret
 
 MapTextbox::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, b
@@ -1028,12 +1028,12 @@ MapTextbox::
 	call SpeechTextBox
 	call SafeUpdateSprites
 	ld a, 1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call ApplyTilemap
 	pop hl
 	call PrintTextBoxText
 	xor a
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	pop af
 	rst Bankswitch
@@ -1042,10 +1042,10 @@ MapTextbox::
 Call_a_de::
 ; Call a:de.
 
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	call .de
@@ -1060,7 +1060,7 @@ Call_a_de::
 
 GetMovementData::
 ; Initialize the movement data for object c at b:hl
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
@@ -1078,7 +1078,7 @@ GetScriptByte::
 
 	push hl
 	push bc
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [wScriptBank]
 	rst Bankswitch
@@ -1125,7 +1125,7 @@ CoordinatesEventText::
 	db "@"
 
 CheckObjectMask::
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld e, a
 	ld d, $0
 	ld hl, wObjectMasks
@@ -1134,7 +1134,7 @@ CheckObjectMask::
 	ret
 
 MaskObject::
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld e, a
 	ld d, $0
 	ld hl, wObjectMasks
@@ -1143,7 +1143,7 @@ MaskObject::
 	ret
 
 UnmaskObject::
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld e, a
 	ld d, $0
 	ld hl, wObjectMasks
@@ -1163,7 +1163,7 @@ ScrollMapDown::
 	ld d, a
 	call UpdateBGMapRow
 	ld a, $1
-	ld [hBGMapUpdate], a
+	ldh [hBGMapUpdate], a
 	ret
 
 ScrollMapUp::
@@ -1186,7 +1186,7 @@ ScrollMapUp::
 	ld d, a
 	call UpdateBGMapRow
 	ld a, $1
-	ld [hBGMapUpdate], a
+	ldh [hBGMapUpdate], a
 	ret
 
 ScrollMapRight::
@@ -1201,7 +1201,7 @@ ScrollMapRight::
 	ld d, a
 	call UpdateBGMapColumn
 	ld a, $1
-	ld [hBGMapUpdate], a
+	ldh [hBGMapUpdate], a
 	ret
 
 ScrollMapLeft::
@@ -1223,7 +1223,7 @@ ScrollMapLeft::
 	ld d, a
 	call UpdateBGMapColumn
 	ld a, $1
-	ld [hBGMapUpdate], a
+	ldh [hBGMapUpdate], a
 	ret
 
 BackupBGMapRow::
@@ -1284,7 +1284,7 @@ UpdateBGMapRow::
 	dec c
 	jr nz, .loop
 	ld a, SCREEN_WIDTH
-	ld [hBGMapTileCount], a
+	ldh [hBGMapTileCount], a
 	ret
 
 UpdateBGMapColumn::
@@ -1310,7 +1310,7 @@ UpdateBGMapColumn::
 	dec c
 	jr nz, .loop
 	ld a, SCREEN_HEIGHT
-	ld [hBGMapTileCount], a
+	ldh [hBGMapTileCount], a
 	ret
 
 Unreferenced_Function2816::
@@ -1328,10 +1328,10 @@ LoadTilesetGFX::
 	ld a, [wTilesetBank]
 	ld e, a
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, e
 	ld de, wDecompressScratch
@@ -1342,10 +1342,10 @@ LoadTilesetGFX::
 	ld bc, $60 tiles
 	call CopyBytes
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, wDecompressScratch + $60 tiles
 	ld de, vTiles2
@@ -1353,10 +1353,10 @@ LoadTilesetGFX::
 	call CopyBytes
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; These tilesets support dynamic per-mapgroup roof tiles.
 	ld a, [wMapTileset]
@@ -1373,7 +1373,7 @@ LoadTilesetGFX::
 
 .skip_roof
 	xor a
-	ld [hTileAnimFrame], a
+	ldh [hTileAnimFrame], a
 	ret
 
 BufferScreen::
@@ -1412,7 +1412,7 @@ SaveScreen::
 	ld de, wScreenSave
 	ld a, [wMapWidth]
 	add 6
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	ld a, [wPlayerStepDirection]
 	and a
 	jr z, .down
@@ -1426,7 +1426,7 @@ SaveScreen::
 
 .up
 	ld de, wScreenSave + SCREEN_META_WIDTH
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	ld c, a
 	ld b, 0
 	add hl, bc
@@ -1458,7 +1458,7 @@ LoadNeighboringBlockData::
 	ld l, a
 	ld a, [wMapWidth]
 	add 6
-	ld [hConnectionStripLength], a
+	ldh [hConnectionStripLength], a
 	ld de, wScreenSave
 	ld b, SCREEN_META_WIDTH
 	ld c, SCREEN_META_HEIGHT
@@ -1483,7 +1483,7 @@ SaveScreen_LoadNeighbor::
 
 .okay
 	pop hl
-	ld a, [hConnectionStripLength]
+	ldh a, [hConnectionStripLength]
 	ld c, a
 	ld b, 0
 	add hl, bc
@@ -1772,7 +1772,7 @@ CheckFacingBGEvent::
 	ret z
 
 	ld c, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call CheckIfFacingTileCoordIsBGEvent
@@ -1826,7 +1826,7 @@ CheckCurrentMapCoordEvents::
 	ret z
 ; Copy the coord event count into c.
 	ld c, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call .CoordEventCheck
@@ -1893,7 +1893,7 @@ CheckCurrentMapCoordEvents::
 
 FadeToMenu::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call LoadStandardMenuHeader
 	farcall FadeOutPalettes
 	call ClearSprites
@@ -1943,7 +1943,7 @@ ReturnToMapWithSpeechTextbox::
 	call UpdateTimePals
 	call DelayFrame
 	ld a, $1
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
 	ret
 
@@ -1953,7 +1953,7 @@ ReloadTilesetAndPalettes::
 	farcall RefreshSprites
 	call LoadStandardFont
 	call LoadFontsExtra
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [wMapGroup]
 	ld b, a
@@ -2023,7 +2023,7 @@ GetMapField::
 	ld c, a
 GetAnyMapField::
 	; bankswitch
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(MapGroupPointers)
 	rst Bankswitch
@@ -2067,7 +2067,7 @@ GetAnyMapAttributesBank::
 CopyMapPartial::
 ; Copy map data bank, tileset, environment, and map data address
 ; from the current map's entry within its group.
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(MapGroupPointers)
 	rst Bankswitch

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -20,7 +20,7 @@ GetSpriteVTile::
 	ld hl, wUsedSprites + 2
 	ld c, SPRITE_GFX_LIST_CAPACITY - 1
 	ld b, a
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	cp 0
 	jr z, .nope
 	ld a, b
@@ -54,7 +54,7 @@ DoesSpriteHaveFacings::
 	push hl
 
 	ld b, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_DoesSpriteHaveFacings)
 	rst Bankswitch
@@ -96,7 +96,7 @@ GetTileCollision::
 	ld d, 0
 	add hl, de
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(TileCollisionTable)
 	rst Bankswitch
@@ -210,14 +210,14 @@ GetMapObject::
 
 CheckObjectVisibility::
 ; Sets carry if the object is not visible on the screen.
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call GetMapObject
 	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jr z, .not_visible
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	call GetObjectStruct
 	and a
 	ret
@@ -301,21 +301,21 @@ CheckObjectTime::
 	ret
 
 ; unused
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call GetMapObject
 	call CopyObjectStruct
 	ret
 
 _CopyObjectStruct::
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call UnmaskObject
-	ld a, [hMapObjectIndexBuffer]
+	ldh a, [hMapObjectIndexBuffer]
 	call GetMapObject
 	farcall CopyObjectStruct
 	ret
 
 ApplyDeletionToMapObject::
-	ld [hMapObjectIndexBuffer], a
+	ldh [hMapObjectIndexBuffer], a
 	call GetMapObject
 	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
 	add hl, bc
@@ -394,7 +394,7 @@ Unreferenced_Function19b8:
 LoadMovementDataPointer::
 ; Load the movement data pointer for object a.
 	ld [wMovementObject], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld [wMovementDataPointer], a
 	ld a, l
 	ld [wMovementDataPointer + 1], a
@@ -484,7 +484,7 @@ endr
 
 CopySpriteMovementData::
 	ld l, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(SpriteMovementData)
 	rst Bankswitch
@@ -551,7 +551,7 @@ endr
 
 _GetMovementByte::
 ; Switch to the movement data bank
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, [hli]
 	rst Bankswitch

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -9,7 +9,7 @@ CopyMenuHeader::
 	ld de, wMenuHeader
 	ld bc, wMenuHeaderEnd - wMenuHeader
 	call CopyBytes
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld [wMenuDataBank], a
 	ret
 
@@ -59,7 +59,7 @@ Call_ExitMenu::
 
 VerticalMenu::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call UpdateSprites
 	call PlaceVerticalMenuItems
@@ -229,17 +229,17 @@ DrawVariableLengthMenuBox::
 
 MenuWriteText::
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call GetMenuIndexSet ; sort out the text
 	call RunMenuItemPrintingFunction ; actually write it
 	call SafeUpdateSprites
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call ApplyTilemap
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 AutomaticGetMenuBottomCoord::
@@ -455,10 +455,10 @@ ClearWindowData::
 	ld hl, w2DMenuCursorInitY
 	call .bytefill
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wWindowStack)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	xor a
 	ld hl, wWindowStackBottom
@@ -470,7 +470,7 @@ ClearWindowData::
 	ld [wWindowStackPointer + 1], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .bytefill
@@ -505,10 +505,10 @@ MenuTextBoxWaitButton::
 	ret
 
 Place2DMenuItemName::
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	call PlaceString
@@ -518,21 +518,21 @@ Place2DMenuItemName::
 	ret
 
 _2DMenu::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld [wMenuData_2DMenuItemStringsBank], a
 	farcall _2DMenu_
 	ld a, [wMenuCursorBuffer]
 	ret
 
 InterpretBattleMenu::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld [wMenuData_2DMenuItemStringsBank], a
 	farcall _InterpretBattleMenu
 	ld a, [wMenuCursorBuffer]
 	ret
 
 InterpretMobileMenu::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	ld [wMenuData_2DMenuItemStringsBank], a
 	farcall _InterpretMobileMenu
 	ld a, [wMenuCursorBuffer]

--- a/home/mobile.asm
+++ b/home/mobile.asm
@@ -20,7 +20,7 @@ Function3e32::
 .okay
 	ld hl, $c822
 	set 6, [hl]
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(Function110030)
 	ld [$c981], a
@@ -51,7 +51,7 @@ Function3e60::
 	ret
 
 MobileReceive::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_MobileReceive)
 	ld [$c981], a
@@ -71,17 +71,17 @@ Timer::
 	push de
 	push hl
 
-	ld a, [hMobile]
+	ldh a, [hMobile]
 	and a
 	jr z, .pop_ret
 
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 
 ; Turn off timer interrupt
-	ld a, [rIF]
+	ldh a, [rIF]
 	and 1 << VBLANK | 1 << LCD_STAT | 1 << SERIAL | 1 << JOYPAD
-	ld [rIF], a
+	ldh [rIF], a
 
 	ld a, [$c86a]
 	or a
@@ -91,11 +91,11 @@ Timer::
 	bit 1, a
 	jr nz, .skip_Timer
 
-	ld a, [rSC]
+	ldh a, [rSC]
 	and 1 << rSC_ON
 	jr nz, .skip_Timer
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_Timer)
 	ld [$c981], a
@@ -109,11 +109,11 @@ Timer::
 	rst Bankswitch
 
 .skip_Timer
-	ld a, [rTMA]
-	ld [rTIMA], a
+	ldh a, [rTMA]
+	ldh [rTIMA], a
 
 	ld a, 1 << rTAC_ON | rTAC_65536_HZ
-	ld [rTAC], a
+	ldh [rTAC], a
 
 .pop_ret
 	pop hl
@@ -124,7 +124,7 @@ Timer::
 
 Unreferenced_Function3ed7::
 	ld [$dc02], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(Function114243)
 	rst Bankswitch

--- a/home/mon_data.asm
+++ b/home/mon_data.asm
@@ -10,7 +10,7 @@ GetBaseData::
 	push bc
 	push de
 	push hl
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(BaseData)
 	rst Bankswitch

--- a/home/mon_stats.asm
+++ b/home/mon_stats.asm
@@ -89,7 +89,7 @@ _PrepMonFrontpic::
 	predef GetMonFrontpic
 	pop hl
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	xor a

--- a/home/movement.asm
+++ b/home/movement.asm
@@ -163,10 +163,10 @@ ScrollingMenuJoypad::
 GetMenuJoypad::
 	push bc
 	push af
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_PAD
 	ld b, a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and BUTTONS
 	or b
 	ld b, a

--- a/home/names.asm
+++ b/home/names.asm
@@ -12,7 +12,7 @@ NamesPointers::
 GetName::
 ; Return name wCurSpecies from name list wNamedObjectTypeBuffer in wStringBuffer1.
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	push hl
 	push bc
@@ -112,7 +112,7 @@ GetBasePokemonName::
 GetPokemonName::
 ; Get Pokemon name for wNamedObjectIndexBuffer.
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	push hl
 	ld a, BANK(PokemonNames)

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -6,28 +6,28 @@ UpdatePalsIfCGB::
 ; return carry if successful
 
 ; check cgb
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
 UpdateCGBPals::
 ; return carry if successful
 ; any pals to update?
-	ld a, [hCGBPalUpdate]
+	ldh a, [hCGBPalUpdate]
 	and a
 	ret z
 
 ForceUpdateCGBPals::
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wBGPals2
 
 ; copy 8 pals to bgpd
 	ld a, 1 << rBGPI_AUTO_INCREMENT
-	ld [rBGPI], a
+	ldh [rBGPI], a
 	ld c, LOW(rBGPD)
 	ld b, 8 / 2
 .bgp
@@ -43,7 +43,7 @@ endr
 
 ; copy 8 pals to obpd
 	ld a, 1 << rOBPI_AUTO_INCREMENT
-	ld [rOBPI], a
+	ldh [rOBPI], a
 	ld c, LOW(rOBPD)
 	ld b, 8 / 2
 .obp
@@ -56,11 +56,11 @@ endr
 	jr nz, .obp
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; clear pal update queue
 	xor a
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	scf
 	ret
@@ -70,38 +70,38 @@ DmgToCgbBGPals::
 
 ; input: a -> bgp
 
-	ld [rBGP], a
+	ldh [rBGP], a
 	push af
 
 ; Don't need to be here if DMG
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .end
 
 	push hl
 	push de
 	push bc
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; copy & reorder bg pal buffer
 	ld hl, wBGPals2 ; to
 	ld de, wBGPals1 ; from
 ; order
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	ld b, a
 ; all pals
 	ld c, 8
 	call CopyPals
 ; request pal update
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	pop de
 	pop hl
@@ -116,49 +116,49 @@ DmgToCgbObjPals::
 ;        e -> obp2
 
 	ld a, e
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	ld a, d
-	ld [rOBP1], a
+	ldh [rOBP1], a
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
 	push hl
 	push de
 	push bc
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wOBPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; copy & reorder obj pal buffer
 	ld hl, wOBPals2 ; to
 	ld de, wOBPals1 ; from
 ; order
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld b, a
 ; all pals
 	ld c, 8
 	call CopyPals
 ; request pal update
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	pop de
 	pop hl
 	ret
 
 DmgToCgbObjPal0::
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	push af
 
 ; Don't need to be here if not CGB
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 
@@ -166,22 +166,22 @@ DmgToCgbObjPal0::
 	push de
 	push bc
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wOBPals2 palette 0
 	ld de, wOBPals1 palette 0
-	ld a, [rOBP0]
+	ldh a, [rOBP0]
 	ld b, a
 	ld c, 1
 	call CopyPals
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	pop bc
 	pop de
@@ -192,10 +192,10 @@ DmgToCgbObjPal0::
 	ret
 
 DmgToCgbObjPal1::
-	ld [rOBP1], a
+	ldh [rOBP1], a
 	push af
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 
@@ -203,22 +203,22 @@ DmgToCgbObjPal1::
 	push de
 	push bc
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wOBPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, wOBPals2 palette 1
 	ld de, wOBPals1 palette 1
-	ld a, [rOBP1]
+	ldh a, [rOBP1]
 	ld b, a
 	ld c, 1
 	call CopyPals
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	pop bc
 	pop de
@@ -281,12 +281,12 @@ endr
 	ret
 
 ClearVBank1::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, VRAM_Begin
 	ld bc, VRAM_End - VRAM_Begin
@@ -294,28 +294,28 @@ ClearVBank1::
 	call ByteFill
 
 	ld a, 0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 ret_d90::
 	ret
 
 ReloadSpritesNoPalettes::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld bc, (8 palettes) + (2 palettes)
 	xor a
 	call ByteFill
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	call DelayFrame
 	ret
 

--- a/home/predef.asm
+++ b/home/predef.asm
@@ -3,7 +3,7 @@ Predef::
 ; Preserves bc, de, hl and f.
 
 	ld [wPredefID], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, BANK(GetPredefPointer)

--- a/home/print_text.asm
+++ b/home/print_text.asm
@@ -55,7 +55,7 @@ PrintLetterDelay::
 	jr nz, .wait
 
 ; Wait one frame if holding A or B.
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	bit A_BUTTON_F, a
 	jr z, .checkb
 	jr .delay
@@ -74,7 +74,7 @@ PrintLetterDelay::
 
 .end
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	pop bc
 	pop de
 	pop hl
@@ -107,10 +107,10 @@ MobilePrintNum::
 	ret
 
 FarPrintText::
-	ld [hBuffer], a
-	ld a, [hROMBank]
+	ldh [hBuffer], a
+	ldh a, [hROMBank]
 	push af
-	ld a, [hBuffer]
+	ldh a, [hBuffer]
 	rst Bankswitch
 
 	call PrintText

--- a/home/queue_script.asm
+++ b/home/queue_script.asm
@@ -1,6 +1,6 @@
 QueueScript::
 ; Push pointer hl in the current bank to wQueuedScriptBank.
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 
 FarQueueScript::
 ; Push pointer a:hl to wQueuedScriptBank.

--- a/home/random.asm
+++ b/home/random.asm
@@ -13,17 +13,17 @@ Random::
 
 	push bc
 
-	ld a, [rDIV]
+	ldh a, [rDIV]
 	ld b, a
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	adc b
-	ld [hRandomAdd], a
+	ldh [hRandomAdd], a
 
-	ld a, [rDIV]
+	ldh a, [rDIV]
 	ld b, a
-	ld a, [hRandomSub]
+	ldh a, [hRandomSub]
 	sbc b
-	ld [hRandomSub], a
+	ldh [hRandomSub], a
 
 	pop bc
 	ret
@@ -34,7 +34,7 @@ BattleRandom::
 ; It handles all RNG calls in the battle engine, allowing
 ; link battles to remain in sync using a shared PRNG.
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_BattleRandom)
 	rst Bankswitch
@@ -67,7 +67,7 @@ RandomRange::
 	push bc
 .loop
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	ld c, a
 	add b
 	jr c, .loop

--- a/home/rst.asm
+++ b/home/rst.asm
@@ -8,7 +8,7 @@ SECTION "rst8", ROM0 ; rst FarCall
 	jp FarCall_hl
 
 SECTION "rst10", ROM0 ; rst Bankswitch
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	ret
 

--- a/home/scrolling_menu.asm
+++ b/home/scrolling_menu.asm
@@ -1,6 +1,6 @@
 ScrollingMenu::
 	call CopyMenuData
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, BANK(_ScrollingMenu)
@@ -43,18 +43,18 @@ InitScrollingMenu::
 JoyTextDelay_ForcehJoyDown::
 	call DelayFrame
 
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call JoyTextDelay
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and D_RIGHT + D_LEFT + D_UP + D_DOWN
 	ld c, a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON + B_BUTTON + SELECT + START
 	or c
 	ld c, a

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -6,7 +6,7 @@ Serial::
 	push de
 	push hl
 
-	ld a, [hMobileReceive]
+	ldh a, [hMobileReceive]
 	and a
 	jr nz, .mobile
 
@@ -14,24 +14,24 @@ Serial::
 	bit 0, a
 	jr nz, .printer
 
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	inc a ; is it equal to CONNECTION_NOT_ESTABLISHED?
 	jr z, .establish_connection
 
-	ld a, [rSB]
-	ld [hSerialReceive], a
+	ldh a, [rSB]
+	ldh [hSerialReceive], a
 
-	ld a, [hSerialSend]
-	ld [rSB], a
+	ldh a, [hSerialSend]
+	ldh [rSB], a
 
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr z, .player2
 
 	ld a, 0 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, 1 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	jr .player2
 
 .mobile
@@ -43,43 +43,43 @@ Serial::
 	jr .end
 
 .establish_connection
-	ld a, [rSB]
+	ldh a, [rSB]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .player1
 	cp USING_INTERNAL_CLOCK
 	jr nz, .player2
 
 .player1
-	ld [hSerialReceive], a
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialReceive], a
+	ldh [hSerialConnectionStatus], a
 	cp USING_INTERNAL_CLOCK
 	jr z, ._player2
 
 	xor a
-	ld [rSB], a
+	ldh [rSB], a
 	ld a, 3
-	ld [rDIV], a
+	ldh [rDIV], a
 
 .wait_bit_7
-	ld a, [rDIV]
+	ldh a, [rDIV]
 	bit 7, a
 	jr nz, .wait_bit_7
 
 	ld a, 0 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, 1 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	jr .player2
 
 ._player2
 	xor a
-	ld [rSB], a
+	ldh [rSB], a
 
 .player2
 	ld a, TRUE
-	ld [hSerialReceivedNewData], a
+	ldh [hSerialReceivedNewData], a
 	ld a, SERIAL_NO_DATA_BYTE
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 
 .end
 	pop hl
@@ -90,10 +90,10 @@ Serial::
 
 Serial_ExchangeBytes::
 	ld a, $1
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 .loop
 	ld a, [hl]
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	call Serial_ExchangeByte
 	push bc
 	ld b, a
@@ -102,7 +102,7 @@ Serial_ExchangeBytes::
 .wait
 	dec a
 	jr nz, .wait
-	ld a, [hSerialIgnoringInitialData]
+	ldh a, [hSerialIgnoringInitialData]
 	and a
 	ld a, b
 	pop bc
@@ -111,7 +111,7 @@ Serial_ExchangeBytes::
 	cp SERIAL_PREAMBLE_BYTE
 	jr nz, .loop
 	xor a
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 	jr .loop
 
 .load
@@ -126,20 +126,20 @@ Serial_ExchangeBytes::
 Serial_ExchangeByte::
 .loop
 	xor a
-	ld [hSerialReceivedNewData], a
-	ld a, [hSerialConnectionStatus]
+	ldh [hSerialReceivedNewData], a
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr nz, .not_player_2
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 .not_player_2
 .loop2
-	ld a, [hSerialReceivedNewData]
+	ldh a, [hSerialReceivedNewData]
 	and a
 	jr nz, .reset_ffca
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr nz, .not_player_1_or_wLinkTimeoutFrames_zero
 	call CheckwLinkTimeoutFramesNonzero
@@ -159,7 +159,7 @@ Serial_ExchangeByte::
 	jp SerialDisconnected
 
 .not_player_1_or_wLinkTimeoutFrames_zero
-	ld a, [rIE]
+	ldh a, [rIE]
 	and (1 << SERIAL) | (1 << TIMER) | (1 << LCD_STAT) | (1 << VBLANK)
 	cp 1 << SERIAL
 	jr nz, .loop2
@@ -171,7 +171,7 @@ Serial_ExchangeByte::
 	dec a
 	ld [wcf5d + 1], a
 	jr nz, .loop2
-	ld a, [hSerialConnectionStatus]
+	ldh a, [hSerialConnectionStatus]
 	cp USING_EXTERNAL_CLOCK
 	jr z, .reset_ffca
 
@@ -182,8 +182,8 @@ Serial_ExchangeByte::
 
 .reset_ffca
 	xor a
-	ld [hSerialReceivedNewData], a
-	ld a, [rIE]
+	ldh [hSerialReceivedNewData], a
+	ldh a, [rIE]
 	and (1 << SERIAL) | (1 << TIMER) | (1 << LCD_STAT) | (1 << VBLANK)
 	sub 1 << SERIAL
 	jr nz, .rIE_not_equal_8
@@ -194,7 +194,7 @@ Serial_ExchangeByte::
 	ld [wcf5d + 1], a
 
 .rIE_not_equal_8
-	ld a, [hSerialReceive]
+	ldh a, [hSerialReceive]
 	cp SERIAL_NO_DATA_BYTE
 	ret nz
 	call CheckwLinkTimeoutFramesNonzero
@@ -214,13 +214,13 @@ Serial_ExchangeByte::
 	jr z, SerialDisconnected
 
 .linkTimeoutFrames_zero
-	ld a, [rIE]
+	ldh a, [rIE]
 	and (1 << SERIAL) | (1 << TIMER) | (1 << LCD_STAT) | (1 << VBLANK)
 	cp 1 << SERIAL
 	ld a, SERIAL_NO_DATA_BYTE
 	ret z
 	ld a, [hl]
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	call DelayFrame
 	jp .loop
 
@@ -252,18 +252,18 @@ Serial_ExchangeLinkMenuSelection::
 	ld de, wOtherPlayerLinkMode
 	ld c, 2
 	ld a, TRUE
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 .asm_847
 	call DelayFrame
 	ld a, [hl]
-	ld [hSerialSend], a
+	ldh [hSerialSend], a
 	call Serial_ExchangeByte
 	ld b, a
 	inc hl
-	ld a, [hSerialIgnoringInitialData]
+	ldh a, [hSerialIgnoringInitialData]
 	and a
 	ld a, FALSE
-	ld [hSerialIgnoringInitialData], a
+	ldh [hSerialIgnoringInitialData], a
 	jr nz, .asm_847
 	ld a, b
 	ld [de], a
@@ -348,14 +348,14 @@ LinkTransfer::
 	call .Receive
 	ld a, [wPlayerLinkAction]
 	add b
-	ld [hSerialSend], a
-	ld a, [hSerialConnectionStatus]
+	ldh [hSerialSend], a
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	jr nz, .player_1
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 
 .player_1
 	call .Receive
@@ -363,13 +363,13 @@ LinkTransfer::
 	ret
 
 .Receive:
-	ld a, [hSerialReceive]
+	ldh a, [hSerialReceive]
 	ld [wOtherPlayerLinkMode], a
 	and $f0
 	cp b
 	ret nz
 	xor a
-	ld [hSerialReceive], a
+	ldh [hSerialReceive], a
 	ld a, [wOtherPlayerLinkMode]
 	and $f
 	ld [wOtherPlayerLinkAction], a
@@ -378,14 +378,14 @@ LinkTransfer::
 LinkDataReceived::
 ; Let the other system know that the data has been received.
 	xor a
-	ld [hSerialSend], a
-	ld a, [hSerialConnectionStatus]
+	ldh [hSerialSend], a
+	ldh a, [hSerialConnectionStatus]
 	cp USING_INTERNAL_CLOCK
 	ret nz
 	ld a, (0 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, (1 << rSC_ON) | 1
-	ld [rSC], a
+	ldh [rSC], a
 	ret
 
 Unreferenced_Function919::
@@ -393,11 +393,11 @@ Unreferenced_Function919::
 	and a
 	ret nz
 	ld a, USING_INTERNAL_CLOCK
-	ld [rSB], a
+	ldh [rSB], a
 	xor a
-	ld [hSerialReceive], a
+	ldh [hSerialReceive], a
 	ld a, 0 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, 1 << rSC_ON
-	ld [rSC], a
+	ldh [rSC], a
 	ret

--- a/home/sprite_anims.asm
+++ b/home/sprite_anims.asm
@@ -1,5 +1,5 @@
 PushLYOverrides::
-	ld a, [hLCDCPointer]
+	ldh a, [hLCDCPointer]
 	and a
 	ret z
 
@@ -19,7 +19,7 @@ PushLYOverrides::
 
 _InitSpriteAnimStruct::
 	ld [wSpriteAnimIDBuffer], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, BANK(InitSpriteAnimStruct)
@@ -35,7 +35,7 @@ _InitSpriteAnimStruct::
 
 ReinitSpriteAnimFrame::
 	ld [wSpriteAnimIDBuffer], a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, BANK(_ReinitSpriteAnimFrame)

--- a/home/sprite_updates.asm
+++ b/home/sprite_updates.asm
@@ -1,6 +1,6 @@
 DisableSpriteUpdates::
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld a, [wVramState]
 	res 0, a
 	ld [wVramState], a
@@ -15,5 +15,5 @@ EnableSpriteUpdates::
 	set 0, a
 	ld [wVramState], a
 	ld a, $1
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret

--- a/home/stone_queue.asm
+++ b/home/stone_queue.asm
@@ -1,5 +1,5 @@
 HandleStoneQueue::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	call SwitchToMapScriptsBank

--- a/home/text.asm
+++ b/home/text.asm
@@ -28,7 +28,7 @@ ClearTileMap::
 	call ByteFill
 
 	; Update the BG Map.
-	ld a, [rLCDC]
+	ldh a, [rLCDC]
 	bit rLCDC_ENABLE, a
 	ret z
 	jp WaitBGMap
@@ -309,12 +309,12 @@ PlaceWatashi: print_name PlaceWatashiText
 PlaceKokoWa:  print_name PlaceKokoWaText
 
 PlaceMoveTargetsName::
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	xor 1
 	jr PlaceMoveUsersName.place
 
 PlaceMoveUsersName::
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 
 .place:
 	push de
@@ -599,15 +599,15 @@ TextScroll::
 
 Text_WaitBGMap::
 	push bc
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, 1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	call WaitBGMap
 
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	pop bc
 	ret
 
@@ -626,7 +626,7 @@ UnloadBlinkingCursor::
 
 FarString::
 	ld b, a
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, b
@@ -744,7 +744,7 @@ TextCommand_FAR::
 ; little endian
 ; [$16][addr][bank]
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	ld a, [hli]
@@ -753,7 +753,7 @@ TextCommand_FAR::
 	ld d, a
 	ld a, [hli]
 
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 
 	push hl
@@ -763,7 +763,7 @@ TextCommand_FAR::
 	pop hl
 
 	pop af
-	ld [hROMBank], a
+	ldh [hROMBank], a
 	ld [MBC3RomBank], a
 	ret
 
@@ -905,7 +905,7 @@ TextCommand_EXIT::
 	push hl
 	push bc
 	call GetJoypad
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and A_BUTTON | B_BUTTON
 	jr nz, .done
 	ld c, 30
@@ -986,7 +986,7 @@ TextCommand_DOTS::
 	ld a, "…"
 	ld [hli], a
 	call GetJoypad
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and A_BUTTON | B_BUTTON
 	jr nz, .next
 	ld c, 10

--- a/home/tilemap.asm
+++ b/home/tilemap.asm
@@ -3,36 +3,36 @@ ClearBGPalettes::
 WaitBGMap::
 ; Tell VBlank to update BG Map
 	ld a, 1 ; BG Map 0 tiles
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 ; Wait for it to do its magic
 	ld c, 4
 	call DelayFrames
 	ret
 
 WaitBGMap2::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .bg0
 
 	ld a, 2
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 
 .bg0
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 	ret
 
 IsCGB::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret
 
 ApplyTilemap::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, .dmg
 
@@ -41,19 +41,19 @@ ApplyTilemap::
 	jr z, .dmg
 
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	jr CopyTilemapAtOnce
 
 .dmg
 ; WaitBGMap
 	ld a, 1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld c, 4
 	call DelayFrames
 	ret
 
 CGBOnly_CopyTilemapAtOnce::
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr z, WaitBGMap
 
@@ -65,52 +65,52 @@ CopyTilemapAtOnce::
 	ret
 
 .CopyTilemapAtOnce:
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 
 .wait
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $7f
 	jr c, .wait
 
 	di
 	ld a, BANK(vTiles3)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0, wAttrMap
 	call .StackPointerMagic
 	ld a, BANK(vTiles0)
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlcoord 0, 0
 	call .StackPointerMagic
 
 .wait2
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp $7f
 	jr c, .wait2
 	ei
 
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .StackPointerMagic:
 ; Copy all tiles to vBGMap
 	ld [hSPBuffer], sp
 	ld sp, hl
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	ld l, 0
 	ld a, SCREEN_HEIGHT
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	ld b, 1 << 1 ; not in v/hblank
 	ld c, LOW(rSTAT)
 
@@ -131,14 +131,14 @@ endr
 
 	ld de, BG_MAP_WIDTH - SCREEN_WIDTH
 	add hl, de
-	ld a, [hTilesPerCycle]
+	ldh a, [hTilesPerCycle]
 	dec a
-	ld [hTilesPerCycle], a
+	ldh [hTilesPerCycle], a
 	jr nz, .loop
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret
@@ -146,14 +146,14 @@ endr
 SetPalettes::
 ; Inits the Palettes
 ; depending on the system the monochromes palettes or color palettes
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .SetPalettesForGameBoyColor
 	ld a, %11100100
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld a, %11010000
-	ld [rOBP0], a
-	ld [rOBP1], a
+	ldh [rOBP0], a
+	ldh [rOBP1], a
 	ret
 
 .SetPalettesForGameBoyColor:
@@ -169,23 +169,23 @@ ClearPalettes::
 ; Make all palettes white
 
 ; CGB: make all the palette colors white
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .cgb
 
 ; DMG: just change palettes to 0 (white)
 	xor a
-	ld [rBGP], a
-	ld [rOBP0], a
-	ld [rOBP1], a
+	ldh [rBGP], a
+	ldh [rOBP0], a
+	ldh [rOBP1], a
 	ret
 
 .cgb
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wBGPals2)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Fill wBGPals2 and wOBPals2 with $ffff (white)
 	ld hl, wBGPals2
@@ -194,11 +194,11 @@ ClearPalettes::
 	call ByteFill
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 ; Request palette update
 	ld a, 1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 GetMemSGBLayout::
@@ -206,11 +206,11 @@ GetMemSGBLayout::
 GetSGBLayout::
 ; load sgb packets unless dmg
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jr nz, .sgb
 
-	ld a, [hSGB]
+	ldh a, [hSGB]
 	and a
 	ret z
 

--- a/home/time.asm
+++ b/home/time.asm
@@ -2,7 +2,7 @@
 
 AskTimer::
 	push af
-	ld a, [hMobile]
+	ldh a, [hMobile]
 	and a
 	jr z, .not_mobile
 	call Timer
@@ -42,25 +42,25 @@ GetClock::
 	ld [hl], RTC_S
 	ld a, [de]
 	maskbits 60
-	ld [hRTCSeconds], a
+	ldh [hRTCSeconds], a
 
 	ld [hl], RTC_M
 	ld a, [de]
 	maskbits 60
-	ld [hRTCMinutes], a
+	ldh [hRTCMinutes], a
 
 	ld [hl], RTC_H
 	ld a, [de]
 	maskbits 24
-	ld [hRTCHours], a
+	ldh [hRTCHours], a
 
 	ld [hl], RTC_DL
 	ld a, [de]
-	ld [hRTCDayLo], a
+	ldh [hRTCDayLo], a
 
 	ld [hl], RTC_DH
 	ld a, [de]
-	ld [hRTCDayHi], a
+	ldh [hRTCDayHi], a
 
 ; unlatch clock / disable clock r/w
 	call CloseSRAM
@@ -71,16 +71,16 @@ FixDays::
 ; mod by 140
 
 ; check if day count > 255 (bit 8 set)
-	ld a, [hRTCDayHi] ; DH
+	ldh a, [hRTCDayHi] ; DH
 	bit 0, a
 	jr z, .daylo
 ; reset dh (bit 8)
 	res 0, a
-	ld [hRTCDayHi], a ; DH
+	ldh [hRTCDayHi], a ; DH
 
 ; mod 140
 ; mod twice since bit 8 (DH) was set
-	ld a, [hRTCDayLo] ; DL
+	ldh a, [hRTCDayLo] ; DL
 .modh
 	sub 140
 	jr nc, .modh
@@ -90,7 +90,7 @@ FixDays::
 	add 140
 
 ; update dl
-	ld [hRTCDayLo], a ; DL
+	ldh [hRTCDayLo], a ; DL
 
 ; flag for sRTCStatusFlags
 	ld a, %01000000
@@ -98,7 +98,7 @@ FixDays::
 
 .daylo
 ; quit if fewer than 140 days have passed
-	ld a, [hRTCDayLo] ; DL
+	ldh a, [hRTCDayLo] ; DL
 	cp 140
 	jr c, .quit
 
@@ -109,7 +109,7 @@ FixDays::
 	add 140
 
 ; update dl
-	ld [hRTCDayLo], a ; DL
+	ldh [hRTCDayLo], a ; DL
 
 ; flag for sRTCStatusFlags
 	ld a, %00100000
@@ -132,7 +132,7 @@ FixTime::
 ; store time in wCurDay, hHours, hMinutes, hSeconds
 
 ; second
-	ld a, [hRTCSeconds] ; S
+	ldh a, [hRTCSeconds] ; S
 	ld c, a
 	ld a, [wStartSecond]
 	add c
@@ -140,11 +140,11 @@ FixTime::
 	jr nc, .updatesec
 	add 60
 .updatesec
-	ld [hSeconds], a
+	ldh [hSeconds], a
 
 ; minute
 	ccf ; carry is set, so turn it off
-	ld a, [hRTCMinutes] ; M
+	ldh a, [hRTCMinutes] ; M
 	ld c, a
 	ld a, [wStartMinute]
 	adc c
@@ -152,11 +152,11 @@ FixTime::
 	jr nc, .updatemin
 	add 60
 .updatemin
-	ld [hMinutes], a
+	ldh [hMinutes], a
 
 ; hour
 	ccf ; carry is set, so turn it off
-	ld a, [hRTCHours] ; H
+	ldh a, [hRTCHours] ; H
 	ld c, a
 	ld a, [wStartHour]
 	adc c
@@ -164,11 +164,11 @@ FixTime::
 	jr nc, .updatehr
 	add 24
 .updatehr
-	ld [hHours], a
+	ldh [hHours], a
 
 ; day
 	ccf ; carry is set, so turn it off
-	ld a, [hRTCDayLo] ; DL
+	ldh a, [hRTCDayLo] ; DL
 	ld c, a
 	ld a, [wStartDay]
 	adc c
@@ -184,11 +184,11 @@ InitTimeOfDay::
 
 InitDayOfWeek::
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [wStringBuffer2 + 1], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [wStringBuffer2 + 2], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [wStringBuffer2 + 3], a
 	jr InitTime ; useless
 
@@ -203,11 +203,11 @@ PanicResetClock::
 
 .ClearhRTC:
 	xor a
-	ld [hRTCSeconds], a
-	ld [hRTCMinutes], a
-	ld [hRTCHours], a
-	ld [hRTCDayLo], a
-	ld [hRTCDayHi], a
+	ldh [hRTCSeconds], a
+	ldh [hRTCMinutes], a
+	ldh [hRTCHours], a
+	ldh [hRTCDayLo], a
+	ldh [hRTCDayHi], a
 	ret
 
 SetClock::
@@ -233,23 +233,23 @@ SetClock::
 
 ; seconds
 	ld [hl], RTC_S
-	ld a, [hRTCSeconds]
+	ldh a, [hRTCSeconds]
 	ld [de], a
 ; minutes
 	ld [hl], RTC_M
-	ld a, [hRTCMinutes]
+	ldh a, [hRTCMinutes]
 	ld [de], a
 ; hours
 	ld [hl], RTC_H
-	ld a, [hRTCHours]
+	ldh a, [hRTCHours]
 	ld [de], a
 ; day lo
 	ld [hl], RTC_DL
-	ld a, [hRTCDayLo]
+	ldh a, [hRTCDayLo]
 	ld [de], a
 ; day hi
 	ld [hl], RTC_DH
-	ld a, [hRTCDayHi]
+	ldh a, [hRTCDayHi]
 	res 6, a ; make sure timer is active
 	ld [de], a
 

--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -1,5 +1,5 @@
 CheckTrainerBattle2::
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 
 	call SwitchToMapScriptsBank
@@ -93,7 +93,7 @@ CheckTrainerBattle::
 .startbattle
 	pop de
 	pop af
-	ld [hLastTalked], a
+	ldh [hLastTalked], a
 	ld a, b
 	ld [wEngineBuffer2], a
 	ld a, c
@@ -110,7 +110,7 @@ LoadTrainer_continue::
 	call GetMapScriptsBank
 	ld [wEngineBuffer1], a
 
-	ld a, [hLastTalked]
+	ldh a, [hLastTalked]
 	call GetMapObject
 
 	ld hl, MAPOBJECT_SCRIPT_POINTER

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -12,7 +12,7 @@ VBlank::
 	push de
 	push hl
 
-	ld a, [hVBlank]
+	ldh a, [hVBlank]
 	and 7
 
 	ld e, a
@@ -63,29 +63,29 @@ VBlank0::
 	inc [hl]
 
 	; advance random variables
-	ld a, [rDIV]
+	ldh a, [rDIV]
 	ld b, a
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	adc b
-	ld [hRandomAdd], a
+	ldh [hRandomAdd], a
 
-	ld a, [rDIV]
+	ldh a, [rDIV]
 	ld b, a
-	ld a, [hRandomSub]
+	ldh a, [hRandomSub]
 	sbc b
-	ld [hRandomSub], a
+	ldh [hRandomSub], a
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
-	ld a, [hSCX]
-	ld [rSCX], a
-	ld a, [hSCY]
-	ld [rSCY], a
-	ld a, [hWY]
-	ld [rWY], a
-	ld a, [hWX]
-	ld [rWX], a
+	ldh a, [hSCX]
+	ldh [rSCX], a
+	ldh a, [hSCY]
+	ldh [rSCY], a
+	ldh a, [hWY]
+	ldh [rWY], a
+	ldh a, [hWX]
+	ldh [rWX], a
 
 	; There's only time to call one of these in one vblank.
 	; Calls are in order of priority.
@@ -106,7 +106,7 @@ VBlank0::
 
 .done
 
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	and a
 	jr nz, .done_oam
 	call hTransferVirtualOAM
@@ -136,25 +136,25 @@ VBlank0::
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
 	call _UpdateSound
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 
-	ld a, [hSeconds]
-	ld [hSecondsBackup], a
+	ldh a, [hSeconds]
+	ldh [hSecondsBackup], a
 
 	ret
 
 VBlank2::
 ; sound only
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
 	call _UpdateSound
 
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 
 	xor a
@@ -169,13 +169,13 @@ VBlank1::
 ; oam
 ; sound / lcd stat
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
-	ld a, [hSCX]
-	ld [rSCX], a
-	ld a, [hSCY]
-	ld [rSCY], a
+	ldh a, [hSCX]
+	ldh [rSCX], a
+	ldh a, [hSCY]
+	ldh [rSCY], a
 
 	call UpdatePals
 	jr c, .done
@@ -190,57 +190,57 @@ VBlank1::
 	ld [wVBlankOccurred], a
 
 	; get requested ints
-	ld a, [rIF]
+	ldh a, [rIF]
 	ld b, a
 	; discard requested ints
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	; enable lcd stat
 	ld a, %10 ; lcd stat
-	ld [rIE], a
+	ldh [rIE], a
 	; rerequest serial int if applicable (still disabled)
 	; request lcd stat
 	ld a, b
 	and %1000 ; serial
 	or %10 ; lcd stat
-	ld [rIF], a
+	ldh [rIF], a
 
 	ei
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
 	call _UpdateSound
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 	di
 
 	; get requested ints
-	ld a, [rIF]
+	ldh a, [rIF]
 	ld b, a
 	; discard requested ints
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	; enable ints besides joypad
 	ld a, %1111 ; serial timer lcdstat vblank
-	ld [rIE], a
+	ldh [rIE], a
 	; rerequest ints
 	ld a, b
-	ld [rIF], a
+	ldh [rIF], a
 	ret
 
 UpdatePals::
 ; update pals for either dmg or cgb
 
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	jp nz, UpdateCGBPals
 
 	; update gb pals
 	ld a, [wBGP]
-	ld [rBGP], a
+	ldh [rBGP], a
 	ld a, [wOBP0]
-	ld [rOBP0], a
+	ldh [rOBP0], a
 	ld a, [wOBP1]
-	ld [rOBP1], a
+	ldh [rOBP1], a
 
 	and a
 	ret
@@ -253,15 +253,15 @@ VBlank3::
 ; oam
 ; sound / lcd stat
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
-	ld a, [hSCX]
-	ld [rSCX], a
-	ld a, [hSCY]
-	ld [rSCY], a
+	ldh a, [hSCX]
+	ldh [rSCX], a
+	ldh a, [hSCY]
+	ldh [rSCY], a
 
-	ld a, [hCGBPalUpdate]
+	ldh a, [hCGBPalUpdate]
 	and a
 	call nz, ForceUpdateCGBPals
 	jr c, .done
@@ -275,24 +275,24 @@ VBlank3::
 	xor a
 	ld [wVBlankOccurred], a
 
-	ld a, [rIF]
+	ldh a, [rIF]
 	push af
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %10 ; lcd stat
-	ld [rIE], a
-	ld [rIF], a
+	ldh [rIE], a
+	ldh [rIF], a
 
 	ei
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
 	call _UpdateSound
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 	di
 
 	; request lcdstat
-	ld a, [rIF]
+	ldh a, [rIF]
 	ld b, a
 	; and any other ints
 	pop af
@@ -300,13 +300,13 @@ VBlank3::
 	ld b, a
 	; reset ints
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	; enable ints besides joypad
 	ld a, %1111 ; serial timer lcdstat vblank
-	ld [rIE], a
+	ldh [rIE], a
 	; request ints
 	ld a, b
-	ld [rIF], a
+	ldh [rIF], a
 	ret
 
 VBlank4::
@@ -317,8 +317,8 @@ VBlank4::
 ; serial
 ; sound
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
 	call UpdateBGMap
 	call Serve2bppRequest
@@ -336,7 +336,7 @@ VBlank4::
 	rst Bankswitch
 	call _UpdateSound
 
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 	ret
 
@@ -348,11 +348,11 @@ VBlank5::
 ; joypad
 ;
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
-	ld a, [hSCX]
-	ld [rSCX], a
+	ldh a, [hSCX]
+	ldh [rSCX], a
 
 	call UpdatePalsIfCGB
 	jr c, .done
@@ -367,25 +367,25 @@ VBlank5::
 	call Joypad
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, %10 ; lcd stat
-	ld [rIE], a
+	ldh [rIE], a
 	; request lcd stat
-	ld [rIF], a
+	ldh [rIF], a
 
 	ei
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
 	call _UpdateSound
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 	di
 
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	; enable ints besides joypad
 	ld a, %1111 ; serial timer lcdstat vblank
-	ld [rIE], a
+	ldh [rIE], a
 	ret
 
 VBlank6::
@@ -394,8 +394,8 @@ VBlank6::
 ; dma transfer
 ; sound
 
-	ld a, [hROMBank]
-	ld [hROMBankBackup], a
+	ldh a, [hROMBank]
+	ldh [hROMBankBackup], a
 
 	; inc frame counter
 	ld hl, hVBlankCounter
@@ -416,6 +416,6 @@ VBlank6::
 	rst Bankswitch
 	call _UpdateSound
 
-	ld a, [hROMBankBackup]
+	ldh a, [hROMBankBackup]
 	rst Bankswitch
 	ret

--- a/home/video.asm
+++ b/home/video.asm
@@ -3,17 +3,17 @@
 DMATransfer::
 ; Return carry if the transfer is completed.
 
-	ld a, [hDMATransfer]
+	ldh a, [hDMATransfer]
 	and a
 	ret z
 
 ; Start transfer
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 ; Execution is halted until the transfer is complete.
 
 	xor a
-	ld [hDMATransfer], a
+	ldh [hDMATransfer], a
 	scf
 	ret
 
@@ -25,11 +25,11 @@ UpdateBGMapBuffer::
 
 ; Return carry on success.
 
-	ld a, [hBGMapUpdate]
+	ldh a, [hBGMapUpdate]
 	and a
 	ret z
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld [hSPBuffer], sp
 
@@ -50,7 +50,7 @@ rept 2
 
 ; Palettes
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld a, [hli]
 	ld [bc], a
@@ -61,7 +61,7 @@ rept 2
 
 ; Tiles
 	ld a, 0
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld a, [de]
 	inc de
@@ -73,35 +73,35 @@ rept 2
 endr
 
 ; We've done 2 16x8 blocks
-	ld a, [hBGMapTileCount]
+	ldh a, [hBGMapTileCount]
 	dec a
 	dec a
-	ld [hBGMapTileCount], a
+	ldh [hBGMapTileCount], a
 
 	jr nz, .next
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	xor a
-	ld [hBGMapUpdate], a
+	ldh [hBGMapUpdate], a
 	scf
 	ret
 
 WaitTop::
 ; Wait until the top third of the BG Map is being updated.
 
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	and a
 	ret z
 
-	ld a, [hBGMapThird]
+	ldh a, [hBGMapThird]
 	and a
 	jr z, .done
 
@@ -110,13 +110,13 @@ WaitTop::
 
 .done
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 UpdateBGMap::
 ; Update the BG Map, in thirds, from wTileMap and wAttrMap.
 
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	and a
 	ret z
 
@@ -129,18 +129,18 @@ UpdateBGMap::
 ; BG Map 1
 	dec a
 
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld l, a
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	push hl
 
 	xor a ; LOW(vBGMap1)
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	cp 3
 	call z, .Tiles
@@ -150,20 +150,20 @@ UpdateBGMap::
 
 	pop hl
 	ld a, l
-	ld [hBGMapAddress], a
+	ldh [hBGMapAddress], a
 	ld a, h
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ret
 
 .Attr:
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	hlcoord 0, 0, wAttrMap
 	call .update
 
 	ld a, 0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 .Tiles:
@@ -173,7 +173,7 @@ UpdateBGMap::
 	ld [hSPBuffer], sp
 
 ; Which third?
-	ld a, [hBGMapThird]
+	ldh a, [hBGMapThird]
 	and a ; 0
 	jr z, .top
 	dec a ; 1
@@ -187,9 +187,9 @@ THIRD_HEIGHT EQU SCREEN_HEIGHT / 3
 	add hl, de
 	ld sp, hl
 
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld l, a
 
 	ld de, 2 * THIRD_HEIGHT * BG_MAP_WIDTH
@@ -204,9 +204,9 @@ THIRD_HEIGHT EQU SCREEN_HEIGHT / 3
 	add hl, de
 	ld sp, hl
 
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld l, a
 
 	ld de, THIRD_HEIGHT * BG_MAP_WIDTH
@@ -219,9 +219,9 @@ THIRD_HEIGHT EQU SCREEN_HEIGHT / 3
 .top
 	ld sp, hl
 
-	ld a, [hBGMapAddress + 1]
+	ldh a, [hBGMapAddress + 1]
 	ld h, a
-	ld a, [hBGMapAddress]
+	ldh a, [hBGMapAddress]
 	ld l, a
 
 ; Next time: middle third
@@ -229,7 +229,7 @@ THIRD_HEIGHT EQU SCREEN_HEIGHT / 3
 
 .start
 ; Which third to update next time
-	ld [hBGMapThird], a
+	ldh [hBGMapThird], a
 
 ; Rows of tiles in a third
 	ld a, SCREEN_HEIGHT / 3
@@ -255,9 +255,9 @@ endr
 	dec a
 	jr nz, .row
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret
@@ -270,7 +270,7 @@ Serve1bppRequest::
 	ret z
 
 ; Back out if we're too far into VBlank
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	ret c
 	cp LY_VBLANK + 2
@@ -333,9 +333,9 @@ endr
 
 	ld [wRequested1bppSource], sp
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret
@@ -348,7 +348,7 @@ Serve2bppRequest::
 	ret z
 
 ; Back out if we're too far into VBlank
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	ret c
 	cp LY_VBLANK + 2
@@ -410,9 +410,9 @@ endr
 
 	ld [wRequested2bppSource], sp
 
-	ld a, [hSPBuffer]
+	ldh a, [hSPBuffer]
 	ld l, a
-	ld a, [hSPBuffer + 1]
+	ldh a, [hSPBuffer + 1]
 	ld h, a
 	ld sp, hl
 	ret
@@ -420,38 +420,38 @@ endr
 AnimateTileset::
 ; Only call during the first fifth of VBlank
 
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	and a
 	ret z
 
 ; Back out if we're too far into VBlank
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK
 	ret c
 	cp LY_VBLANK + 7
 	ret nc
 
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_AnimateTileset)
 	rst Bankswitch
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wTilesetAnim)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, 0
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	call _AnimateTileset
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	rst Bankswitch
 	ret

--- a/home/window.asm
+++ b/home/window.asm
@@ -1,6 +1,6 @@
 RefreshScreen::
 	call ClearWindowData
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(ReanchorBGMap_NoOAMUpdate) ; and BANK(LoadFonts_NoOAMUpdate)
 	rst Bankswitch
@@ -14,15 +14,15 @@ RefreshScreen::
 	ret
 
 CloseText::
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	call .CloseText
 
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ld hl, wVramState
 	res 6, [hl]
 	ret
@@ -30,14 +30,14 @@ CloseText::
 .CloseText:
 	call ClearWindowData
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call OverworldTextModeSwitch
 	call _OpenAndCloseMenu_HDMATransferTileMapAndAttrMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call SafeUpdateSprites
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call ReplaceKrisSprite
 	farcall ReturnFromMapSetupScript
 	farcall LoadOverworldFont
@@ -45,7 +45,7 @@ CloseText::
 
 OpenText::
 	call ClearWindowData
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(ReanchorBGMap_NoOAMUpdate) ; and BANK(LoadFonts_NoOAMUpdate)
 	rst Bankswitch
@@ -60,36 +60,36 @@ OpenText::
 	ret
 
 _OpenAndCloseMenu_HDMATransferTileMapAndAttrMap::
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	farcall OpenAndCloseMenu_HDMATransferTileMapAndAttrMap
 
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 SafeUpdateSprites::
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	push af
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 
 	call UpdateSprites
 
 	xor a
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call DelayFrame
 	pop af
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 ; unused

--- a/hram.asm
+++ b/hram.asm
@@ -1,132 +1,174 @@
-; HRAM uses constants instead of labels so that
-; "ld a, [hAddress]" and "ld [hAddress], a" will
-; use the more efficient "ldh" instruction.
+SECTION "HRAM", HRAM
 
-hTransferVirtualOAM           EQU $ff80 ; 10 bytes
+hTransferVirtualOAM:: ds 10 ; ff80
 
-hROMBankBackup     EQU $ff8a
-hBuffer            EQU $ff8b
-hFF8C              EQU $ff8c
-hRTCDayHi          EQU $ff8d
-hRTCDayLo          EQU $ff8e
-hRTCHours          EQU $ff8f
-hRTCMinutes        EQU $ff90
-hRTCSeconds        EQU $ff91
+hROMBankBackup:: db ; ff8a
+hBuffer:: db ; ff8b
+hFF8C:: db ; ff8c
 
-hHours             EQU $ff94
+hRTCDayHi::   db ; ff8d
+hRTCDayLo::   db ; ff8e
+hRTCHours::   db ; ff8f
+hRTCMinutes:: db ; ff90
+hRTCSeconds:: db ; ff91
 
-hMinutes           EQU $ff96
+	ds 2
 
-hSeconds           EQU $ff98
+hHours:: db ; ff94
+	ds 1
+hMinutes:: db ; ff96
+	ds 1
+hSeconds:: db ; ff98
+	ds 1
 
-hVBlankCounter     EQU $ff9b
+	ds 1
 
-hROMBank           EQU $ff9d
-hVBlank            EQU $ff9e
-hMapEntryMethod    EQU $ff9f
-hMenuReturn        EQU $ffa0
+hVBlankCounter:: db ; ff9b
 
-hJoypadReleased    EQU $ffa2
-hJoypadPressed     EQU $ffa3
-hJoypadDown        EQU $ffa4
-hJoypadSum         EQU $ffa5
-hJoyReleased       EQU $ffa6
-hJoyPressed        EQU $ffa7
-hJoyDown           EQU $ffa8
-hJoyLast           EQU $ffa9
-hInMenu            EQU $ffaa
+	ds 1
 
-hPrinter           EQU $ffac
-hGraphicStartTile  EQU $ffad
-hMoveMon           EQU $ffae
+hROMBank:: db ; ff9d
+hVBlank:: db ; ff9e
+hMapEntryMethod:: db ; ff9f
+hMenuReturn:: db ; ffa0
 
-hMapObjectIndexBuffer    EQU $ffaf
-hObjectStructIndexBuffer EQU $ffb0
+	ds 1
 
-hConnectionStripLength EQU $ffaf
-hConnectedMapWidth EQU $ffb0
+hJoypadReleased:: db ; ffa2
+hJoypadPressed::  db ; ffa3
+hJoypadDown::     db ; ffa4
+hJoypadSum::      db ; ffa5
+hJoyReleased::    db ; ffa6
+hJoyPressed::     db ; ffa7
+hJoyDown::        db ; ffa8
+hJoyLast::        db ; ffa9
 
-hPastLeadingZeroes EQU $ffb3
+hInMenu:: db ; ffaa
 
-hEnemyMonSpeed  EQU $ffb1
-hPartyMon1Speed EQU $ffb5
+	ds 1
 
-hDividend          EQU $ffb3 ; length in b register, before 'call Divide' (max 4 bytes)
-hDivisor           EQU $ffb7 ; 1 byte long
-hQuotient          EQU $ffb4 ; result (3 bytes long)
-hRemainder         EQU $ffb7
+hPrinter:: db ; ffac
+hGraphicStartTile:: db ; ffad
+hMoveMon:: db ; ffae
 
-hMultiplicand      EQU $ffb4 ; 3 bytes long
-hMultiplier        EQU $ffb7 ; 1 byte long
-hProduct           EQU $ffb3 ; result (4 bytes long)
+UNION ; ffaf
+hMapObjectIndexBuffer:: db ; ffaf
+hObjectStructIndexBuffer:: db ; ffb0
+NEXTU ; ffaf
+hConnectionStripLength:: db ; ffaf
+hConnectedMapWidth:: db ; ffb0
+ENDU ; ffb1
 
-hMathBuffer        EQU $ffb8
+hEnemyMonSpeed:: dw ; ffb1
 
-hPrintNum1         EQU $ffb3
-hPrintNum2         EQU $ffb4
-hPrintNum3         EQU $ffb5
-hPrintNum4         EQU $ffb6
-hPrintNum5         EQU $ffb7
-hPrintNum6         EQU $ffb8
-hPrintNum7         EQU $ffb9
-hPrintNum8         EQU $ffba
-hPrintNum9         EQU $ffbb
-hPrintNum10        EQU $ffbc
+UNION ; ffb3
+	ds 2
+hPartyMon1Speed:: dw ; ffb5
 
-hMGStatusFlags     EQU $ffbc
+NEXTU ; ffb3
 
-hUsedSpriteIndex   EQU $ffbd
-hUsedSpriteTile    EQU $ffbe
-hFFBF              EQU $ffbf
-hFFC0              EQU $ffc0
-hFFC1              EQU $ffc1
-hFFC2              EQU $ffc2
-hMoneyTemp         EQU $ffc3
+UNION ; ffb3
+hDividend:: ds 4 ; ffb3
+hDivisor:: db ; ffb7
+NEXTU ; ffb3
+	ds 1
+hQuotient:: ds 3 ; ffb4
+hRemainder:: db ; ffb7
+NEXTU ; ffb3
+	ds 1
+hMultiplicand:: ds 3 ; ffb4
+hMultiplier:: db ; ffb7
+NEXTU ; ffb3
+hProduct:: ds 4 ; ffb3
+ENDU ; ffb8
 
-hMGJoypadPressed   EQU $ffc3
-hMGJoypadReleased  EQU $ffc4
+hMathBuffer:: ds 5 ; ffb8
 
-hLCDCPointer       EQU $ffc6
-hLYOverrideStart   EQU $ffc7
-hLYOverrideEnd     EQU $ffc8
+NEXTU ; ffb3
 
-hMobileReceive             EQU $ffc9
-hSerialReceivedNewData     EQU $ffca
-hSerialConnectionStatus    EQU $ffcb
-hSerialIgnoringInitialData EQU $ffcc
-hSerialSend                EQU $ffcd
-hSerialReceive             EQU $ffce
+hPrintNum1::  db ; ffb3
+hPrintNum2::  db ; ffb4
+hPrintNum3::  db ; ffb5
+hPrintNum4::  db ; ffb6
+hPrintNum5::  db ; ffb7
+hPrintNum6::  db ; ffb8
+hPrintNum7::  db ; ffb9
+hPrintNum8::  db ; ffba
+hPrintNum9::  db ; ffbb
+hPrintNum10:: db ; ffbc
 
-hSCX               EQU $ffcf
-hSCY               EQU $ffd0
-hWX                EQU $ffd1
-hWY                EQU $ffd2
-hTilesPerCycle     EQU $ffd3
-hBGMapMode         EQU $ffd4
-hBGMapThird        EQU $ffd5
-hBGMapAddress      EQU $ffd6
+NEXTU ; ffb3
 
-hOAMUpdate         EQU $ffd8
-hSPBuffer          EQU $ffd9
+	ds 9
+hMGStatusFlags:: db ; ffbc
+ENDU ; ffbd
 
-hBGMapUpdate       EQU $ffdb
-hBGMapTileCount    EQU $ffdc
+hUsedSpriteIndex:: db ; ffbd
+hUsedSpriteTile::  db ; ffbe
+hFFBF::            db ; ffbf
+hFFC0::            db ; ffc0
+hFFC1::            db ; ffc1
+hFFC2::            db ; ffc2
 
-hMapAnims          EQU $ffde
-hTileAnimFrame     EQU $ffdf
+UNION ; ffc3
+hMoneyTemp:: ds 3 ; ffc3
+NEXTU ; ffc3
+hMGJoypadPressed::  db ; ffc3
+hMGJoypadReleased:: db ; ffc4
+ENDU ; ffc6
 
-hLastTalked        EQU $ffe0
+hLCDCPointer::     db ; ffc6
+hLYOverrideStart:: db ; ffc7
+hLYOverrideEnd::   db ; ffc8
 
-hRandom            EQU $ffe1
-hRandomAdd         EQU $ffe1
-hRandomSub         EQU $ffe2
-hSecondsBackup     EQU $ffe3
-hBattleTurn        EQU $ffe4 ; Which trainers turn is it? 0: Player, 1: Opponent Trainer
-hCGBPalUpdate      EQU $ffe5
-hCGB               EQU $ffe6
-hSGB               EQU $ffe7
-hDMATransfer       EQU $ffe8
-hMobile            EQU $ffe9
-hSystemBooted      EQU $ffea
-hClockResetTrigger EQU $ffeb
-hFFEC              EQU $ffec
+hMobileReceive::             db ; ffc9
+hSerialReceivedNewData::     db ; ffca
+hSerialConnectionStatus::    db ; ffcb
+hSerialIgnoringInitialData:: db ; ffcc
+hSerialSend::                db ; ffcd
+hSerialReceive::             db ; ffce
+
+hSCX::           db ; ffcf
+hSCY::           db ; ffd0
+hWX::            db ; ffd1
+hWY::            db ; ffd2
+hTilesPerCycle:: db ; ffd3
+hBGMapMode::     db ; ffd4
+hBGMapThird::    db ; ffd5
+hBGMapAddress::  db ; ffd6
+
+	ds 1
+
+hOAMUpdate:: db ; ffd8
+
+hSPBuffer::  dw ; ffd9
+
+hBGMapUpdate::    db ; ffdb
+hBGMapTileCount:: db ; ffdc
+
+	ds 1
+
+hMapAnims::      db ; ffde
+hTileAnimFrame:: db ; ffdf
+
+hLastTalked:: db ; ffe0
+
+hRandom::
+hRandomAdd:: db ; ffe1
+hRandomSub:: db ; ffe2
+
+hSecondsBackup:: db ; ffe3
+
+hBattleTurn:: ; ffe4
+; Which trainer's turn is it? 0: player, 1: opponent trainer
+	db
+
+hCGBPalUpdate:: db ; ffe5
+hCGB::          db ; ffe6
+hSGB::          db ; ffe7
+
+hDMATransfer:: db ; ffe8
+hMobile:: db ; ffe9
+hSystemBooted:: db ; ffea
+hClockResetTrigger:: db ; ffeb
+hFFEC:: db ; ffec

--- a/lib/mobile/main.asm
+++ b/lib/mobile/main.asm
@@ -185,14 +185,14 @@ Function1100b4:
 
 Function1100dc:
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld e, c
 	ld b, a
 	ld hl, Unknown_112089
 	add hl, bc
 	ld c, [hl]
 	inc hl
-	ld a, [rKEY1]
+	ldh a, [rKEY1]
 	bit 7, a
 	jr nz, .asm_1100f9
 	ld a, e
@@ -205,8 +205,8 @@ Function1100dc:
 
 .asm_1100f9
 	ld a, c
-	ld [rTMA], a
-	ld [rTIMA], a
+	ldh [rTMA], a
+	ldh [rTIMA], a
 	ld a, [hli]
 	ld [$c81f], a
 	ld [$c816], a
@@ -400,10 +400,10 @@ Function110236:
 	push bc
 	push hl
 	xor a
-	ld [rTAC], a
-	ld a, [rIF]
+	ldh [rTAC], a
+	ldh a, [rIF]
 	and $1b
-	ld [rIF], a
+	ldh [rIF], a
 	call Function110029
 	ld bc, $0452
 	ld hl, $c800
@@ -470,7 +470,7 @@ Function110291:
 
 .asm_1102b3
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	xor a
 	ld [$c819], a
 	ld a, l
@@ -554,7 +554,7 @@ Function11032c:
 	cp $1
 	jp nz, Function110226
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld [$c819], a
 	ld hl, $c880
 	ld a, e
@@ -653,7 +653,7 @@ Function1103ac:
 
 .asm_1103d6
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld [$c86d], a
 	ld [$c97a], a
 	ld a, [$c870]
@@ -719,7 +719,7 @@ Function110438:
 
 .asm_110454
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld [$c97a], a
 	ld a, [$c870]
 	ld c, a
@@ -902,7 +902,7 @@ Function110596:
 	ld a, b
 	ld [$cb36], a
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld a, e
 	ld [$c86e], a
 	ld a, d
@@ -935,7 +935,7 @@ Function1105dd:
 	cp $1
 	jp nz, Function110226
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld a, [$c870]
 	ld c, a
 	call Function1100dc
@@ -3249,7 +3249,7 @@ Function111541:
 
 .asm_111582
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld a, [$c870]
 	ld c, a
 	call Function1100dc
@@ -3414,7 +3414,7 @@ Function111664:
 
 Function111686:
 	xor a
-	ld [rTAC], a
+	ldh [rTAC], a
 	ld c, $ff
 	ld a, [$ff00+c]
 	and $f3
@@ -3477,7 +3477,7 @@ _MobileReceive::
 	jp nz, Function1118bc
 	ld hl, $c808
 	add hl, de
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld [hl], a
 	ld a, $8
 	cp l
@@ -3648,7 +3648,7 @@ Function1117e7:
 .asm_111803
 	ld b, $66
 .asm_111805
-	ld a, [rSB]
+	ldh a, [rSB]
 	cp b
 	jr z, .asm_111840
 	cp $d2
@@ -3715,7 +3715,7 @@ Function11186e:
 	jr nz, Function1118bc
 	xor a
 	ld [hli], a
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld [$c80c], a
 	inc [hl]
 	or a
@@ -3734,7 +3734,7 @@ Function111884:
 	jr Function1118bc
 
 Function111892:
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld c, a
 	call Function111664
 	ld hl, $c80a
@@ -3765,7 +3765,7 @@ Function1118bc:
 	ret
 
 Function1118c2:
-	ld a, [rSB]
+	ldh a, [rSB]
 	ld c, a
 	ld b, $0
 	ld hl, $c812
@@ -3965,7 +3965,7 @@ asm_111a40:
 	ld a, $4b
 
 Function111a42:
-	ld [rSB], a
+	ldh [rSB], a
 	jp Function111b2e
 asm_111a47:
 	ld hl, $c815
@@ -4092,7 +4092,7 @@ Function111b21:
 	ld e, a
 	ld d, [hl]
 	ld a, [de]
-	ld [rSB], a
+	ldh [rSB], a
 	inc de
 	ld a, d
 	ld [hld], a
@@ -4102,9 +4102,9 @@ Function111b2e:
 	ld hl, $c822
 	set 1, [hl]
 	ld a, $3
-	ld [rSC], a
+	ldh [rSC], a
 	ld a, $83
-	ld [rSC], a
+	ldh [rSC], a
 
 Function111b3b:
 	ret
@@ -4683,7 +4683,7 @@ Function111f07:
 	scf
 	ret
 .asm_111f17
-	ld a, [rSC]
+	ldh a, [rSC]
 	and $80
 	jr nz, .asm_111f17
 	di

--- a/macros/rst.asm
+++ b/macros/rst.asm
@@ -15,7 +15,7 @@ callfar: MACRO ; address, bank
 ENDM
 
 homecall: MACRO
-	ld a, [hROMBank]
+	ldh a, [hROMBank]
 	push af
 	ld a, BANK(\1)
 	rst Bankswitch

--- a/maps/BattleTowerHallway.asm
+++ b/maps/BattleTowerHallway.asm
@@ -20,16 +20,16 @@ BattleTowerHallway_MapScripts:
 	jump .WalkToChosenBattleRoom
 
 .asm_load_battle_room
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wBTChoiceOfLvlGroup)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wBTChoiceOfLvlGroup]
 	ld [wScriptVar], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 ; enter different rooms for different levels to battle against

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -561,7 +561,7 @@ Function11c3c2:
 
 Function11c3ed:
 	ld hl, wcd20 ; wcd20
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and $8
 	jr nz, .asm_11c426
@@ -726,7 +726,7 @@ Function11c52c:
 
 Function11c53d:
 	ld hl, wcd21
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 
 	ld a, [de]
 	and START
@@ -935,7 +935,7 @@ Function11c658:
 
 Function11c675:
 	ld hl, wMobileCommsJumptableIndex
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and A_BUTTON
 	jr nz, .a
@@ -1507,7 +1507,7 @@ Function11c9bd:
 
 Function11c9c3:
 	ld hl, wcd2a
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and $1
 	jr nz, .asm_11c9de
@@ -1650,7 +1650,7 @@ Function11caad:
 
 Function11cab3:
 	ld hl, wcd2a
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and $1
 	jr nz, .asm_11cace
@@ -1743,7 +1743,7 @@ Function11cb52:
 
 Function11cb66:
 	ld hl, wcd2a
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and $1
 	jr nz, .asm_11cb81
@@ -1898,7 +1898,7 @@ Function11ccef:
 	call Function11cfb5
 
 Function11cd04:
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and a
 	ret z
@@ -1934,7 +1934,7 @@ Function11cd20:
 
 Function11cd54:
 	ld hl, wcd2c
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and A_BUTTON
 	jr nz, .asm_11cd6f
@@ -2039,7 +2039,7 @@ Function11ce2b:
 	ld hl, Unknown_11ceb9
 	add hl, bc
 
-	ld de, hJoypadPressed ; $ffa3
+	ld de, hJoypadPressed
 	ld a, [de]
 	and START
 	jr nz, .start

--- a/mobile/fixed_words.asm
+++ b/mobile/fixed_words.asm
@@ -218,10 +218,10 @@ GetLengthOfWordAtC608:
 	jr .loop
 
 CopyMobileEZChatToC608:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, "@"
 	ld hl, $c608
 	ld bc, NAME_LENGTH
@@ -256,7 +256,7 @@ CopyMobileEZChatToC608:
 	call CopyBytes
 	ld de, $c608
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .get_name
@@ -268,24 +268,24 @@ CopyMobileEZChatToC608:
 	jr .copy_string
 
 Function11c1ab:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call Function11c1b9
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function11c1b9:
 	call .InitKanaMode
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call EZChat_MasterLoop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .InitKanaMode:
@@ -323,16 +323,16 @@ Function11c1b9:
 	farcall ClearSpriteAnims
 	farcall LoadPokemonData
 	farcall Pokedex_ABCMode
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, $c6d0
 	ld de, wLYOverrides
 	ld bc, $100
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call EZChat_GetCategoryWordsByKana
 	call EZChat_GetSeenPokemonByKana
 	ret
@@ -367,8 +367,8 @@ EZChat_ClearBottom12Rows:
 EZChat_MasterLoop:
 .loop
 	call JoyTextDelay
-	ld a, [hJoyPressed]
-	ld [hJoypadPressed], a
+	ldh a, [hJoyPressed]
+	ldh [hJoypadPressed], a
 	ld a, [wJumptableIndex]
 	bit 7, a
 	jr nz, .exit
@@ -1338,13 +1338,13 @@ BCD2String:
 	inc a
 	push af
 	and $f
-	ld [hDividend], a
+	ldh [hDividend], a
 	pop af
 	and $f0
 	swap a
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	xor a
-	ld [hDividend + 2], a
+	ldh [hDividend + 2], a
 	push hl
 	farcall Function11a80c
 	pop hl
@@ -2863,16 +2863,16 @@ AnimateEZChatCursor:
 	ret
 
 Function11d323:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_11d33a
 	ld de, wBGPals1
 	ld bc, 16 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_11d33a:
@@ -2957,7 +2957,7 @@ Palette_11d33a:
 	RGB 00, 00, 00
 
 EZChat_GetSeenPokemonByKana:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld hl, $c648
 	ld a, LOW(w5_d800)
@@ -3014,21 +3014,21 @@ EZChat_GetSeenPokemonByKana:
 .loop1
 ; copy 2*bc bytes from 3:hl to 5:de
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [hli]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	ld [de], a
 	inc de
 
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [hli]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	ld [de], a
 	inc de
@@ -3130,7 +3130,7 @@ EZChat_GetSeenPokemonByKana:
 
 .ExitMasterLoop:
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 .CheckSeenMon:
@@ -3151,10 +3151,10 @@ EZChat_GetSeenPokemonByKana:
 	ret
 
 EZChat_GetCategoryWordsByKana:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	; load pointers
 	ld hl, MobileEZChatCategoryPointers
@@ -3231,7 +3231,7 @@ EZChat_GetCategoryWordsByKana:
 	dec a
 	jr nz, .loop1
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 INCLUDE "data/pokemon/ezchat_order.asm"

--- a/mobile/mobile_12.asm
+++ b/mobile/mobile_12.asm
@@ -371,7 +371,7 @@ Function48304:
 	call ExitMenu
 	call ExitMenu
 	pop af
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit 0, a
 	jr z, .asm_48377
 	call Function483bb
@@ -812,10 +812,10 @@ Function4876f:
 	call PlaceString
 	ld hl, MenuHeader_0x48509
 	call LoadMenuHeader
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	hlcoord 10, 5
 	ld b, $1
 	ld c, $8
@@ -861,7 +861,7 @@ Function4876f:
 	hlcoord 11, 6
 	call Function487ec
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	jp Function4840c
 
 Function487ec:
@@ -891,10 +891,10 @@ String_4880d:
 	db "@"
 
 Function4880e:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jp nz, Function488b9
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and B_BUTTON
 	jp nz, Function488b4
 	ld hl, hJoyLast
@@ -1012,10 +1012,10 @@ Function488d3:
 	jp c, Function4840c
 	ld hl, MenuHeader_0x4850e
 	call LoadMenuHeader
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	hlcoord 10, 9
 	ld b, $1
 	ld c, $8
@@ -1042,7 +1042,7 @@ Function488d3:
 asm_48922:
 	push bc
 	call JoyTextDelay
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and a
 	jp z, Function4896e
 	bit 0, a
@@ -1073,7 +1073,7 @@ asm_48922:
 	jr asm_48972
 
 Function4895a:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and a
 	jr z, .asm_48965
 	pop bc
@@ -1082,7 +1082,7 @@ Function4895a:
 	jr asm_48972
 
 .asm_48965
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and a
 	jr z, asm_48972
 
@@ -1159,7 +1159,7 @@ asm_48972:
 	lb bc, 1, 8
 	call ClearBox
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	jp Function4840c
 
 Function489ea:
@@ -1258,10 +1258,10 @@ String_48aa1:
 	next "Tell Later@"
 
 Function48ab5:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON
 	jp nz, Function48c0f
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and B_BUTTON
 	jp nz, Function48c0d
 	ld a, d
@@ -1746,8 +1746,8 @@ Function48d4a:
 	add c
 	ld [hld], a
 	xor a
-	ld [hMultiplicand + 0], a
-	ld [hMultiplicand + 1], a
+	ldh [hMultiplicand + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
 	srl a
 	srl a
@@ -1759,13 +1759,13 @@ Function48d4a:
 	ld a, [hli]
 	and $f
 	add b
-	ld [hMultiplicand + 2], a
+	ldh [hMultiplicand + 2], a
 	ld a, 100
-	ld [hMultiplier], a
+	ldh [hMultiplier], a
 	call Multiply
-	ld a, [hProduct + 2]
+	ldh a, [hProduct + 2]
 	ld b, a
-	ld a, [hProduct + 3]
+	ldh a, [hProduct + 3]
 	ld c, a
 	ld e, [hl]
 	add e
@@ -1780,17 +1780,17 @@ Function48d4a:
 
 Function48d94:
 	xor a
-	ld [hDividend + 0], a
-	ld [hDividend + 1], a
+	ldh [hDividend + 0], a
+	ldh [hDividend + 1], a
 	ld a, [hli]
-	ld [hDividend + 0], a
+	ldh [hDividend + 0], a
 	ld a, [hl]
-	ld [hDividend + 1], a
+	ldh [hDividend + 1], a
 	ld a, 100
-	ld [hDivisor], a
+	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ld a, [hRemainder]
+	ldh a, [hRemainder]
 	ld c, 10
 	call SimpleDivide
 	sla b
@@ -1799,7 +1799,7 @@ Function48d94:
 	sla b
 	or b
 	ld [hld], a
-	ld a, [hQuotient + 2]
+	ldh a, [hQuotient + 2]
 	ld c, 10
 	call SimpleDivide
 	sla b

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -424,15 +424,15 @@ Function4aad3:
 
 	ld c, a
 	xor a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 .loop
 	push bc
 	push hl
 	ld e, MONICON_PARTYMENU
 	farcall LoadMenuMonIcon
-	ld a, [hObjectStructIndexBuffer]
+	ldh a, [hObjectStructIndexBuffer]
 	inc a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	pop hl
 	pop bc
 	dec c
@@ -686,7 +686,7 @@ Function4ac58:
 
 .asm_4ac96
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Function4acaa
 	call ExitMenu
 	and a
@@ -728,7 +728,7 @@ Function4acaa:
 	call StaticMenuJoypad
 	ld de, SFX_READ_TEXT_2
 	call PlaySFX
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit 0, a
 	jr nz, .asm_4acf4
 	bit 1, a

--- a/mobile/mobile_22.asm
+++ b/mobile/mobile_22.asm
@@ -190,12 +190,12 @@ Mobile22_ButtonSound:
 
 Mobile22_SetBGMapMode0:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Mobile22_SetBGMapMode1:
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Function89245:
@@ -585,16 +585,16 @@ Function89492:
 	ret
 
 Function8949c:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_894b3
 	ld de, wBGPals1 palette 7
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_894b3:
@@ -624,10 +624,10 @@ Function894ca:
 
 Function894dc:
 	push bc
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld c, d
 	ld b, 0
@@ -646,7 +646,7 @@ Function894dc:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	ret
 
@@ -732,17 +732,17 @@ Function8956f:
 	farcall GetMobileOTTrainerClass
 	ld a, c
 	ld [wTrainerClass], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wd030
 	ld a, -1
 	ld [hli], a
 	ld a, " "
 	ld [hl], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wTrainerClass]
 	ld h, 0
 	ld l, a
@@ -750,10 +750,10 @@ Function8956f:
 	add hl, hl
 	ld de, TrainerPalettes
 	add hl, de
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, wd032
 	ld c, 4
 .loop
@@ -769,21 +769,21 @@ Function8956f:
 	ld [hli], a
 	ld [hl], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	ret
 
 Function895c7:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_895de
 	ld de, wd030
 	ld bc, 8
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_895de:
@@ -1184,7 +1184,7 @@ Function897d5:
 
 .asm_897f3
 	ld a, $37
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	hlcoord 12, 3
 	lb bc, 7, 7
 	predef PlaceGraphic
@@ -2038,10 +2038,10 @@ Function89cdf:
 
 Function89d0d:
 	call Mobile22_SetBGMapMode0
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld c, 8
 	ld de, wBGPals1
@@ -2060,7 +2060,7 @@ Function89d0d:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call SetPalettes
 	farcall PrintMail
@@ -2266,16 +2266,16 @@ Function89e6f:
 	jp Function89e36
 
 Function89e9a:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_89eb1
 	ld de, wBGPals1 palette 5
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_89eb1:
@@ -3235,10 +3235,10 @@ Function8a5a3:
 	ret
 
 Function8a5b6:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_8a5e5
 	ld de, wBGPals1 + 4 palettes
 	ld bc, 3 palettes
@@ -3252,7 +3252,7 @@ Function8a5b6:
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_8a5e5:
@@ -3284,16 +3284,16 @@ Palette_8a605:
 	RGB 31, 31, 31
 
 Function8a60d:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_8a624
 	ld de, wOBPals1
 	ld bc, 1 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_8a624:

--- a/mobile/mobile_22_2.asm
+++ b/mobile/mobile_22_2.asm
@@ -257,7 +257,7 @@ Function8b45c:
 	call Function8b4fd
 	call Function89c44
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	pop bc
 	call Function8b3dd
 	jr nc, .asm_8b46e
@@ -593,16 +593,16 @@ Function8b690:
 	ret
 
 Function8b6bb:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_8b6d5
 	ld de, wBGPals1
 	ld bc, 3 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function8949c
 	ret
 

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -4,10 +4,10 @@ Function100000:
 ; d: 1 or 2
 ; e: bank
 ; bc: addr
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call Function100022
 	call Function1000ba
@@ -21,7 +21,7 @@ Function100000:
 	pop bc
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function100022:
@@ -62,11 +62,11 @@ SetRAMStateForMobile:
 	ld hl, wc300
 	ld bc, $100
 	call ByteFill
-	ld a, [rIE]
+	ldh a, [rIE]
 	ld [wBGMapBuffer], a
 	xor a
-	ld [hMapAnims], a
-	ld [hLCDCPointer], a
+	ldh [hMapAnims], a
+	ldh [hLCDCPointer], a
 	ret
 
 EnableMobile:
@@ -78,15 +78,15 @@ EnableMobile:
 	di
 	call DoubleSpeed
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, 1 << VBLANK | 1 << LCD_STAT | 1 << TIMER | 1 << SERIAL
-	ld [rIE], a
+	ldh [rIE], a
 	xor a
-	ld [hMapAnims], a
-	ld [hLCDCPointer], a
+	ldh [hMapAnims], a
+	ldh [hLCDCPointer], a
 	ld a, $01
-	ld [hMobileReceive], a
-	ld [hMobile], a
+	ldh [hMobileReceive], a
+	ldh [hMobile], a
 	ei
 
 	ret
@@ -94,15 +94,15 @@ EnableMobile:
 DisableMobile:
 	di
 	xor a
-	ld [hMobileReceive], a
-	ld [hMobile], a
+	ldh [hMobileReceive], a
+	ldh [hMobile], a
 	xor a
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call NormalSpeed
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, [wBGMapBuffer]
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 	ret
 
@@ -160,13 +160,13 @@ Function1000fa:
 .asm_100117
 	di
 	xor a
-	ld [rIF], a
-	ld a, [rIE]
+	ldh [rIF], a
+	ldh a, [rIE]
 	and $13
-	ld [rIE], a
+	ldh [rIE], a
 	xor a
-	ld [hMobileReceive], a
-	ld [hMobile], a
+	ldh [hMobileReceive], a
+	ldh [hMobile], a
 	ei
 
 	ld a, [wLinkMode]
@@ -311,15 +311,15 @@ Function10020b:
 	call HideSprites
 	call DelayFrame
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $01
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	farcall DisplayMobileError
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function100232:
@@ -401,10 +401,10 @@ Function1002c9:
 
 Function1002dc:
 	ld a, MAPSETUP_LINKRETURN
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	farcall RunMapSetupScript
 	xor a
-	ld [hMapEntryMethod], a
+	ldh [hMapEntryMethod], a
 	call LoadStandardFont
 	ret
 
@@ -412,7 +412,7 @@ Function1002ed:
 	farcall LoadOW_BGPal7
 	farcall ApplyPals
 	ld a, $01
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	call DelayFrame
 	ret
 
@@ -989,11 +989,11 @@ IncrementMobileInactivityTimerByCFrames:
 Function100665:
 	call UpdateTime
 	ld hl, wcd36
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [hli], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [hli], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [hl], a
 	ret
 
@@ -1062,7 +1062,7 @@ Function1006d3:
 Function1006dc:
 	ld a, [hld]
 	ld c, a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	sub c
 	jr nc, .asm_1006e5
 	add $3c
@@ -1072,7 +1072,7 @@ Function1006dc:
 	dec de
 	ld a, [hld]
 	ld c, a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	sbc c
 	jr nc, .asm_1006f0
 	add $3c
@@ -1082,7 +1082,7 @@ Function1006dc:
 	dec de
 	ld a, [hl]
 	ld c, a
-	ld a, [hHours]
+	ldh a, [hHours]
 	sbc c
 	jr nc, .asm_1006fb
 	add $18
@@ -1119,11 +1119,11 @@ Function100720:
 	xor a
 	ld [wcd6a], a
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [wcd72], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [wcd73], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [wcd74], a
 	ld a, $04
 	ld hl, $a800
@@ -1141,11 +1141,11 @@ Function100720:
 
 Function100754:
 	call UpdateTime
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [wcd72], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [wcd73], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [wcd74], a
 	ld a, [wcd6d]
 	ld [wcd6b], a
@@ -1256,11 +1256,11 @@ Function1007f6:
 	call CloseSRAM
 	ld hl, wcd6e
 	call Function100826
-	ld a, [hHours]
+	ldh a, [hHours]
 	ld [wcd72], a
-	ld a, [hMinutes]
+	ldh a, [hMinutes]
 	ld [wcd73], a
-	ld a, [hSeconds]
+	ldh a, [hSeconds]
 	ld [wcd74], a
 	ret
 
@@ -1372,24 +1372,24 @@ Function1008a6:
 	ret
 
 Function1008e0:
-	ld a, [hBGMapMode]
+	ldh a, [hBGMapMode]
 	ld b, a
-	ld a, [hVBlank]
+	ldh a, [hVBlank]
 	ld c, a
 	push bc
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld a, $03
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	call Function100970
 	call Function100902
 	call Function100989
 	call DelayFrame
 	pop bc
 	ld a, c
-	ld [hVBlank], a
+	ldh [hVBlank], a
 	ld a, b
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 Function100902:
@@ -1462,10 +1462,10 @@ Function1009a5:
 	ret
 
 Function1009ae:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $03
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, w3_d800
 	decoord 0, 0, wAttrMap
@@ -1486,19 +1486,19 @@ Function1009ae:
 	jr nz, .loop_row
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function1009d2:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $03
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $01
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, w3_d800
 	debgcoord 0, 0
@@ -1506,14 +1506,14 @@ Function1009d2:
 	call Get2bpp
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function1009f3:
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and SELECT + A_BUTTON
 	cp SELECT + A_BUTTON
 	jr nz, .select_a
@@ -1768,7 +1768,7 @@ MobileMoveSelectionScreen:
 
 .GetMoveSelection:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Function100c74
 	call Function100c98
 .master_loop
@@ -1923,7 +1923,7 @@ Mobile_PartyMenuSelect:
 	cp b
 	jr z, .done
 	ld [wPartyMenuCursor], a
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	ld b, a
 	bit 1, b
 	jr nz, .done
@@ -1993,7 +1993,7 @@ Function100d67:
 	ld hl, .MenuHeader
 	call CopyMenuHeader
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call MenuBox
 	call UpdateSprites
 	call PlaceVerticalMenuItems
@@ -2215,7 +2215,7 @@ Function100eca:
 Function100ed4:
 	farcall ApplyPals
 	ld a, $01
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 Function100edf:
@@ -2993,7 +2993,7 @@ asm_101416
 
 Function101418:
 	call GetJoypad
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and SELECT + A_BUTTON
 	cp SELECT + A_BUTTON
 	jr z, .asm_101425
@@ -3088,7 +3088,7 @@ Function1014a6:
 
 Function1014b7:
 	call GetJoypad
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and $03
 	jr nz, .asm_1014c5
 	ld hl, wcd42
@@ -3719,7 +3719,7 @@ Function101913:
 	ld hl, wcd29
 	res 7, [hl]
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, [wcd21]
 	cp $01
 	jr z, .asm_10193f
@@ -3807,17 +3807,17 @@ _StartMobileBattle:
 	ret
 
 .CopyOTDetails:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, 5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld bc, w5_dc0d
 	ld de, w5_dc11
 	farcall GetMobileOTTrainerClass
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld a, c
 	ld [wOtherTrainerClass], a
@@ -3831,7 +3831,7 @@ _StartMobileBattle:
 	jr z, .got_link_player_number
 	ld a, USING_EXTERNAL_CLOCK
 .got_link_player_number
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 	ret
 
 StartMobileBattle:
@@ -3850,7 +3850,7 @@ StartMobileBattle:
 	xor a
 	ld [wDisableTextAcceleration], a
 	ld a, CONNECTION_NOT_ESTABLISHED
-	ld [hSerialConnectionStatus], a
+	ldh [hSerialConnectionStatus], a
 	pop af
 	ld [wOptions], a
 	ret
@@ -5239,7 +5239,7 @@ Function1024de:
 	ld hl, wcd4e
 	dec [hl]
 	jr z, .asm_1024e9
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON
 	ret z
 
@@ -5528,7 +5528,7 @@ Function1026de:
 	ret
 
 Function1026f3:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit A_BUTTON_F, a
 	jr nz, .asm_102723
 	bit D_UP_F, a
@@ -5612,7 +5612,7 @@ Function102775:
 	ret
 
 Function10278c:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit A_BUTTON_F, a
 	jr nz, asm_1027c6
 	bit B_BUTTON_F, a
@@ -5637,7 +5637,7 @@ Function1027a0:
 	ret
 
 Function1027b7:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit A_BUTTON_F, a
 	jr nz, asm_1027d1
 	bit B_BUTTON_F, a
@@ -6535,7 +6535,7 @@ Function102e4f:
 	push de
 	push hl
 	ld a, c
-	ld [hDividend], a
+	ldh [hDividend], a
 	call GetPokemonName
 	pop hl
 	call PlaceString
@@ -6717,12 +6717,12 @@ Function10305d:
 
 Function10306e:
 	ld a, $01
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call ClearSprites
 	ld de, wVirtualOAM
 	call Function1030cd
 	xor a
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 Function10307f:
@@ -6928,7 +6928,7 @@ Function103302:
 
 Function103309:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wBuffer1
 	ld bc, 10
 	xor a
@@ -7014,7 +7014,7 @@ Function10339a:
 
 Function1033af:
 	call GetJoypad
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	bit D_LEFT_F, a
 	jr nz, .left
 	bit D_RIGHT_F, a

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -105,7 +105,7 @@ StubbedTrainerRankings_BugContestScore:
 	ret
 	ld a, BANK(sTrainerRankingBugContestScore)
 	call GetSRAMBank
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	ld hl, sTrainerRankingBugContestScore
 	cp [hl]
 	jr z, .isLowByteHigher
@@ -114,15 +114,15 @@ StubbedTrainerRankings_BugContestScore:
 
 .isLowByteHigher
 	inc hl
-	ld a, [hMultiplicand]
+	ldh a, [hMultiplicand]
 	cp [hl]
 	jr c, .done
 	dec hl
 
 .newHighScore
-	ld a, [hProduct]
+	ldh a, [hProduct]
 	ld [hli], a
-	ld a, [hMultiplicand]
+	ldh a, [hMultiplicand]
 	ld [hl], a
 
 .done
@@ -375,7 +375,7 @@ StubbedTrainerRankings_LinkBattles:
 StubbedTrainerRankings_Splash:
 	ret
 	; Only counts if it’s the player’s turn
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ret nz
 	ld hl, sTrainerRankingSplash
@@ -410,7 +410,7 @@ StubbedTrainerRankings_ColosseumDraws: ; draw
 StubbedTrainerRankings_Selfdestruct:
 	ret
 	; Only counts if it’s the player’s turn
-	ld a, [hBattleTurn]
+	ldh a, [hBattleTurn]
 	and a
 	ret nz
 	ld hl, sTrainerRankingSelfdestruct
@@ -586,9 +586,9 @@ _MobilePrintNum::
 ; hl: where to print the converted string
 	push bc
 	xor a
-	ld [hPrintNum1], a
-	ld [hPrintNum2], a
-	ld [hPrintNum3], a
+	ldh [hPrintNum1], a
+	ldh [hPrintNum2], a
+	ldh [hPrintNum3], a
 	ld a, b
 	and $f
 	cp $1
@@ -599,29 +599,29 @@ _MobilePrintNum::
 	jr z, .three_bytes
 ; four bytes
 	ld a, [de]
-	ld [hPrintNum1], a
+	ldh [hPrintNum1], a
 	inc de
 
 .three_bytes
 	ld a, [de]
-	ld [hPrintNum2], a
+	ldh [hPrintNum2], a
 	inc de
 
 .two_bytes
 	ld a, [de]
-	ld [hPrintNum3], a
+	ldh [hPrintNum3], a
 	inc de
 
 .one_byte
 	ld a, [de]
-	ld [hPrintNum4], a
+	ldh [hPrintNum4], a
 	inc de
 
 	push de
 	xor a
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 	ld a, b
-	ld [hPrintNum10], a
+	ldh [hPrintNum10], a
 	ld a, c
 	cp 2
 	jr z, .two_digits
@@ -668,7 +668,7 @@ endr
 
 .two_digits
 	ld c, 0
-	ld a, [hPrintNum4]
+	ldh a, [hPrintNum4]
 .mod_ten_loop
 	cp 10
 	jr c, .simple_divide_done
@@ -678,9 +678,9 @@ endr
 
 .simple_divide_done
 	ld b, a
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	or c
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 	jr nz, .create_digit
 	call .LoadMinusTenIfNegative
 	jr .done
@@ -714,53 +714,53 @@ endr
 	ld a, [de]
 	dec de
 	ld b, a
-	ld a, [hPrintNum4]
+	ldh a, [hPrintNum4]
 	sub b
-	ld [hPrintNum8], a
+	ldh [hPrintNum8], a
 	ld a, [de]
 	dec de
 	ld b, a
-	ld a, [hPrintNum3]
+	ldh a, [hPrintNum3]
 	sbc b
-	ld [hPrintNum7], a
+	ldh [hPrintNum7], a
 	ld a, [de]
 	dec de
 	ld b, a
-	ld a, [hPrintNum2]
+	ldh a, [hPrintNum2]
 	sbc b
-	ld [hPrintNum6], a
+	ldh [hPrintNum6], a
 	ld a, [de]
 	inc de
 	inc de
 	inc de
 	ld b, a
-	ld a, [hPrintNum1]
+	ldh a, [hPrintNum1]
 	sbc b
-	ld [hPrintNum5], a
+	ldh [hPrintNum5], a
 	jr c, .asm_1062eb
-	ld a, [hPrintNum5]
-	ld [hPrintNum1], a
-	ld a, [hPrintNum6]
-	ld [hPrintNum2], a
-	ld a, [hPrintNum7]
-	ld [hPrintNum3], a
-	ld a, [hPrintNum8]
-	ld [hPrintNum4], a
+	ldh a, [hPrintNum5]
+	ldh [hPrintNum1], a
+	ldh a, [hPrintNum6]
+	ldh [hPrintNum2], a
+	ldh a, [hPrintNum7]
+	ldh [hPrintNum3], a
+	ldh a, [hPrintNum8]
+	ldh [hPrintNum4], a
 	inc c
 	jr .asm_1062b4
 
 .asm_1062eb
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	or c
 	jr z, .LoadMinusTenIfNegative
 	ld a, -10
 	add c
 	ld [hl], a
-	ld [hPrintNum9], a
+	ldh [hPrintNum9], a
 	ret
 
 .LoadMinusTenIfNegative:
-	ld a, [hPrintNum10]
+	ldh a, [hPrintNum10]
 	bit 7, a
 	ret z
 
@@ -768,12 +768,12 @@ endr
 	ret
 
 .Function1062ff:
-	ld a, [hPrintNum10]
+	ldh a, [hPrintNum10]
 	bit 7, a
 	jr nz, .asm_10630d
 	bit 6, a
 	jr z, .asm_10630d
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	and a
 	ret z
 
@@ -988,8 +988,8 @@ Function106442:
 	ld a, $36
 	call Function3e32
 	xor a
-	ld [hMobile], a
-	ld [hMobileReceive], a
+	ldh [hMobile], a
+	ldh [hMobileReceive], a
 	ld a, [wMobileCommsJumptableIndex]
 	inc a
 	ld [wMobileCommsJumptableIndex], a
@@ -1048,10 +1048,10 @@ Function10649b:
 	ret
 
 Function1064c3:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push bc
 	push hl
 	ld hl, Function3f88
@@ -1060,14 +1060,14 @@ Function1064c3:
 	pop hl
 	pop bc
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr asm_1064ed
 
 Function1064d8:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push bc
 	push hl
 	ld hl, Function3f9f
@@ -1076,25 +1076,25 @@ Function1064d8:
 	pop hl
 	pop bc
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr asm_1064ed
 
 asm_1064ed
 	ld de, wDecompressScratch
 	ld b, $0
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $6
-	ld [rSVBK], a
-	ld a, [rVBK]
+	ldh [rSVBK], a
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	call Get2bpp
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function10650a:

--- a/mobile/mobile_42.asm
+++ b/mobile/mobile_42.asm
@@ -82,10 +82,10 @@ RunMobileTradeAnim_Frontpics:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld hl, wVramState
 	ld a, [hl]
 	push af
@@ -103,7 +103,7 @@ RunMobileTradeAnim_Frontpics:
 	pop af
 	ld [wVramState], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 RunMobileTradeAnim_NoFrontpics:
@@ -111,10 +111,10 @@ RunMobileTradeAnim_NoFrontpics:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	ld a, [hMapAnims]
+	ldh a, [hMapAnims]
 	push af
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld hl, wVramState
 	ld a, [hl]
 	push af
@@ -132,7 +132,7 @@ RunMobileTradeAnim_NoFrontpics:
 	pop af
 	ld [wVramState], a
 	pop af
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ret
 
 Function1080b7:
@@ -148,13 +148,13 @@ Function1080b7:
 	call LoadFontsBattleExtra
 
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108da7
 	ld de, vTiles2
 	call Decompress
 
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108d27
 	ld de, vTiles0 tile $20
 	call Decompress
@@ -162,12 +162,12 @@ Function1080b7:
 	call EnableLCD
 
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 
 	call DelayFrame
@@ -223,12 +223,12 @@ Function108157:
 	call LoadFontsBattleExtra
 	call EnableLCD
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ClearSpriteAnims
 	xor a
 	ld hl, wSpriteAnimDict
@@ -248,13 +248,13 @@ Function108157:
 
 MobileTradeAnim_ClearTiles:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles0
 	ld bc, 3 * $80 tiles
 	xor a
 	call ByteFill
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles0
 	ld bc, 3 * $80 tiles
 	xor a
@@ -263,13 +263,13 @@ MobileTradeAnim_ClearTiles:
 
 MobileTradeAnim_ClearBGMap:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlbgcoord 0, 0
 	ld bc, 2 * BG_MAP_HEIGHT * BG_MAP_WIDTH
 	ld a, $0
 	call ByteFill
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	hlbgcoord 0, 0
 	ld bc, 2 * BG_MAP_HEIGHT * BG_MAP_WIDTH
 	ld a, $7f
@@ -337,12 +337,12 @@ MobileTradeAnim_JumptableLoop:
 
 .StopAnim:
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call LoadStandardFont
 	call LoadFontsBattleExtra
 	farcall Stubbed_Function106462
@@ -450,13 +450,13 @@ MobileTradeAnim_ShowPlayerMonToBeSent:
 	ld de, MUSIC_EVOLUTION
 	call PlayMusic2
 	ld a, $80
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $87
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	call MobileTradeAnim_DisplayMonToBeSent
 	ld a, [wPlayerTrademonSpecies]
 	ld [wCurPartySpecies], a
@@ -471,22 +471,22 @@ MobileTradeAnim_ShowPlayerMonToBeSent:
 	call DmgToCgbBGPals
 	call WaitBGMap
 .loop
-	ld a, [hWX]
+	ldh a, [hWX]
 	cp $7
 	jr z, .okay
 	sub $4
-	ld [hWX], a
-	ld a, [hSCX]
+	ldh [hWX], a
+	ldh a, [hSCX]
 	sub $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	jr .loop
 
 .okay
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, [wPlayerTrademonSpecies]
 	call GetCryIndex
 	jr c, .skip_cry
@@ -526,12 +526,12 @@ MobileTradeAnim_ShowOTMonFromTrade:
 	call EnableLCD
 	farcall DeinitializeAllSprites
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_MOBILE_TRADE_OT_BALL
 	call _InitSpriteAnimStruct
@@ -545,12 +545,12 @@ MobileTradeAnim_ShowOTMonFromTrade:
 	call PlaySFX
 	call MobileTradeAnim_DisplayReceivedMon
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, [wOTTrademonSpecies]
 	ld [wCurPartySpecies], a
 	ld a, [wOTTrademonDVs]
@@ -573,13 +573,13 @@ MobileTradeAnim_ShowPlayerMonForGTS:
 	ld de, MUSIC_EVOLUTION
 	call PlayMusic2
 	ld a, $80
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $87
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	call MobileTradeAnim_DisplayMonToBeSent
 	ld a, [wPlayerTrademonSpecies]
 	ld [wCurPartySpecies], a
@@ -604,22 +604,22 @@ MobileTradeAnim_ShowPlayerMonForGTS:
 	call DmgToCgbBGPals
 	call WaitBGMap
 .loop
-	ld a, [hWX]
+	ldh a, [hWX]
 	cp $7
 	jr z, .done
 	sub $4
-	ld [hWX], a
-	ld a, [hSCX]
+	ldh [hWX], a
+	ldh a, [hSCX]
 	sub $4
-	ld [hSCX], a
+	ldh [hSCX], a
 	call DelayFrame
 	jr .loop
 
 .done
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, [wPlayerTrademonSpecies]
 	call GetCryIndex
 	jr c, .skip_cry
@@ -668,12 +668,12 @@ MobileTradeAnim_ShowOTMonFromGTS:
 	lb bc, BANK(TradePoofGFX), 12
 	call Request2bpp
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_MOBILE_TRADE_OT_BALL
 	call _InitSpriteAnimStruct
@@ -687,12 +687,12 @@ MobileTradeAnim_ShowOTMonFromGTS:
 	call PlaySFX
 	call MobileTradeAnim_DisplayReceivedMon
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, [wOTTrademonSpecies]
 	ld [wCurPartySpecies], a
 	ld a, [wOTTrademonDVs]
@@ -736,12 +736,12 @@ MobileTradeAnim_GetOddEgg:
 	lb bc, BANK(TradePoofGFX), 12
 	call Request2bpp
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_MOBILE_TRADE_OT_BALL
 	call _InitSpriteAnimStruct
@@ -755,12 +755,12 @@ MobileTradeAnim_GetOddEgg:
 	call PlaySFX
 	call Function108a33
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $50
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, [wOTTrademonSpecies]
 	ld [wCurPartySpecies], a
 	ld a, [wOTTrademonDVs]
@@ -786,30 +786,30 @@ MobileTradeAnim_02:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DisableLCD
 	call MobileTradeAnim_ClearBGMap
 	call Function108c80
 	call Function108c6d
 	call EnableLCD
 	ld a, $c
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $78
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
-	ld a, [rSVBK]
+	ldh [hWY], a
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_109107
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function108d07
 	call Function108af4
 	call GetMobileTradeAnimByte
@@ -821,16 +821,16 @@ MobileTradeAnim_10:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DisableLCD
 	call MobileTradeAnim_ClearBGMap
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108da7
 	ld de, vTiles2
 	call Decompress
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108d27
 	ld de, vTiles0 tile $20
 	call Decompress
@@ -838,23 +838,23 @@ MobileTradeAnim_10:
 	call Function108c6d
 	call EnableLCD
 	ld a, $c
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $78
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
-	ld a, [rSVBK]
+	ldh [hWY], a
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_109107
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function108d07
 	call Function108af4
 	call GetMobileTradeAnimByte
@@ -865,15 +865,15 @@ MobileTradeAnim_11:
 	call ClearSprites
 	call ClearTileMap
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DisableLCD
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108da7
 	ld de, vTiles2
 	call Decompress
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_108d27
 	ld de, vTiles0 tile $20
 	call Decompress
@@ -881,28 +881,28 @@ MobileTradeAnim_11:
 	call Function108c6d
 	call EnableLCD
 	ld a, $80
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $90
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $90
-	ld [hWY], a
-	ld a, [rSVBK]
+	ldh [hWY], a
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_109107
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function108d07
 	call Function108af4
 	call Function108b5a
 	ld a, $e0
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld de, MUSIC_EVOLUTION
 	call PlayMusic2
 	call GetMobileTradeAnimByte
@@ -916,12 +916,12 @@ MobileTradeAnim_GiveTrademon1:
 	call Function1082f0
 	call Function108af4
 .loop
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	cp $e0
 	jr z, .loop2
 	dec a
 	dec a
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp $f8
 	jr nz, .next
 	depixel 10, 11, 4, 0
@@ -934,12 +934,12 @@ MobileTradeAnim_GiveTrademon1:
 	jr .loop
 
 .loop2
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	cp $f8
 	jr z, .done
 	dec a
 	dec a
-	ld [hSCY], a
+	ldh [hSCY], a
 	cp $40
 	jr z, .init
 	cp $30
@@ -992,11 +992,11 @@ MobileTradeAnim_GiveTrademon2:
 	ld a, SPRITE_ANIM_INDEX_MOBILE_TRADE_SENT_PULSE
 	call _InitSpriteAnimStruct
 .loop
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	cp $90
 	jr z, .done
 	sub $8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld c, 1
 	call WaitMobileTradeSpriteAnims
 	jr .loop
@@ -1047,11 +1047,11 @@ MobileTradeAnim_GetTrademon1:
 	ld c, 40
 	call WaitMobileTradeSpriteAnims
 .loop
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	cp $f8
 	jr z, .done
 	add $8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld c, 1
 	call WaitMobileTradeSpriteAnims
 	jr .loop
@@ -1078,12 +1078,12 @@ MobileTradeAnim_GetTrademon2:
 	call Function1082fa
 	call Function108af4
 .asm_1088ad
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	cp $78
 	jr z, .asm_1088ee
 	inc a
 	inc a
-	ld [hSCY], a
+	ldh [hSCY], a
 	cp $30
 	jr z, .asm_1088c5
 	cp $40
@@ -1118,12 +1118,12 @@ MobileTradeAnim_GetTrademon2:
 	jr .asm_1088ad
 
 .asm_1088ee
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	cp $c
 	jr z, .asm_108906
 	inc a
 	inc a
-	ld [hSCX], a
+	ldh [hSCX], a
 	cp -8
 	jr nz, .asm_1088e7
 	call MobileTradeAnim_DeleteSprites
@@ -1159,7 +1159,7 @@ MobileTradeAnim_0f:
 
 MobileTradeAnim_FadeToBlack:
 .loop
-	ld a, [rBGP]
+	ldh a, [rBGP]
 	and a
 	jr z, .blank
 	sla a
@@ -1192,7 +1192,7 @@ asm_108966
 	call MobileTradeAnim_ClearTilemap
 	hlcoord 7, 2
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	call WaitBGMap
@@ -1205,7 +1205,7 @@ Function10898a:
 	call MobileTradeAnim_ClearTilemap
 	hlcoord 7, 2
 	xor a
-	ld [hGraphicStartTile], a
+	ldh [hGraphicStartTile], a
 	lb bc, 7, 7
 	predef PlaceGraphic
 	call WaitBGMap
@@ -1251,7 +1251,7 @@ MobileTradeAnim_DisplayEggData:
 	call WaitTop
 	call MobileTradeAnim_ClearTilemap
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 5, 0
 	ld b, 6
 	ld c, 9
@@ -1272,7 +1272,7 @@ Function108a33:
 	call WaitTop
 	call MobileTradeAnim_ClearTilemap
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 5, 0
 	ld b, 6
 	ld c, 9
@@ -1290,7 +1290,7 @@ MobileTradeAnim_LoadMonTemplate:
 	call WaitTop
 	call MobileTradeAnim_ClearTilemap
 	ld a, HIGH(vBGMap1)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	hlcoord 4, 0
 	ld b,  6
 	ld c, 10
@@ -1311,7 +1311,7 @@ MobileTradeAnim_MonDisplay_UpdateBGMap:
 	call WaitBGMap
 	call WaitTop
 	ld a, HIGH(vBGMap0)
-	ld [hBGMapAddress + 1], a
+	ldh [hBGMapAddress + 1], a
 	ret
 
 MobileTradeAnim_MonDisplay_PrintSpeciesNumber:
@@ -1371,20 +1371,20 @@ Function108ad4:
 	ld de, GFX_1091c7
 .asm_108adf
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, vTiles2 tile $4a
 	lb bc, BANK(GFX_1092c7), 16
 	call Get2bpp_2
 	call DelayFrame
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 Function108af4:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcf65]
 	and $1
 	jr z, .copy_palette_109147
@@ -1410,7 +1410,7 @@ Function108af4:
 
 .done_copy
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, %11100100 ; 3,2,1,0
 	call DmgToCgbObjPal0
 	ld a, %11100100 ; 3,2,1,0
@@ -1419,10 +1419,10 @@ Function108af4:
 	ret
 
 Function108b45:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, PALRGB_WHITE
 	ld hl, wBGPals1
 	ld a, e
@@ -1430,14 +1430,14 @@ Function108b45:
 	ld d, a
 	ld [hli], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function108b5a:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, palred 18 + palgreen 31 + palblue 15
 	ld hl, wBGPals2 + 4 palettes
 	ld c, $10
@@ -1449,16 +1449,16 @@ Function108b5a:
 	dec c
 	jr nz, .loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 Function108b78:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, c
 	and $2
 	jr z, .Orange
@@ -1473,9 +1473,9 @@ Function108b78:
 	ld a, d
 	ld [hld], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 Palette_108b98:
@@ -1483,10 +1483,10 @@ Palette_108b98:
 
 Function108b98:
 	ld d, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcf65]
 	and $1
 	xor d
@@ -1501,7 +1501,7 @@ Function108b98:
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 MobileTradeAnim_DeleteSprites:
@@ -1538,7 +1538,7 @@ Function108be0:
 
 Function108bec:
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld hl, .PlayerWillTradeMon
 	call PrintText
 	ld c, 80
@@ -1563,7 +1563,7 @@ Function108bec:
 
 Function108c16:
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld hl, .TakeGoodCareOfMon
 	call PrintText
 	ld c, 80
@@ -1576,7 +1576,7 @@ Function108c16:
 
 Function108c2b:
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld hl, .PlayersMonTrade
 	call PrintText
 	ld c, 80
@@ -1589,7 +1589,7 @@ Function108c2b:
 
 Function108c40:
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, [wcf65]
 	and %10000000
 	jr z, .Getmon
@@ -1625,7 +1625,7 @@ Function108c6d:
 
 Function108c80:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, LZ_1090a7
 	debgcoord 0, 0
 	call Decompress
@@ -1633,7 +1633,7 @@ Function108c80:
 	debgcoord 0, 0, vBGMap1
 	call Decompress
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 DebugMobileTrade:

--- a/mobile/mobile_45.asm
+++ b/mobile/mobile_45.asm
@@ -6748,7 +6748,7 @@ Function117764:
 	xor a
 .asm_117770
 	ld [wcd24], a
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and SELECT
 	jr nz, Function117764_select

--- a/mobile/mobile_45.asm
+++ b/mobile/mobile_45.asm
@@ -128,7 +128,7 @@ String_114232:
 Function114243::
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
-	ld a, [hFF8C]
+	ldh a, [hFF8C]
 	push af ; if [$dc02] == 0, this is popped to pc.
 	push de
 	ld a, [$dc02]
@@ -146,8 +146,8 @@ Function114243::
 Function11425c:
 	ld [$dc02], a
 	pop af
-	ld [hFF8C], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ret
 
@@ -162,7 +162,7 @@ Function114269:
 	ld [$dc03], a
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -359,7 +359,7 @@ Function11433c:
 	pop bc
 	ld a, [$dc03]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	call Function114c0b
 	ld hl, String_114004
@@ -417,7 +417,7 @@ Function1143b7:
 	push af
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld h, [hl]
@@ -472,7 +472,7 @@ Function1143f3:
 Function114412:
 	ld a, c
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, Unknown_11417f
 	ld a, b
@@ -659,7 +659,7 @@ Function1144d1:
 	pop hl
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -676,7 +676,7 @@ Function1144d1:
 	ld hl, $dc06
 	ld a, [hl]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, $dc09
 	ld e, [hl]
@@ -734,7 +734,7 @@ Function114576:
 	jr nz, .asm_1145b4
 	ld a, h
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	push hl
 	push de
@@ -752,7 +752,7 @@ Function114576:
 	jr nz, .asm_1145ba
 	ld a, h
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, String_114218
 	call Function114acf
@@ -924,7 +924,7 @@ Function11463c:
 	pop de
 	pop af
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	xor a
 	ld [wDecoCarpet], a
@@ -945,7 +945,7 @@ Function1146a4:
 	ld hl, $dc03
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -959,7 +959,7 @@ Function1146a4:
 	ld hl, $dc03
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1002,7 +1002,7 @@ Function1146fa:
 	ld hl, $dc03
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1016,7 +1016,7 @@ Function1146fa:
 	ld a, $1
 	ld [$dc0e], a
 	ld a, [$dc00]
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, $1
 	ld [wDecoRightOrnament], a
@@ -1043,7 +1043,7 @@ Function1146fa:
 	ld hl, $dc03
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1097,7 +1097,7 @@ Function1146fa:
 	ld hl, $dc03
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	call Function114a7a
 	and a
@@ -1207,7 +1207,7 @@ Function114843:
 	ld a, [$dc00]
 	push af
 	push de
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	call Function114a18
 	and a
@@ -1230,7 +1230,7 @@ Function114867:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1295,7 +1295,7 @@ Function1148c2:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1393,7 +1393,7 @@ Function11494d:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1483,7 +1483,7 @@ Function1149cc:
 	ld hl, $dc06
 	ld a, [hl]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	push de
 	ld hl, $dc09
@@ -1830,7 +1830,7 @@ endr
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -1868,7 +1868,7 @@ Function114bbc:
 	jr nz, .asm_114bff
 	ld a, h
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	call Function114c0b
 	ld hl, $dc24
@@ -1879,7 +1879,7 @@ Function114bbc:
 	pop hl
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -2085,7 +2085,7 @@ Function114cd9:
 	ld [$dc04], a
 	ld a, h
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, $dc24
 	call Function114d39
@@ -2104,7 +2104,7 @@ endr
 	pop hl
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -2402,7 +2402,7 @@ Function114ea0:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -2602,7 +2602,7 @@ Function114f59:
 	inc hl
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -2680,7 +2680,7 @@ Function115020:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -2737,7 +2737,7 @@ Function115062:
 	ld c, a
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -2888,7 +2888,7 @@ Function115136:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -2941,7 +2941,7 @@ Function115179:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -3059,7 +3059,7 @@ Function115217:
 	ld hl, $dc06
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -3152,7 +3152,7 @@ Function11528f:
 	inc hl
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, [hli]
 	ld e, a
@@ -3401,7 +3401,7 @@ Function1153d2:
 .asm_1153f5
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -3535,7 +3535,7 @@ Function1153d2:
 	ld hl, wDecoRightOrnament
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -3768,7 +3768,7 @@ Function11560a:
 	ld [wCurrMapBGEventCount], a
 	ld a, [$dc17]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, $dc1a
 	ld c, [hl]
@@ -3841,7 +3841,7 @@ Function11560a:
 	ld [hl], d
 	pop bc
 	ld a, [wCurrMapBGEventCount]
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld hl, wCurrMapSceneScriptCount
 	ld e, [hl]
@@ -4147,7 +4147,7 @@ Function11581e:
 	ld hl, $dc02
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -4201,7 +4201,7 @@ Function11581e:
 	ld hl, wCurrMapSceneScriptCount
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -4668,7 +4668,7 @@ Function115b00:
 	ld hl, $dc02
 	ld a, [hli]
 	ld [$dc00], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -4756,7 +4756,7 @@ Function115b00:
 	ld hl, wCurrMapSceneScriptCount
 	ld a, [hli]
 	ld [wCurrMapBGEventCount], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld e, [hl]
 	inc hl
@@ -5149,7 +5149,7 @@ Function115d80:
 	ld a, [bc]
 	inc a
 	ld [bc], a
-	ld [hFF8C], a
+	ldh [hFF8C], a
 	ld [MBC3SRamBank], a
 	ld a, e
 	ld d, $a0
@@ -5337,7 +5337,7 @@ Function11665c:
 .asm_116675
 	ld [wc30f], a
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $7
 	sla a
 	sla a
@@ -5413,7 +5413,7 @@ Function1166f4:
 	ld hl, wc30f
 .asm_116702
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $7
 	jr z, .asm_11670c
 	dec a
@@ -5439,7 +5439,7 @@ Function11671f:
 	ld hl, wc30e
 .asm_11672d
 	call Random
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	and $7
 	sla a
 	sla a
@@ -6618,21 +6618,21 @@ GiveOddEgg:
 	ret
 
 Function11765d:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call Function11766b
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function11766b:
 	call Function117699
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function1176ee
 	ld a, $5
 	call GetSRAMBank
@@ -6645,7 +6645,7 @@ Function11766b:
 	call CopyBytes
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function117699:
@@ -6964,7 +6964,7 @@ Function1178aa:
 	jp MobilePassword_IncrementJumptable
 
 Function1178e8:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	cp B_BUTTON
 	jr z, .b_button
 	cp A_BUTTON
@@ -7111,13 +7111,13 @@ INCBIN "data/mobile/ascii-sym.txt"
 ; Mobile Stadium option from the continue/newgame menu.
 ; Needs better function names
 MobileStudium:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call Function117a8d
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function117a8d:
@@ -7215,7 +7215,7 @@ Function117b31:
 	jp MobileStudium_JumptableIncrement
 
 Function117b4f:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	cp B_BUTTON
 	jr z, .b_button
 	cp A_BUTTON
@@ -7272,7 +7272,7 @@ Function117b4f:
 Function117bb6:
 	call Function117c89
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	farcall Function118284
 	call ClearSprites
 	ld a, [wc300]
@@ -7294,10 +7294,10 @@ Function117bb6:
 	ret
 
 .asm_117be7
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd89]
 	and $1
 	jr nz, .asm_117c16
@@ -7322,19 +7322,19 @@ Function117bb6:
 
 .asm_117c16
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $d3
 	ld [wc300], a
 	jr .asm_117bd0
 
 .asm_117c20
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall Function172eb9
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $7
 	call GetSRAMBank
 	ld hl, w3_d002
@@ -7343,7 +7343,7 @@ Function117bb6:
 	call CopyBytes
 	call CloseSRAM
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jp MobileStudium_JumptableIncrement
 
 Function117c4a:
@@ -7354,10 +7354,10 @@ Function117c4a:
 	farcall ReloadMapPart
 	ld hl, MobileStadiumSuccessText
 	call PrintText
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1
 	ld de, 1 palettes
 	ld c, 8
@@ -7373,7 +7373,7 @@ Function117c4a:
 	jr nz, .loop
 	call RotateThreePalettesRight
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $80
 	ld [wJumptableIndex], a
 	ret

--- a/mobile/mobile_45_sprite_engine.asm
+++ b/mobile/mobile_45_sprite_engine.asm
@@ -375,11 +375,11 @@ Function1161b8:
 	dw Function116441
 
 Function1161d5:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, Unknown_117356
 	ld de, wDecompressScratch
@@ -390,86 +390,86 @@ Function1161d5:
 
 .wait_for_vblank
 ; Wait until a vblank would occur had interrupts not just been disabled.
-	ld a, [rLY]
+	ldh a, [rLY]
 	cp LY_VBLANK + 1
 	jr nz, .wait_for_vblank
 
 	ld a, $d0
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $0
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1c
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	xor a
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	ld a, $d0
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $80
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1c
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, $80
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	ld a, $d1
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $0
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1d
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	xor a
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld a, $d1
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $80
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1c
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	xor a
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	ld a, $d2
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $0
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1c
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	ld a, $80
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	ld a, $d2
-	ld [rHDMA1], a
+	ldh [rHDMA1], a
 	ld a, $80
-	ld [rHDMA2], a
+	ldh [rHDMA2], a
 	ld a, $1d
-	ld [rHDMA3], a
+	ldh [rHDMA3], a
 	xor a
-	ld [rHDMA4], a
+	ldh [rHDMA4], a
 	ld a, $8
-	ld [rHDMA5], a
+	ldh [rHDMA5], a
 
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ei
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	farcall ReloadMapPart
 	ld a, $8
@@ -495,10 +495,10 @@ Function116294:
 	ld a, [$c319]
 	inc a
 	ld [$c319], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1 palette 6
 	ld de, $c320
 	ld bc, 2 palettes
@@ -509,9 +509,9 @@ Function116294:
 	call CopyBytes
 	call SetPalettes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $30
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 Function1162cb:
@@ -519,17 +519,17 @@ Function1162cb:
 	ld a, [$c319]
 	inc a
 	ld [$c319], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_11730e
 	ld de, wOBPals1 + 2 palettes
 	ld bc, 6 palettes
 	call CopyBytes
 	call SetPalettes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function1162f2:
@@ -622,30 +622,30 @@ Function1162f2:
 	ret
 
 Function11636e:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals2
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call SetPalettes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $a0
 	ld hl, wVirtualOAM
 	ld bc, 16 * SPRITEOAMSTRUCT_LENGTH
 	call ByteFill
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call UpdateSprites
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall ReloadMapPart
 	ld a, $8
 	ld [wMusicFade], a
@@ -659,10 +659,10 @@ Function11636e:
 	ret
 
 Function1163c0:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $a0
 	ld hl, wVirtualOAM
 	ld bc, 16 * SPRITEOAMSTRUCT_LENGTH
@@ -671,24 +671,24 @@ Function1163c0:
 	farcall Function14146
 	ld b, SCGB_MAPPALS
 	call GetSGBLayout
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, $c320
 	ld de, wd030
 	ld bc, $0010
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call SetPalettes
 	call DelayFrame
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call UpdateSprites
 	farcall Function14157
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall ReloadMapPart
 	ld a, [wLinkMode]
 	cp $4
@@ -718,7 +718,7 @@ Function1163c0:
 Function116441:
 	farcall Function17d405
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	farcall ReloadMapPart
 	ld a, $8
 	ld [wMusicFade], a

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -17,10 +17,10 @@ asm_11800b
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .loop
 	call JoyTextDelay
 	call Function118473
@@ -41,7 +41,7 @@ asm_11800b
 	cp [hl]
 	jr nz, .loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call ReturnToMapFromSubmenu
 BattleTowerRoomMenu_DoNothing:
@@ -57,10 +57,10 @@ Function11805f:
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_11807d
 	call JoyTextDelay
 	call Function118473
@@ -81,7 +81,7 @@ Function11805f:
 	cp [hl]
 	jr nz, .asm_11807d
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call ReturnToMapFromSubmenu
 	ret
@@ -94,10 +94,10 @@ Function1180b8:
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_1180d1
 	call JoyTextDelay
 	call Function118473
@@ -126,7 +126,7 @@ Function1180b8:
 	cp [hl]
 	jr nz, .asm_1180d1
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call ReturnToMapFromSubmenu
 	ret
@@ -147,10 +147,10 @@ Function118125:
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .loop
 	call JoyTextDelay
 	call Function118473
@@ -172,7 +172,7 @@ Function118125:
 	xor a
 	ld [w3_d000], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call Function118180
 	call ReturnToMapFromSubmenu
@@ -192,10 +192,10 @@ Function118180:
 	ld bc, $0016
 	call CopyBytes
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld de, w3_d202
 	ld c, $96
@@ -213,7 +213,7 @@ Function118180:
 	call CopyBytes
 .reset_banks
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	ret
 
@@ -233,10 +233,10 @@ Function1181da:
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_1181f8
 	call JoyTextDelay
 	call Function118473
@@ -257,7 +257,7 @@ Function1181da:
 	cp [hl]
 	jr nz, .asm_1181f8
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call ReturnToMapFromSubmenu
 	ret
@@ -270,10 +270,10 @@ Function118233:
 	ld [wcd34], a
 	ld a, $6
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_11824c
 	call JoyTextDelay
 	call Function118473
@@ -294,7 +294,7 @@ Function118233:
 	cp [hl]
 	jr nz, .asm_11824c
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	ret
 
@@ -306,10 +306,10 @@ Function118284:
 	ld [wcd34], a
 	ld a, $5
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_11829d
 	call JoyTextDelay
 	call Function118473
@@ -329,7 +329,7 @@ Function118284:
 	cp [hl]
 	jr nz, .asm_11829d
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	ret
 
@@ -341,10 +341,10 @@ Function1182d5:
 	ld [wcd34], a
 	ld a, $4
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_1182ee
 	call JoyTextDelay
 	call Function118473
@@ -365,7 +365,7 @@ Function1182d5:
 	cp [hl]
 	jr nz, .asm_1182ee
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	call ReturnToMapFromSubmenu
 	ret
@@ -378,10 +378,10 @@ Function118329:
 	ld [wcd34], a
 	ld a, $6
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_118342
 	call JoyTextDelay
 	call Function118473
@@ -402,7 +402,7 @@ Function118329:
 	cp [hl]
 	jr nz, .asm_118342
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	ret
 
@@ -414,10 +414,10 @@ Function11837a:
 	ld [wcd34], a
 	ld a, $6
 	ld [wc3f0], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_118393
 	call JoyTextDelay
 	call Function118473
@@ -438,17 +438,17 @@ Function11837a:
 	cp [hl]
 	jr nz, .asm_118393
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_Cleanup
 	ret
 
 BattleTowerRoomMenu_InitRAM:
 	di
-	ld a, [rIE]
+	ldh a, [rIE]
 	ld [wcd32], a
 	call DoubleSpeed
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld [wc300], a
 	ld [wc301], a
 	ld [wc302], a
@@ -470,10 +470,10 @@ BattleTowerRoomMenu_InitRAM:
 	ld [wcd7f], a
 	set 1, [hl]
 	ld a, $f
-	ld [rIE], a
+	ldh [rIE], a
 	ld a, $1
-	ld [hMobileReceive], a
-	ld [hMobile], a
+	ldh [hMobileReceive], a
+	ldh [hMobile], a
 	ei
 	farcall Stubbed_Function106462
 	farcall Function106464
@@ -500,14 +500,14 @@ Function118440:
 BattleTowerRoomMenu_Cleanup:
 	di
 	xor a
-	ld [hMobileReceive], a
-	ld [hMobile], a
-	ld [hVBlank], a
+	ldh [hMobileReceive], a
+	ldh [hMobile], a
+	ldh [hVBlank], a
 	call NormalSpeed
 	xor a
-	ld [rIF], a
+	ldh [rIF], a
 	ld a, [wcd32]
-	ld [rIE], a
+	ldh [rIE], a
 	ei
 	ld a, [wcd7f]
 	ld [wVramState], a
@@ -904,7 +904,7 @@ Function11878d:
 	and $1
 	jr z, .asm_1187a7
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_1187a7
 	jp BattleTowerRoomMenu_IncrementJumptable
 .asm_1187aa
@@ -932,7 +932,7 @@ Function11878d:
 	jr nz, .asm_118803
 	set 0, [hl]
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, $d000
 	ld bc, $1000
 	ld a, [hl]
@@ -977,7 +977,7 @@ Function118821:
 	jr c, .asm_11884a
 	cp $4
 	jr z, .asm_11884a
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	cp $5
 	jr nz, .asm_11884a
 	ld a, $a
@@ -995,7 +995,7 @@ Function118821:
 	ret
 
 Function11884c:
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	cp $5
 	jr nz, .asm_118864
 	ld a, $a
@@ -1154,7 +1154,7 @@ BattleTowerRoomMenu_PlacePickLevelMenu:
 	ld a, $1
 	ld [wcd4f], a
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wStatusFlags]
 	bit STATUSFLAGS_HALL_OF_FAME_F, a
 	jr nz, .asm_11896b
@@ -1173,7 +1173,7 @@ BattleTowerRoomMenu_PlacePickLevelMenu:
 	ld a, h
 	ld [wcd4c], a
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call BattleTowerRoomMenu_IncrementJumptable
 
 BattleTowerRoomMenu_UpdatePickLevelMenu:
@@ -1199,10 +1199,10 @@ BattleTowerRoomMenu_UpdatePickLevelMenu:
 	ld e, a
 	ld a, h
 	ld d, a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld bc, wStringBuffer3
 .asm_1189b5
 	ld a, [hli]
@@ -1220,7 +1220,7 @@ BattleTowerRoomMenu_UpdatePickLevelMenu:
 .asm_1189c4
 	ld [bc], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	hlcoord 13, 9
 	call PlaceString
 	ld hl, hJoyPressed
@@ -1267,13 +1267,13 @@ BattleTowerRoomMenu_UpdatePickLevelMenu:
 	and $fe
 	srl a
 	ld [wcf65], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseWindow
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd38]
 	and a
 	jr nz, .asm_118a30
@@ -1291,13 +1291,13 @@ BattleTowerRoomMenu_UpdatePickLevelMenu:
 	call PlayClickSFX
 
 .asm_118a3c
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseWindow
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $7
 	ld [wcf66], a
 	ld a, $0
@@ -1346,7 +1346,7 @@ Function118aa4:
 	ld bc, $80
 	call CopyBytes
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, w3_d100
 	ld bc, $e00
 	jr Function118b10
@@ -1608,13 +1608,13 @@ Function118ded:
 	ld a, [wcd38]
 	and a
 	jr z, .asm_118e03
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall Function11b93b
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 .asm_118e03
 	jp BattleTowerRoomMenu_IncrementJumptable
@@ -1958,7 +1958,7 @@ Function119054:
 	and $1
 	jr z, .asm_11908a
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wd002
 	ld a, [w3_d000]
 	ld c, a
@@ -1970,7 +1970,7 @@ Function119054:
 .asm_11908a
 	call CloseSRAM
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $5
 	call GetSRAMBank
 	ld a, [wcd4f]
@@ -1981,10 +1981,10 @@ Function119054:
 	ld de, $aa7f
 	ld bc, $000c
 	call CopyBytes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wd474]
 	ld [$b2f3], a
 	ld hl, wd475
@@ -1992,13 +1992,13 @@ Function119054:
 	ld bc, $0004
 	call CopyBytes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	jp BattleTowerRoomMenu_IncrementJumptable
 
 Function1190d0:
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd57]
 	ld l, a
 	ld a, [wcd58]
@@ -2037,7 +2037,7 @@ Function1190ec:
 	and $1
 	jr z, .asm_11913e
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [w3_d000]
 	ld c, a
 	ld a, [w3_d000 + 1]
@@ -2048,7 +2048,7 @@ Function1190ec:
 
 .asm_11913e
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	ld hl, Text_ReceivedNews
 	call BattleTowerRoomMenu_SetMessage
@@ -2125,7 +2125,7 @@ Function1191ad:
 	push bc
 	ld c, $0
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 .asm_1191b4
 	ld a, [hli]
 	ld [de], a
@@ -2139,14 +2139,14 @@ Function1191ad:
 	ld a, $da
 	call Function118805
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	scf
 	ret
 
 .asm_1191cc
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop bc
 	and a
 	ret
@@ -2517,7 +2517,7 @@ Function119413:
 	and $1
 	jr z, .asm_119447
 	ld a, $6
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [w3_d000]
 	ld c, a
 	ld a, [w3_d000 + 1]
@@ -2528,7 +2528,7 @@ Function119413:
 
 .asm_119447
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call CloseSRAM
 	jp BattleTowerRoomMenu_IncrementJumptable
 
@@ -3006,14 +3006,14 @@ Function1196f2:
 	jr z, .asm_11974c
 
 .asm_119735
-	ld a, [hRandomSub]
+	ldh a, [hRandomSub]
 	cp d
 	jr c, .asm_11974c
 	jr z, .asm_11973e
 	jr .asm_119745
 
 .asm_11973e
-	ld a, [hRandomAdd]
+	ldh a, [hRandomAdd]
 	cp e
 	jr c, .asm_11974c
 	jr z, .asm_11974c
@@ -3164,13 +3164,13 @@ Function119800:
 	ld a, [wcf66]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call FadeToMenu
 	farcall Function10803d
 	call Function11a9ce
 	call RestartMapMusic
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	ld [wcf66], a
 	pop af
@@ -3199,13 +3199,13 @@ Function11984e:
 	ld a, [wcf66]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call FadeToMenu
 	farcall MobileTradeAnimation_SendGivemonToGTS
 	call Function11a9ce
 	call RestartMapMusic
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	ld [wcf66], a
 	pop af
@@ -3233,13 +3233,13 @@ Function11984e:
 	ld a, [wcf66]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call FadeToMenu
 	farcall MobileTradeAnimation_RetrieveGivemonFromGTS
 	call Function11a9ce
 	call RestartMapMusic
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
 	ld [wcf66], a
 	pop af
@@ -3882,10 +3882,10 @@ String_119d8c:
 	db "CANCEL@"
 
 BattleTower_LevelCheck:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd4f]
 	ld c, 10
 	call SimpleMultiply
@@ -3912,7 +3912,7 @@ BattleTower_LevelCheck:
 	dec a
 	jr nz, .party_loop
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	and a
 	ret
 
@@ -3921,18 +3921,18 @@ BattleTower_LevelCheck:
 	ld a, $4
 	ld [wcf66], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	scf
 	ret
 
 BattleTower_UbersCheck:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, [wcd4f]
 	cp 70 / 10
 	jr nc, .level_70_or_more
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wPartyMon1Level
 	ld bc, PARTYMON_STRUCT_LENGTH
 	ld de, wPartySpecies
@@ -3960,7 +3960,7 @@ BattleTower_UbersCheck:
 	jr nz, .loop
 .level_70_or_more
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	and a
 	ret
 
@@ -3976,7 +3976,7 @@ BattleTower_UbersCheck:
 	ld a, $a
 	ld [wcf66], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	scf
 	ret
 
@@ -4120,17 +4120,17 @@ Function119ec2:
 	ret
 
 BattleTowerRoomMenu2:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	ld [wcd8c], a
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call .RunJumptable
 
 	ld a, [wcd8c]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .RunJumptable:
@@ -4295,24 +4295,24 @@ Function11a00e:
 
 .asm_11a039
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, $c608
 	ld de, w3_d800
 	ld bc, $00f6
 	call CopyBytes
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call FadeToMenu
 	farcall Function11765d
 	call Function11a9ce
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, w3_d800
 	ld de, $c608
 	ld bc, $00f6
 	call CopyBytes
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall Function115d99
 	ld c, $0
 	farcall Function115e18
@@ -5153,31 +5153,31 @@ Function11a80c:
 	call Function11a88c
 	xor a
 	ld b, a
-	ld a, [hDivisor]
+	ldh a, [hDivisor]
 	and $f
 	ld e, a
-	ld a, [hPrintNum7]
+	ldh a, [hPrintNum7]
 	and $f
 	call Function11a884
 	ld e, a
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	and $f
 	call Function11a884
 	ld [wcd62], a
 	ld e, b
 	xor a
 	ld b, a
-	ld a, [hDivisor]
+	ldh a, [hDivisor]
 	and $f0
 	swap a
 	call Function11a884
 	ld e, a
-	ld a, [hPrintNum7]
+	ldh a, [hPrintNum7]
 	and $f0
 	swap a
 	call Function11a884
 	ld e, a
-	ld a, [hPrintNum9]
+	ldh a, [hPrintNum9]
 	and $f0
 	swap a
 	call Function11a884
@@ -5185,15 +5185,15 @@ Function11a80c:
 	ld e, b
 	xor a
 	ld b, a
-	ld a, [hMathBuffer]
+	ldh a, [hMathBuffer]
 	and $f
 	call Function11a884
 	ld e, a
-	ld a, [hPrintNum8]
+	ldh a, [hPrintNum8]
 	and $f
 	call Function11a884
 	ld e, a
-	ld a, [hPrintNum10]
+	ldh a, [hPrintNum10]
 	and $f
 	call Function11a884
 	ld [wcd64], a
@@ -5253,7 +5253,7 @@ BattleTowerRoomMenu_WriteMessage:
 
 Function11a90f:
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call SpeechTextBox
 	ld a, $50
 	ld hl, $c320
@@ -5307,14 +5307,14 @@ Function11a90f:
 	ld hl, $c31a
 	inc [hl]
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 BattleTowerRoomMenu_WriteMessage_DoNothing:
 	ret
 
 Function11a971:
 	ld hl, $c31f
-	ld a, [hJoyDown]
+	ldh a, [hJoyDown]
 	and a
 	jr nz, .asm_11a97f
 	ld a, [hl]
@@ -5513,7 +5513,7 @@ Function11ac3e:
 
 Function11ac51:
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ld hl, wOptions
 	ld a, [hl]
 	push af
@@ -5522,12 +5522,12 @@ Function11ac51:
 	push af
 	xor a
 	ld [wVramState], a
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	xor a
-	ld [hMapAnims], a
+	ldh [hMapAnims], a
 	ld [wcd49], a
 	ld [wcd4a], a
 	ld [wcd4c], a
@@ -5552,7 +5552,7 @@ Function11ac51:
 .asm_11aca8
 	call ClearSprites
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	pop af
 	ld [wVramState], a
 	pop af
@@ -5619,7 +5619,7 @@ Function11ad1b:
 	ld a, [wMenuCursorY]
 	ld [wcd82], a
 	dec a
-	ld [hObjectStructIndexBuffer], a
+	ldh [hObjectStructIndexBuffer], a
 	ld a, $10
 	ld [wCurIconTile], a
 	ld hl, LoadMenuMonIcon
@@ -6194,10 +6194,10 @@ Function11b0ff:
 	and $3
 	ld [wcd4c], a
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call Function11b099
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	ret
 
 .asm_11b125
@@ -7006,7 +7006,7 @@ Function11b570:
 
 .SaveData:
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, w3_d800
 	ld de, $c608
@@ -7014,7 +7014,7 @@ Function11b570:
 	call CopyBytes
 
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $5
 	call GetSRAMBank
 
@@ -7029,13 +7029,13 @@ Function11b570:
 	push de
 	pop hl
 
-	ld a, [hRTCMinutes]
+	ldh a, [hRTCMinutes]
 	ld [hli], a
-	ld a, [hRTCHours]
+	ldh a, [hRTCHours]
 	ld [hli], a
-	ld a, [hRTCDayLo]
+	ldh a, [hRTCDayLo]
 	ld [hli], a
-	ld a, [hRTCDayHi]
+	ldh a, [hRTCDayHi]
 	ld [hl], a
 
 	call CloseSRAM
@@ -7117,14 +7117,14 @@ Function11b66d:
 	ld a, [wScriptVar]
 	and a
 	jr nz, .asm_11b6b0
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [w3_d090]
 	ld b, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, b
 	and a
 	jr z, .asm_11b691
@@ -7140,14 +7140,14 @@ Function11b66d:
 	jr z, .asm_11b6b0
 	xor a
 	ld [wScriptVar], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $2
 	ld [w3_d090], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 .asm_11b6b0
 	jp Function11ad8a
@@ -7372,15 +7372,15 @@ Function11b879:
 	and a
 	ret z
 	ld hl, wcd4c
-	ld a, [hRTCDayHi]
+	ldh a, [hRTCDayHi]
 	cp [hl]
 	ret nz
 	dec hl
-	ld a, [hRTCDayLo]
+	ldh a, [hRTCDayLo]
 	cp [hl]
 	ret nz
 	ld hl, wcd4a
-	ld a, [hRTCHours]
+	ldh a, [hRTCHours]
 	cp [hl]
 	jr nc, .asm_11b8d8
 	ld a, $18
@@ -7388,16 +7388,16 @@ Function11b879:
 	ld hl, hRTCHours
 	add [hl]
 	ld [wcd4c], a
-	ld a, [hRTCMinutes]
+	ldh a, [hRTCMinutes]
 	ld [wcd4b], a
 	xor a
 	ld [wcd4a], a
 	jr .asm_11b8e2
 
 .asm_11b8d8
-	ld a, [hRTCMinutes]
+	ldh a, [hRTCMinutes]
 	ld [wcd4b], a
-	ld a, [hRTCHours]
+	ldh a, [hRTCHours]
 	ld [wcd4c], a
 
 .asm_11b8e2

--- a/mobile/mobile_5b.asm
+++ b/mobile/mobile_5b.asm
@@ -1,10 +1,10 @@
 Unreferenced_Function16c000:
 	; Only for CGB
-	ld a, [hCGB]
+	ldh a, [hCGB]
 	and a
 	ret z
 	; Only do this once per boot cycle
-	ld a, [hSystemBooted]
+	ldh a, [hSystemBooted]
 	and a
 	ret z
 	; Set some flag, preserving the old state
@@ -21,7 +21,7 @@ Unreferenced_Function16c000:
 	; Prevent this routine from running again
 	; until the next time the system is turned on
 	xor a
-	ld [hSystemBooted], a
+	ldh [hSystemBooted], a
 	; Restore the flag state
 	pop af
 	ld [wcfbe], a
@@ -81,7 +81,7 @@ Function16c089:
 	ld [wBuffer2], a
 	ld [wd1f1], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	call Function16c0fa
 	ld a, [wd002]
 	ld [wcf64], a
@@ -100,7 +100,7 @@ Function16c0a8:
 	ld [wd1f1], a
 	call ClearSprites
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	call Function16c0fa
 	ret
 
@@ -167,7 +167,7 @@ MobileSystemSplashScreen_InitGFX:
 	call Function16cc73
 	call Function16cc02
 	xor a
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call EnableLCD
 	ret
 
@@ -218,22 +218,22 @@ Function16c943:
 	ld a, [wd003]
 	and a
 	jr nz, .asm_16c95e
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $ff
 	ld bc, 1 palettes
 	ld hl, wBGPals1
 	call ByteFill
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 .asm_16c95e
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld e, $0
 	ld a, $0
 .asm_16c969
@@ -313,26 +313,26 @@ Function16c943:
 	jr nz, .asm_16c969
 	farcall ApplyPals
 	call SetPalettes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wd003]
 	cp $1f
 	jr z, .asm_16ca09
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld e, $0
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	and a
 	ret
 
 .asm_16ca09
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	scf
 	ret
 
@@ -343,10 +343,10 @@ Function16ca11:
 	farcall ApplyPals
 
 .asm_16ca1d
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld e, $0
 	ld a, $0
 .asm_16ca28
@@ -414,25 +414,25 @@ Function16ca11:
 	jr nz, .asm_16ca28
 	farcall ApplyPals
 	call SetPalettes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wd003]
 	cp $1f
 	jr z, .asm_16caae
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	and a
 	ret
 
 .asm_16caae
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	scf
 	ret
 
@@ -651,7 +651,7 @@ Function16cbd1:
 	call FarCopyWRAM
 	farcall ApplyPals
 	ld a, $1
-	ld [hCGBPalUpdate], a
+	ldh [hCGBPalUpdate], a
 	ret
 
 Unknown_16cbfb:
@@ -721,20 +721,20 @@ Function16cc6e:
 	jr Function16cc73
 
 Function16cc73:
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $0
-	ld [rVBK], a
+	ldh [rVBK], a
 	push hl
 	decoord 0, 0
 	call Function16cc90
 	pop hl
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	decoord 0, 0, wAttrMap
 	call Function16cc90
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 Function16cc90:

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -522,7 +522,7 @@ Function171b4b:
 	jp Function171c66
 
 Function171b85:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and $2
 	jp nz, Function171b9f
@@ -569,7 +569,7 @@ Function171bbd:
 	jp Function171c66
 
 Function171bcc:
-	ld hl, hJoyPressed ; $ffa7
+	ld hl, hJoyPressed
 	ld a, [hl]
 	and $2
 	jp nz, Function171bdc

--- a/mobile/mobile_5c.asm
+++ b/mobile/mobile_5c.asm
@@ -249,21 +249,21 @@ CheckBTMonMovesForErrors:
 	ret
 
 Function170cc6:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wDecompressScratch)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, PichuAnimatedMobileGFX
 	ld de, wDecompressScratch
 	call Decompress
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld de, wDecompressScratch
 	ld hl, vTiles0
 	lb bc, BANK(wDecompressScratch), 193
 	call Get2bpp
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, ElectroBallMobileGFX
 	ld de, wDecompressScratch
 	call Decompress
@@ -272,18 +272,18 @@ Function170cc6:
 	lb bc, BANK(wDecompressScratch), 83
 	call Get2bpp
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function170d02:
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld de, GFX_171848
 	ld hl, vTiles0 tile $c1
 	lb bc, BANK(GFX_171848), 24
 	call Get2bpp
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	ret
 
 PichuAnimatedMobileGFX:
@@ -296,25 +296,25 @@ GFX_171848:
 INCBIN "gfx/unknown/171848.2bpp"
 
 Function1719c8:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call Function1719d6
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function1719d6:
 	farcall BattleTowerRoomMenu_InitRAM
 	call Function1719ed
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function171a11
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function1719ed:
@@ -389,13 +389,13 @@ Function171a5d:
 	ld [wc302], a
 	ld a, $a
 	call Function3e32
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall BattleTowerRoomMenu_Cleanup
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, $a
 	ld [wcd49], a
 	ret
@@ -431,13 +431,13 @@ Function171ad7:
 	jp Function171c66
 
 Function171aec:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	farcall BattleTowerRoomMenu_Cleanup
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	hlcoord 2, 6
 	ld a, $8
 .asm_171b01
@@ -684,10 +684,10 @@ Function171c87:
 	ret
 
 Function171ccd:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_171d71
 	ld de, wBGPals1
 	ld bc, 8 palettes
@@ -699,7 +699,7 @@ Function171ccd:
 	ld [hl], a
 	call SetPalettes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function171cf0:
@@ -846,10 +846,10 @@ Function172e78:
 	ret
 
 Function172eb9:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_172edf
 	ld de, wBGPals1
 	ld bc, 8 palettes
@@ -860,7 +860,7 @@ Function172eb9:
 	call CopyBytes
 	call SetPalettes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Palette_172edf:

--- a/mobile/mobile_5e.asm
+++ b/mobile/mobile_5e.asm
@@ -138,24 +138,24 @@ Function17a751:
 	ret
 
 Function17a770:
-	ld a, [hOAMUpdate]
+	ldh a, [hOAMUpdate]
 	push af
 	ld a, $1
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	call HideSprites
 	call Function17a9cb
 	pop af
-	ld [hOAMUpdate], a
+	ldh [hOAMUpdate], a
 	ret
 
 Function17a781:
-	ld a, [hInMenu]
+	ldh a, [hInMenu]
 	push af
 	ld a, $1
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	call JoyTextDelay
 	pop af
-	ld [hInMenu], a
+	ldh [hInMenu], a
 	ret
 
 Function17a78f:
@@ -243,7 +243,7 @@ Function17a7ff:
 Function17a81a:
 	call IsSFXPlaying
 	ret nc
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and $3
 	ret z
 	call ExitMenu
@@ -258,10 +258,10 @@ Function17a81a:
 	ret
 
 Function17a83c:
-	ld a, [hJoyLast]
+	ldh a, [hJoyLast]
 	and $f0
 	ld c, a
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and $b
 	or c
 	ld c, a
@@ -724,10 +724,10 @@ Unknown_17aaf7:
 	db $0, $0,$f0,$10, $e, $c, $c, $b, $9, $b, $9, $b, $9
 
 Function17aba0:
-	ld a, [rVBK]
+	ldh a, [rVBK]
 	push af
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, vTiles5 tile $00
 	ld de, GFX_17afa5
@@ -735,7 +735,7 @@ Function17aba0:
 	call Get2bpp
 
 	pop af
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, vTiles0 tile $00
 	ld de, GFX_17afa5 + $4c0
@@ -749,10 +749,10 @@ Function17aba0:
 	ret
 
 Function17abcf:
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, Palette_17ac55
 	ld de, wBGPals1 ; $d000
@@ -776,7 +776,7 @@ Function17abcf:
 	call FarCopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function17ac0c:

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -41,11 +41,11 @@ Function17c000:
 	dec a
 	jr nz, .y
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 
 	ld a, BANK(wBGPals1)
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, HaveWantPals
 	ld de, wBGPals1
@@ -53,7 +53,7 @@ Function17c000:
 	call CopyBytes
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld hl, MobileSelectGFX
 	ld de, vTiles0 tile $30
@@ -61,7 +61,7 @@ Function17c000:
 	call CopyBytes
 
 	ld a, 1
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	ld hl, HaveWantGFX
 	ld de, vTiles2
@@ -74,7 +74,7 @@ Function17c000:
 	call CopyBytes
 
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 
 	call EnableLCD
 	farcall ReloadMapPart
@@ -522,14 +522,14 @@ Function17d2ce:
 	ret c
 	call SpeechTextBox
 	call FadeToMenu
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17d370
 	call Function17d45a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld de, MUSIC_MOBILE_CENTER
 	ld a, e
 	ld [wMapMusic], a
@@ -610,7 +610,7 @@ Function17d370:
 	ld bc, 1 tiles
 	call CopyBytes
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, PokemonNewsGFX
 	ld de, vTiles1
 	ld bc, $48 tiles
@@ -624,7 +624,7 @@ Function17d370:
 	ld bc, 1 tiles
 	call CopyBytes
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, GFX_17eb7e
 	ld de, vTiles2 tile $60
 	ld bc, 1 tiles
@@ -657,7 +657,7 @@ Function17d405:
 	ld bc, 1 tiles
 	call CopyBytes
 	ld a, $1
-	ld [rVBK], a
+	ldh [rVBK], a
 	ld hl, PokemonNewsGFX
 	ld de, vTiles1
 	ld bc, $48 tiles
@@ -671,19 +671,19 @@ Function17d405:
 	ld bc, 1 tiles
 	call CopyBytes
 	xor a
-	ld [rVBK], a
+	ldh [rVBK], a
 	call EnableLCD
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, Palette_17eff6
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	call SetPalettes
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function17d45a:
@@ -900,7 +900,7 @@ Function17d5be:
 	call Function17e438
 
 Function17d5c4:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and a
 	ret z
 	ld c, 0
@@ -937,13 +937,13 @@ Function17d5c4:
 
 Function17d5f6:
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc608
 	ld de, wBGPals1
 	ld bc, 8 palettes
 	call CopyBytes
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function17d60b:
@@ -1325,7 +1325,7 @@ Function17d85d:
 	cp $c0
 	jr c, .asm_17d89b
 	ld a, [wcd4f]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17d8a1
 
 .asm_17d89b
@@ -1353,7 +1353,7 @@ Function17d85d:
 	cp $c0
 	jr c, .asm_17d8c2
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17d878
 
 .asm_17d8c2
@@ -1364,13 +1364,13 @@ Function17d85d:
 	call HlToCrashCheckPointer
 	push bc
 	ld a, $3
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc608
 	ld de, wBGPals1
 	ld b, $0
 	call CopyBytes
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e32b
 	pop bc
 	ld a, c
@@ -1431,10 +1431,10 @@ Function17d93a:
 	call CopyBytes
 	call HlToCrashCheckPointer
 	call Function17e32b
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wc70c]
 	call Function17e6de
 	ld a, [wc70a]
@@ -1455,7 +1455,7 @@ Function17d93a:
 	ld d, h
 	farcall HOF_AnimateFrontpic
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e349
 	ret
 
@@ -1466,10 +1466,10 @@ Function17d98b:
 	call CopyBytes
 	call HlToCrashCheckPointer
 	call Function17e32b
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wc70b]
 	call Function17e6de
 	ld a, [wc70a]
@@ -1491,7 +1491,7 @@ Function17d98b:
 	ld bc, $707
 	predef PlaceGraphic
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e349
 	ret
 
@@ -1506,7 +1506,7 @@ Function17d9e3:
 	cp $c0
 	jr c, .asm_17da01
 	ld a, [wc70c]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17da07
 
 .asm_17da01
@@ -1531,7 +1531,7 @@ Function17d9e3:
 	cp $c0
 	jr c, .asm_17da2d
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17da30
 
 .asm_17da2d
@@ -1551,7 +1551,7 @@ Function17da31:
 	cp $c0
 	jr c, .asm_17da4f
 	ld a, [wc70a]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17da55
 
 .asm_17da4f
@@ -1591,7 +1591,7 @@ Function17da31:
 	cp $c0
 	jr c, .asm_17da88
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17da8b
 
 .asm_17da88
@@ -1828,10 +1828,10 @@ Function17dc1f:
 	ld bc, $6
 	call CopyBytes
 	call Function17e32b
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc688
 	ld a, $40
 	ld [wc708], a
@@ -1859,7 +1859,7 @@ Function17dc1f:
 .asm_17dc6e
 	call CloseWindow
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wMenuCursorY]
 	cp $1
 	jr nz, .asm_17dc85
@@ -1900,7 +1900,7 @@ Function17dca9:
 
 Function17dcaf:
 	ld a, $5
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wBGPals1
 	ld de, 1 palettes
 	ld c, 8
@@ -1916,7 +1916,7 @@ Function17dcaf:
 	jr nz, .asm_17dcbb
 	call RotateThreePalettesRight
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 
 Function17dccf:
@@ -2016,7 +2016,7 @@ Function17dd49:
 	cp $c0
 	jr c, .sram
 	ld a, [wc708]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .got_bank
 
 .sram
@@ -2037,7 +2037,7 @@ Function17dd49:
 	cp $c0
 	jr c, .close_sram
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .exited_bank
 
 .close_sram
@@ -2092,7 +2092,7 @@ Function17ddcd:
 	cp $c0
 	jr c, .asm_17dde7
 	ld a, [wc708]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17dded
 
 .asm_17dde7
@@ -2113,7 +2113,7 @@ Function17ddcd:
 	cp $c0
 	jr c, .asm_17de0c
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17de0f
 
 .asm_17de0c
@@ -2250,10 +2250,10 @@ Function17ded9:
 	ld bc, $1f
 	call CopyBytes
 	call Function17e32b
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc708
 	ld a, [hli]
 	ld [wCurPartySpecies], a
@@ -2576,7 +2576,7 @@ asm_17e0ee
 	ld h, [hl]
 	ld l, a
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	push hl
 	call Function17e349
 	pop hl
@@ -2588,10 +2588,10 @@ Function17e0fd:
 	ld de, wc708
 	ld bc, $6
 	call CopyBytes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc708
 	ld a, [hli]
 	ld [wCurItem], a
@@ -2612,7 +2612,7 @@ Function17e0fd:
 	ld h, a
 	ld l, b
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e40f
 	ret
 
@@ -2621,10 +2621,10 @@ Function17e133:
 	ld de, wc708
 	ld bc, $5
 	call CopyBytes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc708
 	ld a, [hli]
 	ld [wScriptVar], a
@@ -2642,7 +2642,7 @@ Function17e133:
 	ld h, a
 	ld l, b
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e40f
 	ret
 
@@ -2651,10 +2651,10 @@ Function17e165:
 	ld de, wc708
 	ld bc, $5
 	call CopyBytes
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wc708
 	ld a, [hli]
 	ld [wCurItem], a
@@ -2678,7 +2678,7 @@ Function17e165:
 	ld h, a
 	ld l, b
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call Function17e40f
 	ret
 
@@ -2691,7 +2691,7 @@ Function17e1a1:
 	cp $c0
 	jr c, .asm_17e1bb
 	ld a, [wc708]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17e1c1
 
 .asm_17e1bb
@@ -2712,7 +2712,7 @@ Function17e1a1:
 	cp $c0
 	jr c, .asm_17e1e2
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17e1e5
 
 .asm_17e1e2
@@ -2723,7 +2723,7 @@ Function17e1a1:
 	cp $c0
 	jr c, .asm_17e1f3
 	ld a, [wc70c]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17e1f9
 
 .asm_17e1f3
@@ -2744,7 +2744,7 @@ Function17e1a1:
 	cp $c0
 	jr c, .asm_17e21a
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17e21d
 
 .asm_17e21a
@@ -2953,16 +2953,16 @@ Function17e349:
 inc_crash_check_pointer_farcall: MACRO
 	call IncCrashCheckPointer
 	call HlToCrashCheckPointer ; redundant
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 rept _NARG
 	farcall \1
 	shift
 endr
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ret
 ENDM
 
@@ -2987,7 +2987,7 @@ Function17e3e0:
 	ld c, a
 	call HlToCrashCheckPointer
 	ld a, $1
-	ld [hBGMapMode], a
+	ldh [hBGMapMode], a
 	call DelayFrames
 	ret
 
@@ -3901,7 +3901,7 @@ Function17f1d0:
 	add hl, de
 	ld a, [hl]
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld [wNamedObjectIndexBuffer], a
 	call GetPokemonName
 	pop hl
@@ -3911,7 +3911,7 @@ Function17f1d0:
 	ld a, b
 	ld [wcd53], a
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd54]
 	call Function17f50f
 	pop de
@@ -4020,7 +4020,7 @@ Function17f27b:
 	add hl, de
 	ld a, [hl]
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld [wNamedObjectIndexBuffer], a
 	call GetItemName
 	pop hl
@@ -4030,7 +4030,7 @@ Function17f27b:
 	ld a, b
 	ld [wcd53], a
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld a, [wcd54]
 	call Function17f50f
 	pop de
@@ -4077,13 +4077,13 @@ Function17f2ff:
 	push hl
 	push bc
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	ld hl, wPlayerName
 	ld de, wc608
 	ld bc, $6
 	call CopyBytes
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	pop hl
 	ld de, wc608
 	call PlaceString
@@ -4325,7 +4325,7 @@ Function17f44f:
 	cp $c0
 	jr c, .asm_17f488
 	ld a, [wcd54]
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17f48e
 
 .asm_17f488
@@ -4346,7 +4346,7 @@ Function17f44f:
 	cp $c0
 	jr c, .asm_17f4af
 	ld a, $4
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	jr .asm_17f4b7
 
 .asm_17f4af
@@ -4461,15 +4461,15 @@ BattleTowerMobileError:
 	call FadeToMenu
 	xor a
 	ld [wc303], a
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	call DisplayMobileError
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 	call ExitAllMenus
 	ret
 
@@ -5087,7 +5087,7 @@ String_17fedf:
 	db   "@"
 
 Function17ff23:
-	ld a, [hJoyPressed]
+	ldh a, [hJoyPressed]
 	and a
 	ret z
 	ld a, $8

--- a/mobile/print_opp_message.asm
+++ b/mobile/print_opp_message.asm
@@ -13,17 +13,17 @@ Mobile_PrintOpponentBattleMessage:
 	ld a, BANK(w5_MobileOpponentBattleMessages)
 	call FarCopyWRAM
 
-	ld a, [rSVBK]
+	ldh a, [rSVBK]
 	push af
 	ld a, $1
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld bc, wMobileOpponentBattleMessage
 	decoord 1, 14
 	farcall PrintEZChatBattleMessage
 
 	pop af
-	ld [rSVBK], a
+	ldh [rSVBK], a
 
 	ld c, 180
 	call DelayFrames

--- a/pokecrystal.link
+++ b/pokecrystal.link
@@ -363,3 +363,5 @@ SRAM $03
 	"Boxes 8-14"
 SRAM $05
 	"SRAM Mobile"
+HRAM
+	"HRAM"

--- a/tools/sort_symfile.sh
+++ b/tools/sort_symfile.sh
@@ -7,6 +7,7 @@ sed \
     -e "s/^..:[A-B]/3_SRAM@&/g" \
     -e "s/^00:[C-D]/4_WRAM0@&/g" \
     -e "s/^..:[D-D]/5_WRAMX@&/g" \
+    -e "s/^..:[F-F]/6_HRAM@&/g" \
     $1 \
 | sort \
 | sed -e "s/^.*@//g" > $TEMP_FILE

--- a/wram.asm
+++ b/wram.asm
@@ -3114,3 +3114,5 @@ wWindowStackBottom:: ds 1
 
 
 INCLUDE "sram.asm"
+
+INCLUDE "hram.asm"


### PR DESCRIPTION
Until now we've left HRAM locations as constants so that `ld [hLabel], a` and `ld a, [hLabel]` would be automatically optimized to use the smaller `ldh` opcode. This PR fixes that, defining real labels for HRAM that will be included in the .sym file. As a result, all accesses to HRAM explicitly use `ldh`. The Makefile disables the `ld` → `ldh` optimization to make sure this is done consistently.