### PR TITLE
Miscellaneous changes

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -74,11 +74,11 @@ PascalCase:: ; global label
 wPascalCase: ; wram
 sPascalCase: ; sram
 vPascalCase: ; vram
+hPascalCase: ; hram
 PascalCase:  ; rom
 
 ; Some constants are also prefixed
 rBGP EQU $ff47 ; hardware register
-hPascalCase EQU $ff80 ; hram
 
 ; Most other constants should be upper case
 UPPER_CASE EQU 1

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -763,9 +763,9 @@ Function3851e: ; This appears to be unused
 	ldh [hDividend + 1], a
 	ld b, 2
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld c, a
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld b, a
 	ld hl, wEnemyMonHP + 1
 	ld a, [hld]

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7868,7 +7868,6 @@ CalcExpBar:
 	ld [hld], a
 	xor a
 	ld [hl], a
-; multiply by 64
 	ld a, 64
 	ldh [hMultiplier], a
 	call Multiply

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -352,7 +352,7 @@ HandleBerserkGene:
 
 .reverse
 	call .enemy
-;	jr .player
+	; fallthrough
 
 .player
 	call SetPlayerTurn
@@ -366,7 +366,7 @@ HandleBerserkGene:
 	ld de, wOTPartyMon1Item
 	ld a, [wCurOTMon]
 	ld b, a
-;	jr .go
+	; fallthrough
 
 .go
 	push de

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3715,23 +3715,23 @@ TryToRunAwayFromBattle:
 	inc a
 	ld [wNumFleeAttempts], a
 	ld a, [hli]
-	ldh [hPartyMon1Speed + 0], a
+	ldh [hMultiplicand + 1], a
 	ld a, [hl]
-	ldh [hPartyMon1Speed + 1], a
+	ldh [hMultiplicand + 2], a
 	ld a, [de]
 	inc de
 	ldh [hEnemyMonSpeed + 0], a
 	ld a, [de]
 	ldh [hEnemyMonSpeed + 1], a
 	call Call_LoadTempTileMapToTileMap
-	ld de, hPartyMon1Speed
+	ld de, hMultiplicand + 1
 	ld hl, hEnemyMonSpeed
 	ld c, 2
 	call CompareBytes
 	jr nc, .can_escape
 
 	xor a
-	ldh [hMultiplicand], a
+	ldh [hMultiplicand + 0], a
 	ld a, 32
 	ldh [hMultiplier], a
 	call Multiply
@@ -3751,7 +3751,7 @@ TryToRunAwayFromBattle:
 	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	and a
 	jr nz, .can_escape
 	ld a, [wNumFleeAttempts]
@@ -3760,16 +3760,16 @@ TryToRunAwayFromBattle:
 	dec c
 	jr z, .cant_escape_2
 	ld b, 30
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add b
-	ldh [hQuotient + 2], a
+	ldh [hQuotient + 3], a
 	jr c, .can_escape
 	jr .loop
 
 .cant_escape_2
 	call BattleRandom
 	ld b, a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	cp b
 	jr nc, .can_escape
 	ld a, BATTLEPLAYERACTION_USEITEM
@@ -4787,7 +4787,7 @@ DrawEnemyHUD:
 
 .not_fainted
 	xor a
-	ldh [hMultiplicand], a
+	ldh [hMultiplicand + 0], a
 	ld a, HP_BAR_LENGTH_PX
 	ldh [hMultiplier], a
 	call Multiply
@@ -4824,7 +4824,7 @@ DrawEnemyHUD:
 	ld a, 2
 	ld b, a
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld e, a
 	ld a, HP_BAR_LENGTH
 	ld d, a
@@ -6723,22 +6723,22 @@ ApplyStatLevelMultiplier:
 	pop hl
 
 ; Cap at 999.
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	sub LOW(MAX_STAT_VALUE)
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	sbc HIGH(MAX_STAT_VALUE)
 	jp c, .okay3
 
 	ld a, HIGH(MAX_STAT_VALUE)
-	ldh [hQuotient + 1], a
-	ld a, LOW(MAX_STAT_VALUE)
 	ldh [hQuotient + 2], a
+	ld a, LOW(MAX_STAT_VALUE)
+	ldh [hQuotient + 3], a
 
 .okay3
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld [hli], a
 	ld b, a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [hl], a
 	or b
 	jr nz, .okay4
@@ -7095,9 +7095,9 @@ GiveExperiencePoints:
 	ld a, [hl]
 	cp LUCKY_EGG
 	call z, BoostExp
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [wStringBuffer2 + 1], a
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld [wStringBuffer2], a
 	ld a, [wCurPartyMon]
 	ld hl, wPartyMonNicknames
@@ -7105,9 +7105,9 @@ GiveExperiencePoints:
 	ld hl, Text_MonGainedExpPoint
 	call BattleTextBox
 	ld a, [wStringBuffer2 + 1]
-	ldh [hQuotient + 2], a
+	ldh [hQuotient + 3], a
 	ld a, [wStringBuffer2]
-	ldh [hQuotient + 1], a
+	ldh [hQuotient + 2], a
 	pop bc
 	call AnimateExpBar
 	push bc
@@ -7116,11 +7116,11 @@ GiveExperiencePoints:
 	ld hl, MON_EXP + 2
 	add hl, bc
 	ld d, [hl]
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add d
 	ld [hld], a
 	ld d, [hl]
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	adc d
 	ld [hl], a
 	jr nc, .skip2
@@ -7148,11 +7148,11 @@ GiveExperiencePoints:
 	ld hl, MON_EXP + 2
 	add hl, bc
 	push bc
-	ldh a, [hQuotient]
-	ld b, a
 	ldh a, [hQuotient + 1]
-	ld c, a
+	ld b, a
 	ldh a, [hQuotient + 2]
+	ld c, a
+	ldh a, [hQuotient + 3]
 	ld d, a
 	ld a, [hld]
 	sub d
@@ -7371,7 +7371,7 @@ GiveExperiencePoints:
 	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [hli], a
 	dec c
 	jr nz, .count_loop2
@@ -7646,7 +7646,7 @@ SendOutMonText:
 	ldh [hDivisor], a
 	call Divide
 
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld hl, JumpText_GoMon
 	cp 70
 	jr nc, .skip_to_textbox
@@ -7728,7 +7728,7 @@ WithdrawMonText:
 	call Divide
 	pop bc
 	pop de
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld hl, TextJump_ThatsEnoughComeBack
 	and a
 	ret z
@@ -7869,7 +7869,7 @@ CalcExpBar:
 	xor a
 	ld [hl], a
 ; multiply by 64
-	ld a, $40
+	ld a, 64
 	ldh [hMultiplier], a
 	call Multiply
 	pop af
@@ -7897,7 +7897,7 @@ CalcExpBar:
 	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld b, a
 	ld a, $40
 	sub b

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -1368,9 +1368,9 @@ BattleCommand_Stab:
 	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 1]
-	ld b, a
 	ldh a, [hQuotient + 2]
+	ld b, a
+	ldh a, [hQuotient + 3]
 	or b
 	jr nz, .ok
 
@@ -1469,7 +1469,7 @@ CheckTypeMatchup:
 	ld b, 4
 	call Divide
 	pop bc
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [wTypeMatchup], a
 	jr .TypesLoop
 
@@ -1547,10 +1547,10 @@ BattleCommand_DamageVariation:
 	call Divide
 
 ; ...to get .85-1.00x damage.
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld hl, wCurDamage
 	ld [hli], a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [hl], a
 	ret
 
@@ -1832,14 +1832,14 @@ BattleCommand_CheckHit:
 	ld b, 4
 	call Divide
 	; minimum accuracy is $0001
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld b, a
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	or b
 	jr nz, .min_accuracy
-	ldh [hQuotient + 1], a
-	ld a, 1
 	ldh [hQuotient + 2], a
+	ld a, 1
+	ldh [hQuotient + 3], a
 
 .min_accuracy
 	; do the same thing to the target's evasion
@@ -1848,9 +1848,9 @@ BattleCommand_CheckHit:
 	jr nz, .accuracy_loop
 
 	; if the result is more than 2 bytes, max out at 100%
-	ldh a, [hQuotient + 1]
-	and a
 	ldh a, [hQuotient + 2]
+	and a
+	ldh a, [hQuotient + 3]
 	jr z, .finish_accuracy
 	ld a, $ff
 
@@ -2984,7 +2984,7 @@ BattleCommand_DamageCalc:
 	ld a, e
 	add a
 	jr nc, .level_not_overflowing
-	ld [hl], $1
+	ld [hl], 1
 .level_not_overflowing
 	inc hl
 	ld [hli], a
@@ -2993,7 +2993,7 @@ BattleCommand_DamageCalc:
 	ld a, 5
 	ld [hld], a
 	push bc
-	ld b, $4
+	ld b, 4
 	call Divide
 	pop bc
 
@@ -3012,7 +3012,7 @@ BattleCommand_DamageCalc:
 
 ; / Defense
 	ld [hl], c
-	ld b, $4
+	ld b, 4
 	call Divide
 
 ; / 50
@@ -3146,11 +3146,11 @@ BattleCommand_DamageCalc:
 	ret z
 
 ; x2
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add a
 	ldh [hProduct + 3], a
 
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	rl a
 	ldh [hProduct + 2], a
 
@@ -3257,7 +3257,7 @@ BattleCommand_ConstantDamage:
 	ldh [hMultiplicand + 1], a
 	ld a, [hli]
 	ldh [hMultiplicand + 2], a
-	ld a, $30
+	ld a, 48
 	ldh [hMultiplier], a
 	call Multiply
 	ld a, [hli]
@@ -3288,7 +3288,7 @@ BattleCommand_ConstantDamage:
 .skip_to_divide
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld b, a
 	ld hl, FlailReversalPower
 
@@ -4918,34 +4918,34 @@ CalcStats:
 	ld b, 4
 	call Divide
 
-	ldh a, [hQuotient + 1]
-	ld b, a
 	ldh a, [hQuotient + 2]
+	ld b, a
+	ldh a, [hQuotient + 3]
 	or b
 	jr nz, .check_maxed_out
 
 	ld a, 1
-	ldh [hQuotient + 2], a
+	ldh [hQuotient + 3], a
 	jr .not_maxed_out
 
 .check_maxed_out
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	cp LOW(MAX_STAT_VALUE)
 	ld a, b
 	sbc HIGH(MAX_STAT_VALUE)
 	jr c, .not_maxed_out
 
 	ld a, LOW(MAX_STAT_VALUE)
-	ldh [hQuotient + 2], a
+	ldh [hQuotient + 3], a
 	ld a, HIGH(MAX_STAT_VALUE)
-	ldh [hQuotient + 1], a
+	ldh [hQuotient + 2], a
 
 .not_maxed_out
 	pop bc
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld [bc], a
 	inc bc
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [bc], a
 	inc bc
 	pop hl

--- a/engine/battle/link_result.asm
+++ b/engine/battle/link_result.asm
@@ -100,10 +100,10 @@ DetermineLinkBattleResult:
 	ldh [hDivisor], a
 	ld b, $4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add e
 	ld e, a
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	adc d
 	ld d, a
 	dec hl

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -119,14 +119,14 @@ DoWeatherModifiers:
 	ld b, 4
 	call Divide
 
-	ldh a, [hQuotient + 0]
+	ldh a, [hQuotient + 1]
 	and a
 	ld bc, -1
 	jr nz, .Update
 
-	ldh a, [hQuotient + 1]
-	ld b, a
 	ldh a, [hQuotient + 2]
+	ld b, a
+	ldh a, [hQuotient + 3]
 	ld c, a
 	or b
 	jr nz, .Update

--- a/engine/battle/move_effects/frustration.asm
+++ b/engine/battle/move_effects/frustration.asm
@@ -21,7 +21,7 @@ BattleCommand_FrustrationPower:
 	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld d, a
 	pop bc
 	ret

--- a/engine/battle/move_effects/return.asm
+++ b/engine/battle/move_effects/return.asm
@@ -19,7 +19,7 @@ BattleCommand_HappinessPower:
 	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld d, a
 	pop bc
 	ret

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -305,12 +305,12 @@ ComputeTrainerReward:
 	ld hl, hProduct
 	xor a
 	ld [hli], a
-	ld [hli], a
-	ld [hli], a
+	ld [hli], a ; hMultiplicand + 0
+	ld [hli], a ; hMultiplicand + 1
 	ld a, [wEnemyTrainerBaseReward]
-	ld [hli], a
+	ld [hli], a ; hMultiplicand + 2
 	ld a, [wCurPartyLevel]
-	ld [hl], a
+	ld [hl], a ; hMultiplier
 	call Multiply
 	ld hl, wBattleReward
 	xor a

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -205,7 +205,7 @@ CalcMagikarpLength:
 	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld c, a
 
 	; de = c + 100 × (2 + i)

--- a/engine/events/treemons.asm
+++ b/engine/events/treemons.asm
@@ -250,9 +250,9 @@ GetTreeScore:
 	ld b, 2
 	call Divide
 
-	ldh a, [hQuotient + 1]
-	ldh [hDividend], a
 	ldh a, [hQuotient + 2]
+	ldh [hDividend], a
+	ldh a, [hQuotient + 3]
 	ldh [hDividend + 1], a
 	ld a, 10
 	ldh [hDivisor], a

--- a/engine/gfx/load_pics.asm
+++ b/engine/gfx/load_pics.asm
@@ -43,7 +43,7 @@ GetUnownLetter:
 	call Divide
 
 ; Increment to get 1-26
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	inc a
 	ld [wUnownLetter], a
 	ret

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -310,10 +310,10 @@ PokeBallEffect:
 
 	ld a, b
 	ldh [hDivisor], a
-	ld b, $4
+	ld b, 4
 	call Divide
 
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	and a
 	jr nz, .statuscheck
 	ld a, 1
@@ -1313,7 +1313,7 @@ RareCandyEffect:
 	ld a, MON_EXP
 	call GetPartyParamLocation
 
-	ldh a, [hMultiplicand]
+	ldh a, [hMultiplicand + 0]
 	ld [hli], a
 	ldh a, [hMultiplicand + 1]
 	ld [hli], a
@@ -1963,9 +1963,9 @@ GetOneFifthMaxHP:
 	ldh [hDivisor], a
 	ld b, 2
 	call Divide
-	ldh a, [hQuotient + 1]
-	ld d, a
 	ldh a, [hQuotient + 2]
+	ld d, a
+	ldh a, [hQuotient + 3]
 	ld e, a
 	pop bc
 	ret
@@ -2814,7 +2814,7 @@ ComputeMaxPP:
 	; Since this would overflow into bit 6, we prevent that from happening
 	; by decreasing the extra amount of PP each PP Up provides, resulting
 	; in a maximum of 61.
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	cp $8
 	jr c, .okay
 	ld a, $7

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -786,10 +786,10 @@ Link_PrepPartyData_Gen1:
 	pop bc
 	pop de
 
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	ld [de], a
 	inc de
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld [de], a
 	inc de
 	ld h, b
@@ -1059,9 +1059,9 @@ Function2868a:
 	predef CalcMonStatC
 	pop bc
 	pop hl
-	ldh a, [hQuotient + 1]
-	ld [hli], a
 	ldh a, [hQuotient + 2]
+	ld [hli], a
+	ldh a, [hQuotient + 3]
 	ld [hli], a
 	push hl
 	push bc
@@ -1072,9 +1072,9 @@ Function2868a:
 	predef CalcMonStatC
 	pop bc
 	pop hl
-	ldh a, [hQuotient + 1]
-	ld [hli], a
 	ldh a, [hQuotient + 2]
+	ld [hli], a
+	ldh a, [hQuotient + 3]
 	ld [hli], a
 	push hl
 	ld hl, $1b

--- a/engine/math/math.asm
+++ b/engine/math/math.asm
@@ -172,18 +172,18 @@ _Divide::
 
 .done
 	ldh a, [hDividend + 1]
-	ldh [hDivisor], a
+	ldh [hRemainder], a
 
 	ldh a, [hMathBuffer + 4]
-	ldh [hDividend + 3], a
+	ldh [hQuotient + 2], a
 
 	ldh a, [hMathBuffer + 3]
-	ldh [hDividend + 2], a
+	ldh [hQuotient + 1], a
 
 	ldh a, [hMathBuffer + 2]
-	ldh [hDividend + 1], a
+	ldh [hQuotient + 0], a
 
 	ldh a, [hMathBuffer + 1]
-	ldh [hDividend + 0], a
+	ldh [hQuotient - 1], a
 
 	ret

--- a/engine/math/math.asm
+++ b/engine/math/math.asm
@@ -175,15 +175,15 @@ _Divide::
 	ldh [hRemainder], a
 
 	ldh a, [hMathBuffer + 4]
-	ldh [hQuotient + 2], a
+	ldh [hQuotient + 3], a
 
 	ldh a, [hMathBuffer + 3]
-	ldh [hQuotient + 1], a
+	ldh [hQuotient + 2], a
 
 	ldh a, [hMathBuffer + 2]
-	ldh [hQuotient + 0], a
+	ldh [hQuotient + 1], a
 
 	ldh a, [hMathBuffer + 1]
-	ldh [hQuotient - 1], a
+	ldh [hQuotient + 0], a
 
 	ret

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -21,8 +21,8 @@ Credits::
 	call ClearSprites
 
 	ld hl, wCreditsFaux2bpp
-	ld c, $80
-	ld de, $ff00
+	ld c, wCreditsFaux2bppEnd - wCreditsFaux2bpp
+	ld de, `22222222 ; eight pixels, each with color #2
 
 .load_loop
 	ld a, e

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -22,7 +22,10 @@ Credits::
 
 	ld hl, wCreditsBlankFrame2bpp
 	ld c, (wCreditsBlankFrame2bppEnd - wCreditsBlankFrame2bpp) / 2
-	ld de, `22222222 ; eight pixels, each with color #2
+	ld de, `22222222 ; eight pixels, each color #2 (dark)
+
+; Fill wCreditsBlankFrame2bpp with 4x4=16 tiles, all solid dark color
+; (the same color used for the four border frame mons' backgrounds)
 
 .load_loop
 	ld a, e

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -20,8 +20,8 @@ Credits::
 	call ClearTileMap
 	call ClearSprites
 
-	ld hl, wCreditsFaux2bpp
-	ld c, wCreditsFaux2bppEnd - wCreditsFaux2bpp
+	ld hl, wCreditsBlankFrame2bpp
+	ld c, (wCreditsBlankFrame2bppEnd - wCreditsBlankFrame2bpp) / 2
 	ld de, `22222222 ; eight pixels, each with color #2
 
 .load_loop
@@ -561,7 +561,7 @@ Credits_LoadBorderGFX:
 	ret
 
 .init
-	ld hl, wCreditsFaux2bpp
+	ld hl, wCreditsBlankFrame2bpp
 	ret
 
 .Frames:

--- a/engine/movie/crystal_intro.asm
+++ b/engine/movie/crystal_intro.asm
@@ -795,7 +795,7 @@ IntroScene9:
 	call DelayFrame
 	call DelayFrame
 	call DelayFrame
-	ld a, $c ; $980c
+	ld a, LOW(vBGMap0 + $c) ; $c
 	ldh [hBGMapAddress], a
 	call DelayFrame
 	call DelayFrame

--- a/engine/pokemon/experience.asm
+++ b/engine/pokemon/experience.asm
@@ -58,11 +58,11 @@ CalcExpAtLevel:
 	ld b, 4
 	call Divide
 ; Push the cubic term to the stack
-	ldh a, [hQuotient + 0]
-	push af
 	ldh a, [hQuotient + 1]
 	push af
 	ldh a, [hQuotient + 2]
+	push af
+	ldh a, [hQuotient + 3]
 	push af
 ; Square the level and multiply by the lower 7 bits of c
 	call .LevelSquared

--- a/engine/pokemon/health.asm
+++ b/engine/pokemon/health.asm
@@ -91,7 +91,7 @@ ComputeHPBarPixels:
 	ldh [hDivisor], a
 	ld b, 4
 	call Divide
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld e, a
 	pop hl
 	and a

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -766,10 +766,10 @@ MonMenu_Softboiled_MilkDrink:
 	call Divide
 	ld a, MON_HP + 1
 	call GetPartyParamLocation
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	sub [hl]
 	dec hl
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	sbc [hl]
 	ret
 

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -1570,11 +1570,11 @@ CalcMonStatC:
 	jr nz, .not_hp
 	ld a, [wCurPartyLevel]
 	ld b, a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add b
 	ldh [hMultiplicand + 2], a
 	jr nc, .no_overflow_3
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	inc a
 	ldh [hMultiplicand + 1], a
 
@@ -1583,21 +1583,21 @@ CalcMonStatC:
 
 .not_hp
 	ld b, a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	add b
 	ldh [hMultiplicand + 2], a
 	jr nc, .no_overflow_4
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	inc a
 	ldh [hMultiplicand + 1], a
 
 .no_overflow_4
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	cp HIGH(MAX_STAT_VALUE + 1) + 1
 	jr nc, .max_stat
 	cp HIGH(MAX_STAT_VALUE + 1)
 	jr c, .stat_value_okay
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	cp LOW(MAX_STAT_VALUE + 1)
 	jr c, .stat_value_okay
 

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -636,15 +636,15 @@ StatsScreen_LoadGFX:
 	farcall CalcExpAtLevel
 	ld hl, wTempMonExp + 2
 	ld hl, wTempMonExp + 2
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	sub [hl]
 	dec hl
 	ld [wBuffer3], a
-	ldh a, [hQuotient + 1]
+	ldh a, [hQuotient + 2]
 	sbc [hl]
 	dec hl
 	ld [wBuffer2], a
-	ldh a, [hQuotient]
+	ldh a, [hQuotient + 1]
 	sbc [hl]
 	ld [wBuffer1], a
 	ret

--- a/hram.asm
+++ b/hram.asm
@@ -66,7 +66,7 @@ UNION ; ffb3
 
 UNION ; ffb3
 ; inputs to Multiply
-    ds 1
+	ds 1
 hMultiplicand:: ds 3 ; ffb4
 hMultiplier::   db   ; ffb7
 NEXTU ; ffb3

--- a/hram.asm
+++ b/hram.asm
@@ -63,9 +63,7 @@ hEnemyMonSpeed:: dw ; ffb1
 
 UNION ; ffb3
 ; miscellaneous
-	ds 2
-hPartyMon1Speed:: dw ; ffb5
-	ds 5
+	ds 9
 hMGStatusFlags:: db ; ffbc
 
 NEXTU ; ffb3
@@ -85,8 +83,7 @@ hDivisor:: db ; ffb7
 
 NEXTU ; ffb3
 ; results of Divide
-	ds 1
-hQuotient:: ds 3 ; ffb4
+hQuotient:: ds 4 ; ffb3
 hRemainder:: db ; ffb7
 
 NEXTU ; ffb3

--- a/hram.asm
+++ b/hram.asm
@@ -62,38 +62,36 @@ ENDU ; ffb1
 hEnemyMonSpeed:: dw ; ffb1
 
 UNION ; ffb3
-; miscellaneous
-	ds 9
-hMGStatusFlags:: db ; ffbc
+; math-related values
 
-NEXTU ; ffb3
+UNION ; ffb3
 ; inputs to Multiply
-	ds 1
+    ds 1
 hMultiplicand:: ds 3 ; ffb4
-hMultiplier:: db ; ffb7
-
+hMultiplier::   db   ; ffb7
 NEXTU ; ffb3
 ; result of Multiply
-hProduct:: ds 4 ; ffb3
-
+hProduct::      ds 4 ; ffb3
 NEXTU ; ffb3
 ; inputs to Divide
-hDividend:: ds 4 ; ffb3
-hDivisor:: db ; ffb7
-
+hDividend::     ds 4 ; ffb3
+hDivisor::      db   ; ffb7
 NEXTU ; ffb3
 ; results of Divide
-hQuotient:: ds 4 ; ffb3
-hRemainder:: db ; ffb7
+hQuotient::     ds 4 ; ffb3
+hRemainder::    db   ; ffb7
+ENDU ; ffb8
 
-NEXTU ; ffb3
-; math-related scratch space
-	ds 5
 hMathBuffer:: ds 5 ; ffb8
 
 NEXTU ; ffb3
 ; PrintNum scratch space
 hPrintNumBuffer:: ds 10 ; ffb3
+
+NEXTU ; ffb3
+; miscellaneous
+    ds 9
+hMGStatusFlags:: db ; ffbc
 ENDU ; ffbd
 
 hUsedSpriteIndex:: db ; ffbd

--- a/mobile/mobile_12.asm
+++ b/mobile/mobile_12.asm
@@ -1799,7 +1799,7 @@ Function48d94:
 	sla b
 	or b
 	ld [hld], a
-	ldh a, [hQuotient + 2]
+	ldh a, [hQuotient + 3]
 	ld c, 10
 	call SimpleDivide
 	sla b

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -5145,7 +5145,7 @@ Function11a80c:
 	ld bc, hDividend
 	ld hl, Unknown_11a89a
 	call Function11a88c
-	ld bc, hQuotient
+	ld bc, hQuotient + 1
 	ld hl, Unknown_11a8ba
 	call Function11a88c
 	ld bc, hPrintNumBuffer + 2

--- a/wram.asm
+++ b/wram.asm
@@ -1069,26 +1069,22 @@ wc9f9:: ds 7
 
 UNION ; ca00
 ; blank credits tile buffer
-wCreditsFaux2bpp:: ds 8 * LEN_2BPP_TILE
-wCreditsFaux2bppEnd::
+wCreditsBlankFrame2bpp:: ds 16 tiles
+wCreditsBlankFrame2bppEnd::
 
 NEXTU ; ca00
 ; mystery gift data
 wca00:: db
 wca01:: db
 wca02:: db
-	ds 160
-ENDU ; caa3
 
-wcaa3:: ds 2
-wcaa5:: ds 16
-wcab5:: ds 10
-wcabf:: ds 10
-wcac9:: ds 63
-wcb08:: ds 6
+NEXTU ; ca00
+; link data
+	ds 191
+wcabf:: ds 79
 wcb0e:: ds 5
-wcb13:: ds 9
-wcb1c:: ds 14
+wcb13:: ds 23
+ENDU ; cb2a
 
 wBillsPC_ScrollPosition:: db
 wBillsPC_CursorPosition:: db

--- a/wram.asm
+++ b/wram.asm
@@ -45,7 +45,7 @@ wCurNoteDuration:: db ; used in MusicE0 and LoadNote
 wCurMusicByte:: db ; c298
 wCurChannel:: db ; c299
 wVolume:: ; c29a
-; corresponds to $ff24
+; corresponds to rNR50
 ; Channel control / ON-OFF / Volume (R/W)
 ;   bit 7 - Vin->SO2 ON/OFF
 ;   bit 6-4 - SO2 output level (volume) (# 0-7)
@@ -53,12 +53,12 @@ wVolume:: ; c29a
 ;   bit 2-0 - SO1 output level (volume) (# 0-7)
 	db
 wSoundOutput:: ; c29b
-; corresponds to $ff25
+; corresponds to rNR51
 ; bit 4-7: ch1-4 so2 on/off
 ; bit 0-3: ch1-4 so1 on/off
 	db
 wSoundInput:: ; c29c
-; corresponds to $ff26
+; corresponds to rNR52
 ; bit 7: global on/off
 ; bit 0: ch1 on/off
 ; bit 1: ch2 on/off
@@ -1069,7 +1069,8 @@ wc9f9:: ds 7
 
 UNION ; ca00
 ; blank credits tile buffer
-wCreditsFaux2bpp:: ds 128
+wCreditsFaux2bpp:: ds 8 * LEN_2BPP_TILE
+wCreditsFaux2bppEnd::
 
 NEXTU ; ca00
 ; mystery gift data

--- a/wram.asm
+++ b/wram.asm
@@ -1069,7 +1069,7 @@ wc9f9:: ds 7
 
 UNION ; ca00
 ; blank credits tile buffer
-wCreditsBlankFrame2bpp:: ds 16 tiles
+wCreditsBlankFrame2bpp:: ds 4 * 4 tiles
 wCreditsBlankFrame2bppEnd::
 
 NEXTU ; ca00


### PR DESCRIPTION
- Use rgbasm's GameBoy graphics literal for initializing `wCreditsFaux2bpp`

In the 2BPP format, two bytes `%ABCDEFGH %abcdefgh` define eight pixels `%Aa %Bb %Cc %Dd %Ee %Ff %Gg %Hh`.  
Four valid colors: `%00` = 0 = white, `%01` = 1 = dark, `%10` = 2 = light, `%11` = 3 = black.  
Thus `` `22222222 `` = pixels `%10 %10 %10 %10 %10 %10 %10 %10` = bytes `%11111111 %00000000` = `$ff00`.

- `_Divide` results go in `hQuotient` and `hRemainder`, not in `hDividend` and `hDivisor`

Note that the result quotient is four bytes, but `hQuotient` is a three-byte buffer. Issue #558 explains this.