### PR TITLE
Fix #537: Palettes generated from PNGs use .gbcpal directly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,20 @@ pokecrystal11.gbc: $(crystal11_obj) pokecrystal.link
 		tools/lzcomp -- $< $@)
 
 
+### Pokemon pic graphics rules
+
+gfx/pokemon/%/front.animated.2bpp: gfx/pokemon/%/front.2bpp gfx/pokemon/%/front.dimensions
+	tools/pokemon_animation_graphics -o $@ $^
+gfx/pokemon/%/front.animated.tilemap: gfx/pokemon/%/front.2bpp gfx/pokemon/%/front.dimensions
+	tools/pokemon_animation_graphics -t $@ $^
+gfx/pokemon/%/bitmask.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/front.dimensions
+	tools/pokemon_animation -b $^ > $@
+gfx/pokemon/%/frames.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/front.dimensions
+	tools/pokemon_animation -f $^ > $@
+gfx/pokemon/%/back.2bpp: gfx/pokemon/%/back.png
+	$(RGBGFX) -h -o $@ $<
+
+
 ### Terrible hacks to match animations. Delete these rules if you don't care about matching.
 
 # Dewgong has an unused tile id in its last frame. The tile itself is missing.
@@ -117,24 +131,6 @@ gfx/pokemon/girafarig/front.animated.2bpp: gfx/pokemon/girafarig/front.2bpp gfx/
 	tools/pokemon_animation_graphics --girafarig -o $@ $^
 gfx/pokemon/girafarig/front.animated.tilemap: gfx/pokemon/girafarig/front.2bpp gfx/pokemon/girafarig/front.dimensions
 	tools/pokemon_animation_graphics --girafarig -t $@ $^
-
-
-### Pokemon pic graphics rules
-
-gfx/pokemon/%/front.dimensions: gfx/pokemon/%/front.png
-	tools/png_dimensions $< $@
-gfx/pokemon/%/normal.gbcpal: gfx/pokemon/%/front.png
-	$(RGBGFX) -p $@ $<
-gfx/pokemon/%/back.2bpp: gfx/pokemon/%/back.png
-	$(RGBGFX) -h -o $@ $<
-gfx/pokemon/%/bitmask.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/front.dimensions
-	tools/pokemon_animation -b $^ > $@
-gfx/pokemon/%/frames.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/front.dimensions
-	tools/pokemon_animation -f $^ > $@
-gfx/pokemon/%/front.animated.2bpp: gfx/pokemon/%/front.2bpp gfx/pokemon/%/front.dimensions
-	tools/pokemon_animation_graphics -o $@ $^
-gfx/pokemon/%/front.animated.tilemap: gfx/pokemon/%/front.2bpp gfx/pokemon/%/front.dimensions
-	tools/pokemon_animation_graphics -t $@ $^
 
 
 ### Misc file-specific graphics rules

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ pokecrystal11.gbc: $(crystal11_obj) pokecrystal.link
 		tools/lzcomp -- $< $@)
 
 
-### Pokemon pic graphics rules
+### Pokemon pic animation rules
 
 gfx/pokemon/%/front.animated.2bpp: gfx/pokemon/%/front.2bpp gfx/pokemon/%/front.dimensions
 	tools/pokemon_animation_graphics -o $@ $^
@@ -109,8 +109,6 @@ gfx/pokemon/%/bitmask.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/fr
 	tools/pokemon_animation -b $^ > $@
 gfx/pokemon/%/frames.asm: gfx/pokemon/%/front.animated.tilemap gfx/pokemon/%/front.dimensions
 	tools/pokemon_animation -f $^ > $@
-gfx/pokemon/%/back.2bpp: gfx/pokemon/%/back.png
-	$(RGBGFX) -h -o $@ $<
 
 
 ### Terrible hacks to match animations. Delete these rules if you don't care about matching.
@@ -135,10 +133,12 @@ gfx/pokemon/girafarig/front.animated.tilemap: gfx/pokemon/girafarig/front.2bpp g
 
 ### Misc file-specific graphics rules
 
-gfx/new_game/shrink1.2bpp: rgbgfx += -h
-gfx/new_game/shrink2.2bpp: rgbgfx += -h
+gfx/pokemon/%/back.2bpp: rgbgfx += -h
 
 gfx/trainers/%.2bpp: rgbgfx += -h
+
+gfx/new_game/shrink1.2bpp: rgbgfx += -h
+gfx/new_game/shrink2.2bpp: rgbgfx += -h
 
 gfx/mail/dragonite.1bpp: tools/gfx += --remove-whitespace
 gfx/mail/large_note.1bpp: tools/gfx += --remove-whitespace

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,6 @@ gfx/pokemon/girafarig/front.animated.tilemap: gfx/pokemon/girafarig/front.2bpp g
 
 gfx/pokemon/%/front.dimensions: gfx/pokemon/%/front.png
 	tools/png_dimensions $< $@
-gfx/pokemon/%/normal.pal: gfx/pokemon/%/normal.gbcpal
-	tools/palette -p $< > $@
 gfx/pokemon/%/normal.gbcpal: gfx/pokemon/%/front.png
 	$(RGBGFX) -p $@ $<
 gfx/pokemon/%/back.2bpp: gfx/pokemon/%/back.png
@@ -145,10 +143,6 @@ gfx/new_game/shrink1.2bpp: rgbgfx += -h
 gfx/new_game/shrink2.2bpp: rgbgfx += -h
 
 gfx/trainers/%.2bpp: rgbgfx += -h
-gfx/trainers/%.pal: gfx/trainers/%.gbcpal
-	tools/palette -p $< > $@
-gfx/trainers/%.gbcpal: gfx/trainers/%.png
-	$(RGBGFX) -p $@ $<
 
 gfx/mail/dragonite.1bpp: tools/gfx += --remove-whitespace
 gfx/mail/large_note.1bpp: tools/gfx += --remove-whitespace

--- a/data/pokemon/palettes.asm
+++ b/data/pokemon/palettes.asm
@@ -1,8 +1,9 @@
 PokemonPalettes:
 ; entries correspond to Pokémon species, two apiece
 
-; Each normal.gbcpal is generated from front.png, and
+; Each front.gbcpal is generated from the corresponding .png, and
 ; only the middle two colors are included, not black or white.
+; Shiny palettes are defined directly, not generated.
 
 ; 000
 	RGB 30, 22, 17
@@ -11,507 +12,507 @@ PokemonPalettes:
 	RGB 30, 22, 17
 	RGB 16, 14, 19
 
-INCBIN "gfx/pokemon/bulbasaur/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/bulbasaur/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bulbasaur/shiny.pal"
-INCBIN "gfx/pokemon/ivysaur/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ivysaur/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ivysaur/shiny.pal"
-INCBIN "gfx/pokemon/venusaur/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/venusaur/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venusaur/shiny.pal"
-INCBIN "gfx/pokemon/charmander/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/charmander/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charmander/shiny.pal"
-INCBIN "gfx/pokemon/charmeleon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/charmeleon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charmeleon/shiny.pal"
-INCBIN "gfx/pokemon/charizard/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/charizard/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charizard/shiny.pal"
-INCBIN "gfx/pokemon/squirtle/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/squirtle/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/squirtle/shiny.pal"
-INCBIN "gfx/pokemon/wartortle/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/wartortle/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wartortle/shiny.pal"
-INCBIN "gfx/pokemon/blastoise/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/blastoise/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/blastoise/shiny.pal"
-INCBIN "gfx/pokemon/caterpie/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/caterpie/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/caterpie/shiny.pal"
-INCBIN "gfx/pokemon/metapod/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/metapod/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/metapod/shiny.pal"
-INCBIN "gfx/pokemon/butterfree/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/butterfree/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/butterfree/shiny.pal"
-INCBIN "gfx/pokemon/weedle/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/weedle/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weedle/shiny.pal"
-INCBIN "gfx/pokemon/kakuna/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kakuna/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kakuna/shiny.pal"
-INCBIN "gfx/pokemon/beedrill/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/beedrill/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/beedrill/shiny.pal"
-INCBIN "gfx/pokemon/pidgey/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pidgey/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgey/shiny.pal"
-INCBIN "gfx/pokemon/pidgeotto/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pidgeotto/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgeotto/shiny.pal"
-INCBIN "gfx/pokemon/pidgeot/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pidgeot/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgeot/shiny.pal"
-INCBIN "gfx/pokemon/rattata/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/rattata/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rattata/shiny.pal"
-INCBIN "gfx/pokemon/raticate/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/raticate/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raticate/shiny.pal"
-INCBIN "gfx/pokemon/spearow/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/spearow/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/spearow/shiny.pal"
-INCBIN "gfx/pokemon/fearow/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/fearow/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/fearow/shiny.pal"
-INCBIN "gfx/pokemon/ekans/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ekans/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ekans/shiny.pal"
-INCBIN "gfx/pokemon/arbok/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/arbok/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/arbok/shiny.pal"
-INCBIN "gfx/pokemon/pikachu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pikachu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pikachu/shiny.pal"
-INCBIN "gfx/pokemon/raichu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/raichu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raichu/shiny.pal"
-INCBIN "gfx/pokemon/sandshrew/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sandshrew/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sandshrew/shiny.pal"
-INCBIN "gfx/pokemon/sandslash/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sandslash/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sandslash/shiny.pal"
-INCBIN "gfx/pokemon/nidoran_f/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidoran_f/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoran_f/shiny.pal"
-INCBIN "gfx/pokemon/nidorina/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidorina/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidorina/shiny.pal"
-INCBIN "gfx/pokemon/nidoqueen/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidoqueen/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoqueen/shiny.pal"
-INCBIN "gfx/pokemon/nidoran_m/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidoran_m/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoran_m/shiny.pal"
-INCBIN "gfx/pokemon/nidorino/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidorino/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidorino/shiny.pal"
-INCBIN "gfx/pokemon/nidoking/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/nidoking/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoking/shiny.pal"
-INCBIN "gfx/pokemon/clefairy/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/clefairy/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/clefairy/shiny.pal"
-INCBIN "gfx/pokemon/clefable/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/clefable/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/clefable/shiny.pal"
-INCBIN "gfx/pokemon/vulpix/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/vulpix/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vulpix/shiny.pal"
-INCBIN "gfx/pokemon/ninetales/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ninetales/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ninetales/shiny.pal"
-INCBIN "gfx/pokemon/jigglypuff/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/jigglypuff/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jigglypuff/shiny.pal"
-INCBIN "gfx/pokemon/wigglytuff/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/wigglytuff/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wigglytuff/shiny.pal"
-INCBIN "gfx/pokemon/zubat/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/zubat/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/zubat/shiny.pal"
-INCBIN "gfx/pokemon/golbat/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/golbat/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golbat/shiny.pal"
-INCBIN "gfx/pokemon/oddish/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/oddish/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/oddish/shiny.pal"
-INCBIN "gfx/pokemon/gloom/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/gloom/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gloom/shiny.pal"
-INCBIN "gfx/pokemon/vileplume/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/vileplume/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vileplume/shiny.pal"
-INCBIN "gfx/pokemon/paras/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/paras/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/paras/shiny.pal"
-INCBIN "gfx/pokemon/parasect/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/parasect/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/parasect/shiny.pal"
-INCBIN "gfx/pokemon/venonat/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/venonat/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venonat/shiny.pal"
-INCBIN "gfx/pokemon/venomoth/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/venomoth/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venomoth/shiny.pal"
-INCBIN "gfx/pokemon/diglett/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/diglett/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/diglett/shiny.pal"
-INCBIN "gfx/pokemon/dugtrio/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dugtrio/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dugtrio/shiny.pal"
-INCBIN "gfx/pokemon/meowth/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/meowth/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/meowth/shiny.pal"
-INCBIN "gfx/pokemon/persian/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/persian/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/persian/shiny.pal"
-INCBIN "gfx/pokemon/psyduck/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/psyduck/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/psyduck/shiny.pal"
-INCBIN "gfx/pokemon/golduck/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/golduck/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golduck/shiny.pal"
-INCBIN "gfx/pokemon/mankey/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mankey/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mankey/shiny.pal"
-INCBIN "gfx/pokemon/primeape/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/primeape/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/primeape/shiny.pal"
-INCBIN "gfx/pokemon/growlithe/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/growlithe/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/growlithe/shiny.pal"
-INCBIN "gfx/pokemon/arcanine/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/arcanine/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/arcanine/shiny.pal"
-INCBIN "gfx/pokemon/poliwag/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/poliwag/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwag/shiny.pal"
-INCBIN "gfx/pokemon/poliwhirl/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/poliwhirl/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwhirl/shiny.pal"
-INCBIN "gfx/pokemon/poliwrath/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/poliwrath/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwrath/shiny.pal"
-INCBIN "gfx/pokemon/abra/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/abra/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/abra/shiny.pal"
-INCBIN "gfx/pokemon/kadabra/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kadabra/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kadabra/shiny.pal"
-INCBIN "gfx/pokemon/alakazam/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/alakazam/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/alakazam/shiny.pal"
-INCBIN "gfx/pokemon/machop/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/machop/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machop/shiny.pal"
-INCBIN "gfx/pokemon/machoke/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/machoke/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machoke/shiny.pal"
-INCBIN "gfx/pokemon/machamp/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/machamp/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machamp/shiny.pal"
-INCBIN "gfx/pokemon/bellsprout/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/bellsprout/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bellsprout/shiny.pal"
-INCBIN "gfx/pokemon/weepinbell/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/weepinbell/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weepinbell/shiny.pal"
-INCBIN "gfx/pokemon/victreebel/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/victreebel/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/victreebel/shiny.pal"
-INCBIN "gfx/pokemon/tentacool/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tentacool/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tentacool/shiny.pal"
-INCBIN "gfx/pokemon/tentacruel/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tentacruel/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tentacruel/shiny.pal"
-INCBIN "gfx/pokemon/geodude/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/geodude/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/geodude/shiny.pal"
-INCBIN "gfx/pokemon/graveler/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/graveler/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/graveler/shiny.pal"
-INCBIN "gfx/pokemon/golem/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/golem/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golem/shiny.pal"
-INCBIN "gfx/pokemon/ponyta/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ponyta/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ponyta/shiny.pal"
-INCBIN "gfx/pokemon/rapidash/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/rapidash/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rapidash/shiny.pal"
-INCBIN "gfx/pokemon/slowpoke/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/slowpoke/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowpoke/shiny.pal"
-INCBIN "gfx/pokemon/slowbro/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/slowbro/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowbro/shiny.pal"
-INCBIN "gfx/pokemon/magnemite/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magnemite/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magnemite/shiny.pal"
-INCBIN "gfx/pokemon/magneton/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magneton/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magneton/shiny.pal"
-INCBIN "gfx/pokemon/farfetch_d/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/farfetch_d/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/farfetch_d/shiny.pal"
-INCBIN "gfx/pokemon/doduo/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/doduo/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/doduo/shiny.pal"
-INCBIN "gfx/pokemon/dodrio/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dodrio/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dodrio/shiny.pal"
-INCBIN "gfx/pokemon/seel/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/seel/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seel/shiny.pal"
-INCBIN "gfx/pokemon/dewgong/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dewgong/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dewgong/shiny.pal"
-INCBIN "gfx/pokemon/grimer/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/grimer/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/grimer/shiny.pal"
-INCBIN "gfx/pokemon/muk/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/muk/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/muk/shiny.pal"
-INCBIN "gfx/pokemon/shellder/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/shellder/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/shellder/shiny.pal"
-INCBIN "gfx/pokemon/cloyster/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/cloyster/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cloyster/shiny.pal"
-INCBIN "gfx/pokemon/gastly/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/gastly/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gastly/shiny.pal"
-INCBIN "gfx/pokemon/haunter/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/haunter/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/haunter/shiny.pal"
-INCBIN "gfx/pokemon/gengar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/gengar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gengar/shiny.pal"
-INCBIN "gfx/pokemon/onix/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/onix/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/onix/shiny.pal"
-INCBIN "gfx/pokemon/drowzee/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/drowzee/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/drowzee/shiny.pal"
-INCBIN "gfx/pokemon/hypno/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hypno/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hypno/shiny.pal"
-INCBIN "gfx/pokemon/krabby/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/krabby/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/krabby/shiny.pal"
-INCBIN "gfx/pokemon/kingler/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kingler/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kingler/shiny.pal"
-INCBIN "gfx/pokemon/voltorb/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/voltorb/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/voltorb/shiny.pal"
-INCBIN "gfx/pokemon/electrode/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/electrode/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/electrode/shiny.pal"
-INCBIN "gfx/pokemon/exeggcute/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/exeggcute/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/exeggcute/shiny.pal"
-INCBIN "gfx/pokemon/exeggutor/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/exeggutor/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/exeggutor/shiny.pal"
-INCBIN "gfx/pokemon/cubone/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/cubone/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cubone/shiny.pal"
-INCBIN "gfx/pokemon/marowak/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/marowak/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/marowak/shiny.pal"
-INCBIN "gfx/pokemon/hitmonlee/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hitmonlee/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmonlee/shiny.pal"
-INCBIN "gfx/pokemon/hitmonchan/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hitmonchan/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmonchan/shiny.pal"
-INCBIN "gfx/pokemon/lickitung/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/lickitung/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lickitung/shiny.pal"
-INCBIN "gfx/pokemon/koffing/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/koffing/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/koffing/shiny.pal"
-INCBIN "gfx/pokemon/weezing/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/weezing/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weezing/shiny.pal"
-INCBIN "gfx/pokemon/rhyhorn/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/rhyhorn/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rhyhorn/shiny.pal"
-INCBIN "gfx/pokemon/rhydon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/rhydon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rhydon/shiny.pal"
-INCBIN "gfx/pokemon/chansey/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/chansey/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chansey/shiny.pal"
-INCBIN "gfx/pokemon/tangela/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tangela/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tangela/shiny.pal"
-INCBIN "gfx/pokemon/kangaskhan/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kangaskhan/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kangaskhan/shiny.pal"
-INCBIN "gfx/pokemon/horsea/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/horsea/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/horsea/shiny.pal"
-INCBIN "gfx/pokemon/seadra/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/seadra/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seadra/shiny.pal"
-INCBIN "gfx/pokemon/goldeen/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/goldeen/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/goldeen/shiny.pal"
-INCBIN "gfx/pokemon/seaking/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/seaking/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seaking/shiny.pal"
-INCBIN "gfx/pokemon/staryu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/staryu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/staryu/shiny.pal"
-INCBIN "gfx/pokemon/starmie/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/starmie/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/starmie/shiny.pal"
-INCBIN "gfx/pokemon/mr__mime/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mr__mime/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mr__mime/shiny.pal"
-INCBIN "gfx/pokemon/scyther/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/scyther/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/scyther/shiny.pal"
-INCBIN "gfx/pokemon/jynx/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/jynx/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jynx/shiny.pal"
-INCBIN "gfx/pokemon/electabuzz/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/electabuzz/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/electabuzz/shiny.pal"
-INCBIN "gfx/pokemon/magmar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magmar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magmar/shiny.pal"
-INCBIN "gfx/pokemon/pinsir/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pinsir/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pinsir/shiny.pal"
-INCBIN "gfx/pokemon/tauros/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tauros/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tauros/shiny.pal"
-INCBIN "gfx/pokemon/magikarp/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magikarp/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magikarp/shiny.pal"
-INCBIN "gfx/pokemon/gyarados/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/gyarados/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gyarados/shiny.pal"
-INCBIN "gfx/pokemon/lapras/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/lapras/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lapras/shiny.pal"
-INCBIN "gfx/pokemon/ditto/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ditto/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ditto/shiny.pal"
-INCBIN "gfx/pokemon/eevee/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/eevee/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/eevee/shiny.pal"
-INCBIN "gfx/pokemon/vaporeon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/vaporeon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vaporeon/shiny.pal"
-INCBIN "gfx/pokemon/jolteon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/jolteon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jolteon/shiny.pal"
-INCBIN "gfx/pokemon/flareon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/flareon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/flareon/shiny.pal"
-INCBIN "gfx/pokemon/porygon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/porygon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/porygon/shiny.pal"
-INCBIN "gfx/pokemon/omanyte/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/omanyte/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/omanyte/shiny.pal"
-INCBIN "gfx/pokemon/omastar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/omastar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/omastar/shiny.pal"
-INCBIN "gfx/pokemon/kabuto/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kabuto/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kabuto/shiny.pal"
-INCBIN "gfx/pokemon/kabutops/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kabutops/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kabutops/shiny.pal"
-INCBIN "gfx/pokemon/aerodactyl/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/aerodactyl/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/aerodactyl/shiny.pal"
-INCBIN "gfx/pokemon/snorlax/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/snorlax/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/snorlax/shiny.pal"
-INCBIN "gfx/pokemon/articuno/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/articuno/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/articuno/shiny.pal"
-INCBIN "gfx/pokemon/zapdos/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/zapdos/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/zapdos/shiny.pal"
-INCBIN "gfx/pokemon/moltres/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/moltres/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/moltres/shiny.pal"
-INCBIN "gfx/pokemon/dratini/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dratini/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dratini/shiny.pal"
-INCBIN "gfx/pokemon/dragonair/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dragonair/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dragonair/shiny.pal"
-INCBIN "gfx/pokemon/dragonite/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dragonite/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dragonite/shiny.pal"
-INCBIN "gfx/pokemon/mewtwo/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mewtwo/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mewtwo/shiny.pal"
-INCBIN "gfx/pokemon/mew/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mew/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mew/shiny.pal"
-INCBIN "gfx/pokemon/chikorita/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/chikorita/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chikorita/shiny.pal"
-INCBIN "gfx/pokemon/bayleef/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/bayleef/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bayleef/shiny.pal"
-INCBIN "gfx/pokemon/meganium/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/meganium/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/meganium/shiny.pal"
-INCBIN "gfx/pokemon/cyndaquil/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/cyndaquil/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cyndaquil/shiny.pal"
-INCBIN "gfx/pokemon/quilava/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/quilava/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/quilava/shiny.pal"
-INCBIN "gfx/pokemon/typhlosion/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/typhlosion/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/typhlosion/shiny.pal"
-INCBIN "gfx/pokemon/totodile/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/totodile/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/totodile/shiny.pal"
-INCBIN "gfx/pokemon/croconaw/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/croconaw/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/croconaw/shiny.pal"
-INCBIN "gfx/pokemon/feraligatr/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/feraligatr/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/feraligatr/shiny.pal"
-INCBIN "gfx/pokemon/sentret/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sentret/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sentret/shiny.pal"
-INCBIN "gfx/pokemon/furret/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/furret/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/furret/shiny.pal"
-INCBIN "gfx/pokemon/hoothoot/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hoothoot/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hoothoot/shiny.pal"
-INCBIN "gfx/pokemon/noctowl/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/noctowl/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/noctowl/shiny.pal"
-INCBIN "gfx/pokemon/ledyba/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ledyba/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ledyba/shiny.pal"
-INCBIN "gfx/pokemon/ledian/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ledian/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ledian/shiny.pal"
-INCBIN "gfx/pokemon/spinarak/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/spinarak/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/spinarak/shiny.pal"
-INCBIN "gfx/pokemon/ariados/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ariados/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ariados/shiny.pal"
-INCBIN "gfx/pokemon/crobat/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/crobat/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/crobat/shiny.pal"
-INCBIN "gfx/pokemon/chinchou/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/chinchou/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chinchou/shiny.pal"
-INCBIN "gfx/pokemon/lanturn/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/lanturn/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lanturn/shiny.pal"
-INCBIN "gfx/pokemon/pichu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pichu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pichu/shiny.pal"
-INCBIN "gfx/pokemon/cleffa/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/cleffa/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cleffa/shiny.pal"
-INCBIN "gfx/pokemon/igglybuff/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/igglybuff/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/igglybuff/shiny.pal"
-INCBIN "gfx/pokemon/togepi/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/togepi/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/togepi/shiny.pal"
-INCBIN "gfx/pokemon/togetic/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/togetic/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/togetic/shiny.pal"
-INCBIN "gfx/pokemon/natu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/natu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/natu/shiny.pal"
-INCBIN "gfx/pokemon/xatu/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/xatu/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/xatu/shiny.pal"
-INCBIN "gfx/pokemon/mareep/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mareep/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mareep/shiny.pal"
-INCBIN "gfx/pokemon/flaaffy/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/flaaffy/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/flaaffy/shiny.pal"
-INCBIN "gfx/pokemon/ampharos/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ampharos/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ampharos/shiny.pal"
-INCBIN "gfx/pokemon/bellossom/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/bellossom/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bellossom/shiny.pal"
-INCBIN "gfx/pokemon/marill/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/marill/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/marill/shiny.pal"
-INCBIN "gfx/pokemon/azumarill/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/azumarill/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/azumarill/shiny.pal"
-INCBIN "gfx/pokemon/sudowoodo/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sudowoodo/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sudowoodo/shiny.pal"
-INCBIN "gfx/pokemon/politoed/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/politoed/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/politoed/shiny.pal"
-INCBIN "gfx/pokemon/hoppip/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hoppip/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hoppip/shiny.pal"
-INCBIN "gfx/pokemon/skiploom/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/skiploom/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/skiploom/shiny.pal"
-INCBIN "gfx/pokemon/jumpluff/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/jumpluff/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jumpluff/shiny.pal"
-INCBIN "gfx/pokemon/aipom/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/aipom/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/aipom/shiny.pal"
-INCBIN "gfx/pokemon/sunkern/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sunkern/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sunkern/shiny.pal"
-INCBIN "gfx/pokemon/sunflora/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sunflora/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sunflora/shiny.pal"
-INCBIN "gfx/pokemon/yanma/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/yanma/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/yanma/shiny.pal"
-INCBIN "gfx/pokemon/wooper/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/wooper/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wooper/shiny.pal"
-INCBIN "gfx/pokemon/quagsire/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/quagsire/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/quagsire/shiny.pal"
-INCBIN "gfx/pokemon/espeon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/espeon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/espeon/shiny.pal"
-INCBIN "gfx/pokemon/umbreon/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/umbreon/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/umbreon/shiny.pal"
-INCBIN "gfx/pokemon/murkrow/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/murkrow/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/murkrow/shiny.pal"
-INCBIN "gfx/pokemon/slowking/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/slowking/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowking/shiny.pal"
-INCBIN "gfx/pokemon/misdreavus/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/misdreavus/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/misdreavus/shiny.pal"
-INCLUDE "gfx/pokemon/unown/normal.pal" ; not .gbcpal
+INCLUDE "gfx/pokemon/unown/normal.pal" ; not front.gbcpal
 INCLUDE "gfx/pokemon/unown/shiny.pal"
-INCBIN "gfx/pokemon/wobbuffet/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/wobbuffet/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wobbuffet/shiny.pal"
-INCBIN "gfx/pokemon/girafarig/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/girafarig/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/girafarig/shiny.pal"
-INCBIN "gfx/pokemon/pineco/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pineco/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pineco/shiny.pal"
-INCBIN "gfx/pokemon/forretress/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/forretress/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/forretress/shiny.pal"
-INCBIN "gfx/pokemon/dunsparce/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/dunsparce/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dunsparce/shiny.pal"
-INCBIN "gfx/pokemon/gligar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/gligar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gligar/shiny.pal"
-INCBIN "gfx/pokemon/steelix/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/steelix/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/steelix/shiny.pal"
-INCBIN "gfx/pokemon/snubbull/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/snubbull/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/snubbull/shiny.pal"
-INCBIN "gfx/pokemon/granbull/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/granbull/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/granbull/shiny.pal"
-INCBIN "gfx/pokemon/qwilfish/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/qwilfish/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/qwilfish/shiny.pal"
-INCBIN "gfx/pokemon/scizor/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/scizor/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/scizor/shiny.pal"
-INCBIN "gfx/pokemon/shuckle/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/shuckle/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/shuckle/shiny.pal"
-INCBIN "gfx/pokemon/heracross/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/heracross/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/heracross/shiny.pal"
-INCBIN "gfx/pokemon/sneasel/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/sneasel/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sneasel/shiny.pal"
-INCBIN "gfx/pokemon/teddiursa/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/teddiursa/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/teddiursa/shiny.pal"
-INCBIN "gfx/pokemon/ursaring/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ursaring/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ursaring/shiny.pal"
-INCBIN "gfx/pokemon/slugma/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/slugma/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slugma/shiny.pal"
-INCBIN "gfx/pokemon/magcargo/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magcargo/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magcargo/shiny.pal"
-INCBIN "gfx/pokemon/swinub/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/swinub/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/swinub/shiny.pal"
-INCBIN "gfx/pokemon/piloswine/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/piloswine/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/piloswine/shiny.pal"
-INCBIN "gfx/pokemon/corsola/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/corsola/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/corsola/shiny.pal"
-INCBIN "gfx/pokemon/remoraid/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/remoraid/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/remoraid/shiny.pal"
-INCBIN "gfx/pokemon/octillery/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/octillery/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/octillery/shiny.pal"
-INCBIN "gfx/pokemon/delibird/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/delibird/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/delibird/shiny.pal"
-INCBIN "gfx/pokemon/mantine/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/mantine/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mantine/shiny.pal"
-INCBIN "gfx/pokemon/skarmory/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/skarmory/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/skarmory/shiny.pal"
-INCBIN "gfx/pokemon/houndour/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/houndour/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/houndour/shiny.pal"
-INCBIN "gfx/pokemon/houndoom/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/houndoom/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/houndoom/shiny.pal"
-INCBIN "gfx/pokemon/kingdra/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/kingdra/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kingdra/shiny.pal"
-INCBIN "gfx/pokemon/phanpy/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/phanpy/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/phanpy/shiny.pal"
-INCBIN "gfx/pokemon/donphan/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/donphan/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/donphan/shiny.pal"
-INCBIN "gfx/pokemon/porygon2/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/porygon2/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/porygon2/shiny.pal"
-INCBIN "gfx/pokemon/stantler/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/stantler/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/stantler/shiny.pal"
-INCBIN "gfx/pokemon/smeargle/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/smeargle/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/smeargle/shiny.pal"
-INCBIN "gfx/pokemon/tyrogue/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tyrogue/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tyrogue/shiny.pal"
-INCBIN "gfx/pokemon/hitmontop/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/hitmontop/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmontop/shiny.pal"
-INCBIN "gfx/pokemon/smoochum/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/smoochum/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/smoochum/shiny.pal"
-INCBIN "gfx/pokemon/elekid/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/elekid/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/elekid/shiny.pal"
-INCBIN "gfx/pokemon/magby/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/magby/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magby/shiny.pal"
-INCBIN "gfx/pokemon/miltank/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/miltank/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/miltank/shiny.pal"
-INCBIN "gfx/pokemon/blissey/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/blissey/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/blissey/shiny.pal"
-INCBIN "gfx/pokemon/raikou/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/raikou/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raikou/shiny.pal"
-INCBIN "gfx/pokemon/entei/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/entei/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/entei/shiny.pal"
-INCBIN "gfx/pokemon/suicune/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/suicune/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/suicune/shiny.pal"
-INCBIN "gfx/pokemon/larvitar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/larvitar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/larvitar/shiny.pal"
-INCBIN "gfx/pokemon/pupitar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/pupitar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pupitar/shiny.pal"
-INCBIN "gfx/pokemon/tyranitar/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/tyranitar/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tyranitar/shiny.pal"
-INCBIN "gfx/pokemon/lugia/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/lugia/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lugia/shiny.pal"
-INCBIN "gfx/pokemon/ho_oh/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/ho_oh/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ho_oh/shiny.pal"
-INCBIN "gfx/pokemon/celebi/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/celebi/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/celebi/shiny.pal"
 
 ; 252
@@ -521,7 +522,7 @@ INCLUDE "gfx/pokemon/celebi/shiny.pal"
 	RGB 30, 26, 11
 	RGB 23, 16, 00
 
-INCBIN "gfx/pokemon/egg/normal.gbcpal", middle_colors
+INCBIN "gfx/pokemon/egg/front.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/egg/shiny.pal"
 
 ; 254

--- a/data/pokemon/palettes.asm
+++ b/data/pokemon/palettes.asm
@@ -1,6 +1,9 @@
 PokemonPalettes:
 ; entries correspond to Pokémon species, two apiece
 
+; Each normal.gbcpal is generated from front.png, and
+; only the middle two colors are included, not black or white.
+
 ; 000
 	RGB 30, 22, 17
 	RGB 16, 14, 19
@@ -8,507 +11,507 @@ PokemonPalettes:
 	RGB 30, 22, 17
 	RGB 16, 14, 19
 
-INCLUDE "gfx/pokemon/bulbasaur/normal.pal"
+INCBIN "gfx/pokemon/bulbasaur/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bulbasaur/shiny.pal"
-INCLUDE "gfx/pokemon/ivysaur/normal.pal"
+INCBIN "gfx/pokemon/ivysaur/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ivysaur/shiny.pal"
-INCLUDE "gfx/pokemon/venusaur/normal.pal"
+INCBIN "gfx/pokemon/venusaur/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venusaur/shiny.pal"
-INCLUDE "gfx/pokemon/charmander/normal.pal"
+INCBIN "gfx/pokemon/charmander/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charmander/shiny.pal"
-INCLUDE "gfx/pokemon/charmeleon/normal.pal"
+INCBIN "gfx/pokemon/charmeleon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charmeleon/shiny.pal"
-INCLUDE "gfx/pokemon/charizard/normal.pal"
+INCBIN "gfx/pokemon/charizard/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/charizard/shiny.pal"
-INCLUDE "gfx/pokemon/squirtle/normal.pal"
+INCBIN "gfx/pokemon/squirtle/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/squirtle/shiny.pal"
-INCLUDE "gfx/pokemon/wartortle/normal.pal"
+INCBIN "gfx/pokemon/wartortle/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wartortle/shiny.pal"
-INCLUDE "gfx/pokemon/blastoise/normal.pal"
+INCBIN "gfx/pokemon/blastoise/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/blastoise/shiny.pal"
-INCLUDE "gfx/pokemon/caterpie/normal.pal"
+INCBIN "gfx/pokemon/caterpie/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/caterpie/shiny.pal"
-INCLUDE "gfx/pokemon/metapod/normal.pal"
+INCBIN "gfx/pokemon/metapod/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/metapod/shiny.pal"
-INCLUDE "gfx/pokemon/butterfree/normal.pal"
+INCBIN "gfx/pokemon/butterfree/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/butterfree/shiny.pal"
-INCLUDE "gfx/pokemon/weedle/normal.pal"
+INCBIN "gfx/pokemon/weedle/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weedle/shiny.pal"
-INCLUDE "gfx/pokemon/kakuna/normal.pal"
+INCBIN "gfx/pokemon/kakuna/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kakuna/shiny.pal"
-INCLUDE "gfx/pokemon/beedrill/normal.pal"
+INCBIN "gfx/pokemon/beedrill/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/beedrill/shiny.pal"
-INCLUDE "gfx/pokemon/pidgey/normal.pal"
+INCBIN "gfx/pokemon/pidgey/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgey/shiny.pal"
-INCLUDE "gfx/pokemon/pidgeotto/normal.pal"
+INCBIN "gfx/pokemon/pidgeotto/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgeotto/shiny.pal"
-INCLUDE "gfx/pokemon/pidgeot/normal.pal"
+INCBIN "gfx/pokemon/pidgeot/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pidgeot/shiny.pal"
-INCLUDE "gfx/pokemon/rattata/normal.pal"
+INCBIN "gfx/pokemon/rattata/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rattata/shiny.pal"
-INCLUDE "gfx/pokemon/raticate/normal.pal"
+INCBIN "gfx/pokemon/raticate/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raticate/shiny.pal"
-INCLUDE "gfx/pokemon/spearow/normal.pal"
+INCBIN "gfx/pokemon/spearow/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/spearow/shiny.pal"
-INCLUDE "gfx/pokemon/fearow/normal.pal"
+INCBIN "gfx/pokemon/fearow/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/fearow/shiny.pal"
-INCLUDE "gfx/pokemon/ekans/normal.pal"
+INCBIN "gfx/pokemon/ekans/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ekans/shiny.pal"
-INCLUDE "gfx/pokemon/arbok/normal.pal"
+INCBIN "gfx/pokemon/arbok/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/arbok/shiny.pal"
-INCLUDE "gfx/pokemon/pikachu/normal.pal"
+INCBIN "gfx/pokemon/pikachu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pikachu/shiny.pal"
-INCLUDE "gfx/pokemon/raichu/normal.pal"
+INCBIN "gfx/pokemon/raichu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raichu/shiny.pal"
-INCLUDE "gfx/pokemon/sandshrew/normal.pal"
+INCBIN "gfx/pokemon/sandshrew/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sandshrew/shiny.pal"
-INCLUDE "gfx/pokemon/sandslash/normal.pal"
+INCBIN "gfx/pokemon/sandslash/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sandslash/shiny.pal"
-INCLUDE "gfx/pokemon/nidoran_f/normal.pal"
+INCBIN "gfx/pokemon/nidoran_f/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoran_f/shiny.pal"
-INCLUDE "gfx/pokemon/nidorina/normal.pal"
+INCBIN "gfx/pokemon/nidorina/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidorina/shiny.pal"
-INCLUDE "gfx/pokemon/nidoqueen/normal.pal"
+INCBIN "gfx/pokemon/nidoqueen/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoqueen/shiny.pal"
-INCLUDE "gfx/pokemon/nidoran_m/normal.pal"
+INCBIN "gfx/pokemon/nidoran_m/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoran_m/shiny.pal"
-INCLUDE "gfx/pokemon/nidorino/normal.pal"
+INCBIN "gfx/pokemon/nidorino/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidorino/shiny.pal"
-INCLUDE "gfx/pokemon/nidoking/normal.pal"
+INCBIN "gfx/pokemon/nidoking/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/nidoking/shiny.pal"
-INCLUDE "gfx/pokemon/clefairy/normal.pal"
+INCBIN "gfx/pokemon/clefairy/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/clefairy/shiny.pal"
-INCLUDE "gfx/pokemon/clefable/normal.pal"
+INCBIN "gfx/pokemon/clefable/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/clefable/shiny.pal"
-INCLUDE "gfx/pokemon/vulpix/normal.pal"
+INCBIN "gfx/pokemon/vulpix/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vulpix/shiny.pal"
-INCLUDE "gfx/pokemon/ninetales/normal.pal"
+INCBIN "gfx/pokemon/ninetales/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ninetales/shiny.pal"
-INCLUDE "gfx/pokemon/jigglypuff/normal.pal"
+INCBIN "gfx/pokemon/jigglypuff/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jigglypuff/shiny.pal"
-INCLUDE "gfx/pokemon/wigglytuff/normal.pal"
+INCBIN "gfx/pokemon/wigglytuff/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wigglytuff/shiny.pal"
-INCLUDE "gfx/pokemon/zubat/normal.pal"
+INCBIN "gfx/pokemon/zubat/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/zubat/shiny.pal"
-INCLUDE "gfx/pokemon/golbat/normal.pal"
+INCBIN "gfx/pokemon/golbat/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golbat/shiny.pal"
-INCLUDE "gfx/pokemon/oddish/normal.pal"
+INCBIN "gfx/pokemon/oddish/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/oddish/shiny.pal"
-INCLUDE "gfx/pokemon/gloom/normal.pal"
+INCBIN "gfx/pokemon/gloom/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gloom/shiny.pal"
-INCLUDE "gfx/pokemon/vileplume/normal.pal"
+INCBIN "gfx/pokemon/vileplume/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vileplume/shiny.pal"
-INCLUDE "gfx/pokemon/paras/normal.pal"
+INCBIN "gfx/pokemon/paras/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/paras/shiny.pal"
-INCLUDE "gfx/pokemon/parasect/normal.pal"
+INCBIN "gfx/pokemon/parasect/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/parasect/shiny.pal"
-INCLUDE "gfx/pokemon/venonat/normal.pal"
+INCBIN "gfx/pokemon/venonat/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venonat/shiny.pal"
-INCLUDE "gfx/pokemon/venomoth/normal.pal"
+INCBIN "gfx/pokemon/venomoth/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/venomoth/shiny.pal"
-INCLUDE "gfx/pokemon/diglett/normal.pal"
+INCBIN "gfx/pokemon/diglett/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/diglett/shiny.pal"
-INCLUDE "gfx/pokemon/dugtrio/normal.pal"
+INCBIN "gfx/pokemon/dugtrio/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dugtrio/shiny.pal"
-INCLUDE "gfx/pokemon/meowth/normal.pal"
+INCBIN "gfx/pokemon/meowth/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/meowth/shiny.pal"
-INCLUDE "gfx/pokemon/persian/normal.pal"
+INCBIN "gfx/pokemon/persian/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/persian/shiny.pal"
-INCLUDE "gfx/pokemon/psyduck/normal.pal"
+INCBIN "gfx/pokemon/psyduck/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/psyduck/shiny.pal"
-INCLUDE "gfx/pokemon/golduck/normal.pal"
+INCBIN "gfx/pokemon/golduck/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golduck/shiny.pal"
-INCLUDE "gfx/pokemon/mankey/normal.pal"
+INCBIN "gfx/pokemon/mankey/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mankey/shiny.pal"
-INCLUDE "gfx/pokemon/primeape/normal.pal"
+INCBIN "gfx/pokemon/primeape/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/primeape/shiny.pal"
-INCLUDE "gfx/pokemon/growlithe/normal.pal"
+INCBIN "gfx/pokemon/growlithe/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/growlithe/shiny.pal"
-INCLUDE "gfx/pokemon/arcanine/normal.pal"
+INCBIN "gfx/pokemon/arcanine/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/arcanine/shiny.pal"
-INCLUDE "gfx/pokemon/poliwag/normal.pal"
+INCBIN "gfx/pokemon/poliwag/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwag/shiny.pal"
-INCLUDE "gfx/pokemon/poliwhirl/normal.pal"
+INCBIN "gfx/pokemon/poliwhirl/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwhirl/shiny.pal"
-INCLUDE "gfx/pokemon/poliwrath/normal.pal"
+INCBIN "gfx/pokemon/poliwrath/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/poliwrath/shiny.pal"
-INCLUDE "gfx/pokemon/abra/normal.pal"
+INCBIN "gfx/pokemon/abra/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/abra/shiny.pal"
-INCLUDE "gfx/pokemon/kadabra/normal.pal"
+INCBIN "gfx/pokemon/kadabra/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kadabra/shiny.pal"
-INCLUDE "gfx/pokemon/alakazam/normal.pal"
+INCBIN "gfx/pokemon/alakazam/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/alakazam/shiny.pal"
-INCLUDE "gfx/pokemon/machop/normal.pal"
+INCBIN "gfx/pokemon/machop/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machop/shiny.pal"
-INCLUDE "gfx/pokemon/machoke/normal.pal"
+INCBIN "gfx/pokemon/machoke/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machoke/shiny.pal"
-INCLUDE "gfx/pokemon/machamp/normal.pal"
+INCBIN "gfx/pokemon/machamp/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/machamp/shiny.pal"
-INCLUDE "gfx/pokemon/bellsprout/normal.pal"
+INCBIN "gfx/pokemon/bellsprout/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bellsprout/shiny.pal"
-INCLUDE "gfx/pokemon/weepinbell/normal.pal"
+INCBIN "gfx/pokemon/weepinbell/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weepinbell/shiny.pal"
-INCLUDE "gfx/pokemon/victreebel/normal.pal"
+INCBIN "gfx/pokemon/victreebel/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/victreebel/shiny.pal"
-INCLUDE "gfx/pokemon/tentacool/normal.pal"
+INCBIN "gfx/pokemon/tentacool/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tentacool/shiny.pal"
-INCLUDE "gfx/pokemon/tentacruel/normal.pal"
+INCBIN "gfx/pokemon/tentacruel/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tentacruel/shiny.pal"
-INCLUDE "gfx/pokemon/geodude/normal.pal"
+INCBIN "gfx/pokemon/geodude/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/geodude/shiny.pal"
-INCLUDE "gfx/pokemon/graveler/normal.pal"
+INCBIN "gfx/pokemon/graveler/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/graveler/shiny.pal"
-INCLUDE "gfx/pokemon/golem/normal.pal"
+INCBIN "gfx/pokemon/golem/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/golem/shiny.pal"
-INCLUDE "gfx/pokemon/ponyta/normal.pal"
+INCBIN "gfx/pokemon/ponyta/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ponyta/shiny.pal"
-INCLUDE "gfx/pokemon/rapidash/normal.pal"
+INCBIN "gfx/pokemon/rapidash/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rapidash/shiny.pal"
-INCLUDE "gfx/pokemon/slowpoke/normal.pal"
+INCBIN "gfx/pokemon/slowpoke/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowpoke/shiny.pal"
-INCLUDE "gfx/pokemon/slowbro/normal.pal"
+INCBIN "gfx/pokemon/slowbro/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowbro/shiny.pal"
-INCLUDE "gfx/pokemon/magnemite/normal.pal"
+INCBIN "gfx/pokemon/magnemite/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magnemite/shiny.pal"
-INCLUDE "gfx/pokemon/magneton/normal.pal"
+INCBIN "gfx/pokemon/magneton/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magneton/shiny.pal"
-INCLUDE "gfx/pokemon/farfetch_d/normal.pal"
+INCBIN "gfx/pokemon/farfetch_d/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/farfetch_d/shiny.pal"
-INCLUDE "gfx/pokemon/doduo/normal.pal"
+INCBIN "gfx/pokemon/doduo/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/doduo/shiny.pal"
-INCLUDE "gfx/pokemon/dodrio/normal.pal"
+INCBIN "gfx/pokemon/dodrio/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dodrio/shiny.pal"
-INCLUDE "gfx/pokemon/seel/normal.pal"
+INCBIN "gfx/pokemon/seel/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seel/shiny.pal"
-INCLUDE "gfx/pokemon/dewgong/normal.pal"
+INCBIN "gfx/pokemon/dewgong/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dewgong/shiny.pal"
-INCLUDE "gfx/pokemon/grimer/normal.pal"
+INCBIN "gfx/pokemon/grimer/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/grimer/shiny.pal"
-INCLUDE "gfx/pokemon/muk/normal.pal"
+INCBIN "gfx/pokemon/muk/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/muk/shiny.pal"
-INCLUDE "gfx/pokemon/shellder/normal.pal"
+INCBIN "gfx/pokemon/shellder/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/shellder/shiny.pal"
-INCLUDE "gfx/pokemon/cloyster/normal.pal"
+INCBIN "gfx/pokemon/cloyster/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cloyster/shiny.pal"
-INCLUDE "gfx/pokemon/gastly/normal.pal"
+INCBIN "gfx/pokemon/gastly/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gastly/shiny.pal"
-INCLUDE "gfx/pokemon/haunter/normal.pal"
+INCBIN "gfx/pokemon/haunter/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/haunter/shiny.pal"
-INCLUDE "gfx/pokemon/gengar/normal.pal"
+INCBIN "gfx/pokemon/gengar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gengar/shiny.pal"
-INCLUDE "gfx/pokemon/onix/normal.pal"
+INCBIN "gfx/pokemon/onix/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/onix/shiny.pal"
-INCLUDE "gfx/pokemon/drowzee/normal.pal"
+INCBIN "gfx/pokemon/drowzee/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/drowzee/shiny.pal"
-INCLUDE "gfx/pokemon/hypno/normal.pal"
+INCBIN "gfx/pokemon/hypno/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hypno/shiny.pal"
-INCLUDE "gfx/pokemon/krabby/normal.pal"
+INCBIN "gfx/pokemon/krabby/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/krabby/shiny.pal"
-INCLUDE "gfx/pokemon/kingler/normal.pal"
+INCBIN "gfx/pokemon/kingler/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kingler/shiny.pal"
-INCLUDE "gfx/pokemon/voltorb/normal.pal"
+INCBIN "gfx/pokemon/voltorb/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/voltorb/shiny.pal"
-INCLUDE "gfx/pokemon/electrode/normal.pal"
+INCBIN "gfx/pokemon/electrode/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/electrode/shiny.pal"
-INCLUDE "gfx/pokemon/exeggcute/normal.pal"
+INCBIN "gfx/pokemon/exeggcute/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/exeggcute/shiny.pal"
-INCLUDE "gfx/pokemon/exeggutor/normal.pal"
+INCBIN "gfx/pokemon/exeggutor/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/exeggutor/shiny.pal"
-INCLUDE "gfx/pokemon/cubone/normal.pal"
+INCBIN "gfx/pokemon/cubone/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cubone/shiny.pal"
-INCLUDE "gfx/pokemon/marowak/normal.pal"
+INCBIN "gfx/pokemon/marowak/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/marowak/shiny.pal"
-INCLUDE "gfx/pokemon/hitmonlee/normal.pal"
+INCBIN "gfx/pokemon/hitmonlee/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmonlee/shiny.pal"
-INCLUDE "gfx/pokemon/hitmonchan/normal.pal"
+INCBIN "gfx/pokemon/hitmonchan/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmonchan/shiny.pal"
-INCLUDE "gfx/pokemon/lickitung/normal.pal"
+INCBIN "gfx/pokemon/lickitung/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lickitung/shiny.pal"
-INCLUDE "gfx/pokemon/koffing/normal.pal"
+INCBIN "gfx/pokemon/koffing/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/koffing/shiny.pal"
-INCLUDE "gfx/pokemon/weezing/normal.pal"
+INCBIN "gfx/pokemon/weezing/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/weezing/shiny.pal"
-INCLUDE "gfx/pokemon/rhyhorn/normal.pal"
+INCBIN "gfx/pokemon/rhyhorn/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rhyhorn/shiny.pal"
-INCLUDE "gfx/pokemon/rhydon/normal.pal"
+INCBIN "gfx/pokemon/rhydon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/rhydon/shiny.pal"
-INCLUDE "gfx/pokemon/chansey/normal.pal"
+INCBIN "gfx/pokemon/chansey/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chansey/shiny.pal"
-INCLUDE "gfx/pokemon/tangela/normal.pal"
+INCBIN "gfx/pokemon/tangela/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tangela/shiny.pal"
-INCLUDE "gfx/pokemon/kangaskhan/normal.pal"
+INCBIN "gfx/pokemon/kangaskhan/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kangaskhan/shiny.pal"
-INCLUDE "gfx/pokemon/horsea/normal.pal"
+INCBIN "gfx/pokemon/horsea/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/horsea/shiny.pal"
-INCLUDE "gfx/pokemon/seadra/normal.pal"
+INCBIN "gfx/pokemon/seadra/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seadra/shiny.pal"
-INCLUDE "gfx/pokemon/goldeen/normal.pal"
+INCBIN "gfx/pokemon/goldeen/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/goldeen/shiny.pal"
-INCLUDE "gfx/pokemon/seaking/normal.pal"
+INCBIN "gfx/pokemon/seaking/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/seaking/shiny.pal"
-INCLUDE "gfx/pokemon/staryu/normal.pal"
+INCBIN "gfx/pokemon/staryu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/staryu/shiny.pal"
-INCLUDE "gfx/pokemon/starmie/normal.pal"
+INCBIN "gfx/pokemon/starmie/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/starmie/shiny.pal"
-INCLUDE "gfx/pokemon/mr__mime/normal.pal"
+INCBIN "gfx/pokemon/mr__mime/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mr__mime/shiny.pal"
-INCLUDE "gfx/pokemon/scyther/normal.pal"
+INCBIN "gfx/pokemon/scyther/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/scyther/shiny.pal"
-INCLUDE "gfx/pokemon/jynx/normal.pal"
+INCBIN "gfx/pokemon/jynx/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jynx/shiny.pal"
-INCLUDE "gfx/pokemon/electabuzz/normal.pal"
+INCBIN "gfx/pokemon/electabuzz/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/electabuzz/shiny.pal"
-INCLUDE "gfx/pokemon/magmar/normal.pal"
+INCBIN "gfx/pokemon/magmar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magmar/shiny.pal"
-INCLUDE "gfx/pokemon/pinsir/normal.pal"
+INCBIN "gfx/pokemon/pinsir/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pinsir/shiny.pal"
-INCLUDE "gfx/pokemon/tauros/normal.pal"
+INCBIN "gfx/pokemon/tauros/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tauros/shiny.pal"
-INCLUDE "gfx/pokemon/magikarp/normal.pal"
+INCBIN "gfx/pokemon/magikarp/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magikarp/shiny.pal"
-INCLUDE "gfx/pokemon/gyarados/normal.pal"
+INCBIN "gfx/pokemon/gyarados/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gyarados/shiny.pal"
-INCLUDE "gfx/pokemon/lapras/normal.pal"
+INCBIN "gfx/pokemon/lapras/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lapras/shiny.pal"
-INCLUDE "gfx/pokemon/ditto/normal.pal"
+INCBIN "gfx/pokemon/ditto/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ditto/shiny.pal"
-INCLUDE "gfx/pokemon/eevee/normal.pal"
+INCBIN "gfx/pokemon/eevee/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/eevee/shiny.pal"
-INCLUDE "gfx/pokemon/vaporeon/normal.pal"
+INCBIN "gfx/pokemon/vaporeon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/vaporeon/shiny.pal"
-INCLUDE "gfx/pokemon/jolteon/normal.pal"
+INCBIN "gfx/pokemon/jolteon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jolteon/shiny.pal"
-INCLUDE "gfx/pokemon/flareon/normal.pal"
+INCBIN "gfx/pokemon/flareon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/flareon/shiny.pal"
-INCLUDE "gfx/pokemon/porygon/normal.pal"
+INCBIN "gfx/pokemon/porygon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/porygon/shiny.pal"
-INCLUDE "gfx/pokemon/omanyte/normal.pal"
+INCBIN "gfx/pokemon/omanyte/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/omanyte/shiny.pal"
-INCLUDE "gfx/pokemon/omastar/normal.pal"
+INCBIN "gfx/pokemon/omastar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/omastar/shiny.pal"
-INCLUDE "gfx/pokemon/kabuto/normal.pal"
+INCBIN "gfx/pokemon/kabuto/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kabuto/shiny.pal"
-INCLUDE "gfx/pokemon/kabutops/normal.pal"
+INCBIN "gfx/pokemon/kabutops/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kabutops/shiny.pal"
-INCLUDE "gfx/pokemon/aerodactyl/normal.pal"
+INCBIN "gfx/pokemon/aerodactyl/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/aerodactyl/shiny.pal"
-INCLUDE "gfx/pokemon/snorlax/normal.pal"
+INCBIN "gfx/pokemon/snorlax/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/snorlax/shiny.pal"
-INCLUDE "gfx/pokemon/articuno/normal.pal"
+INCBIN "gfx/pokemon/articuno/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/articuno/shiny.pal"
-INCLUDE "gfx/pokemon/zapdos/normal.pal"
+INCBIN "gfx/pokemon/zapdos/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/zapdos/shiny.pal"
-INCLUDE "gfx/pokemon/moltres/normal.pal"
+INCBIN "gfx/pokemon/moltres/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/moltres/shiny.pal"
-INCLUDE "gfx/pokemon/dratini/normal.pal"
+INCBIN "gfx/pokemon/dratini/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dratini/shiny.pal"
-INCLUDE "gfx/pokemon/dragonair/normal.pal"
+INCBIN "gfx/pokemon/dragonair/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dragonair/shiny.pal"
-INCLUDE "gfx/pokemon/dragonite/normal.pal"
+INCBIN "gfx/pokemon/dragonite/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dragonite/shiny.pal"
-INCLUDE "gfx/pokemon/mewtwo/normal.pal"
+INCBIN "gfx/pokemon/mewtwo/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mewtwo/shiny.pal"
-INCLUDE "gfx/pokemon/mew/normal.pal"
+INCBIN "gfx/pokemon/mew/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mew/shiny.pal"
-INCLUDE "gfx/pokemon/chikorita/normal.pal"
+INCBIN "gfx/pokemon/chikorita/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chikorita/shiny.pal"
-INCLUDE "gfx/pokemon/bayleef/normal.pal"
+INCBIN "gfx/pokemon/bayleef/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bayleef/shiny.pal"
-INCLUDE "gfx/pokemon/meganium/normal.pal"
+INCBIN "gfx/pokemon/meganium/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/meganium/shiny.pal"
-INCLUDE "gfx/pokemon/cyndaquil/normal.pal"
+INCBIN "gfx/pokemon/cyndaquil/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cyndaquil/shiny.pal"
-INCLUDE "gfx/pokemon/quilava/normal.pal"
+INCBIN "gfx/pokemon/quilava/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/quilava/shiny.pal"
-INCLUDE "gfx/pokemon/typhlosion/normal.pal"
+INCBIN "gfx/pokemon/typhlosion/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/typhlosion/shiny.pal"
-INCLUDE "gfx/pokemon/totodile/normal.pal"
+INCBIN "gfx/pokemon/totodile/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/totodile/shiny.pal"
-INCLUDE "gfx/pokemon/croconaw/normal.pal"
+INCBIN "gfx/pokemon/croconaw/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/croconaw/shiny.pal"
-INCLUDE "gfx/pokemon/feraligatr/normal.pal"
+INCBIN "gfx/pokemon/feraligatr/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/feraligatr/shiny.pal"
-INCLUDE "gfx/pokemon/sentret/normal.pal"
+INCBIN "gfx/pokemon/sentret/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sentret/shiny.pal"
-INCLUDE "gfx/pokemon/furret/normal.pal"
+INCBIN "gfx/pokemon/furret/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/furret/shiny.pal"
-INCLUDE "gfx/pokemon/hoothoot/normal.pal"
+INCBIN "gfx/pokemon/hoothoot/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hoothoot/shiny.pal"
-INCLUDE "gfx/pokemon/noctowl/normal.pal"
+INCBIN "gfx/pokemon/noctowl/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/noctowl/shiny.pal"
-INCLUDE "gfx/pokemon/ledyba/normal.pal"
+INCBIN "gfx/pokemon/ledyba/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ledyba/shiny.pal"
-INCLUDE "gfx/pokemon/ledian/normal.pal"
+INCBIN "gfx/pokemon/ledian/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ledian/shiny.pal"
-INCLUDE "gfx/pokemon/spinarak/normal.pal"
+INCBIN "gfx/pokemon/spinarak/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/spinarak/shiny.pal"
-INCLUDE "gfx/pokemon/ariados/normal.pal"
+INCBIN "gfx/pokemon/ariados/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ariados/shiny.pal"
-INCLUDE "gfx/pokemon/crobat/normal.pal"
+INCBIN "gfx/pokemon/crobat/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/crobat/shiny.pal"
-INCLUDE "gfx/pokemon/chinchou/normal.pal"
+INCBIN "gfx/pokemon/chinchou/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/chinchou/shiny.pal"
-INCLUDE "gfx/pokemon/lanturn/normal.pal"
+INCBIN "gfx/pokemon/lanturn/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lanturn/shiny.pal"
-INCLUDE "gfx/pokemon/pichu/normal.pal"
+INCBIN "gfx/pokemon/pichu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pichu/shiny.pal"
-INCLUDE "gfx/pokemon/cleffa/normal.pal"
+INCBIN "gfx/pokemon/cleffa/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/cleffa/shiny.pal"
-INCLUDE "gfx/pokemon/igglybuff/normal.pal"
+INCBIN "gfx/pokemon/igglybuff/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/igglybuff/shiny.pal"
-INCLUDE "gfx/pokemon/togepi/normal.pal"
+INCBIN "gfx/pokemon/togepi/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/togepi/shiny.pal"
-INCLUDE "gfx/pokemon/togetic/normal.pal"
+INCBIN "gfx/pokemon/togetic/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/togetic/shiny.pal"
-INCLUDE "gfx/pokemon/natu/normal.pal"
+INCBIN "gfx/pokemon/natu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/natu/shiny.pal"
-INCLUDE "gfx/pokemon/xatu/normal.pal"
+INCBIN "gfx/pokemon/xatu/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/xatu/shiny.pal"
-INCLUDE "gfx/pokemon/mareep/normal.pal"
+INCBIN "gfx/pokemon/mareep/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mareep/shiny.pal"
-INCLUDE "gfx/pokemon/flaaffy/normal.pal"
+INCBIN "gfx/pokemon/flaaffy/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/flaaffy/shiny.pal"
-INCLUDE "gfx/pokemon/ampharos/normal.pal"
+INCBIN "gfx/pokemon/ampharos/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ampharos/shiny.pal"
-INCLUDE "gfx/pokemon/bellossom/normal.pal"
+INCBIN "gfx/pokemon/bellossom/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/bellossom/shiny.pal"
-INCLUDE "gfx/pokemon/marill/normal.pal"
+INCBIN "gfx/pokemon/marill/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/marill/shiny.pal"
-INCLUDE "gfx/pokemon/azumarill/normal.pal"
+INCBIN "gfx/pokemon/azumarill/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/azumarill/shiny.pal"
-INCLUDE "gfx/pokemon/sudowoodo/normal.pal"
+INCBIN "gfx/pokemon/sudowoodo/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sudowoodo/shiny.pal"
-INCLUDE "gfx/pokemon/politoed/normal.pal"
+INCBIN "gfx/pokemon/politoed/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/politoed/shiny.pal"
-INCLUDE "gfx/pokemon/hoppip/normal.pal"
+INCBIN "gfx/pokemon/hoppip/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hoppip/shiny.pal"
-INCLUDE "gfx/pokemon/skiploom/normal.pal"
+INCBIN "gfx/pokemon/skiploom/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/skiploom/shiny.pal"
-INCLUDE "gfx/pokemon/jumpluff/normal.pal"
+INCBIN "gfx/pokemon/jumpluff/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/jumpluff/shiny.pal"
-INCLUDE "gfx/pokemon/aipom/normal.pal"
+INCBIN "gfx/pokemon/aipom/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/aipom/shiny.pal"
-INCLUDE "gfx/pokemon/sunkern/normal.pal"
+INCBIN "gfx/pokemon/sunkern/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sunkern/shiny.pal"
-INCLUDE "gfx/pokemon/sunflora/normal.pal"
+INCBIN "gfx/pokemon/sunflora/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sunflora/shiny.pal"
-INCLUDE "gfx/pokemon/yanma/normal.pal"
+INCBIN "gfx/pokemon/yanma/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/yanma/shiny.pal"
-INCLUDE "gfx/pokemon/wooper/normal.pal"
+INCBIN "gfx/pokemon/wooper/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wooper/shiny.pal"
-INCLUDE "gfx/pokemon/quagsire/normal.pal"
+INCBIN "gfx/pokemon/quagsire/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/quagsire/shiny.pal"
-INCLUDE "gfx/pokemon/espeon/normal.pal"
+INCBIN "gfx/pokemon/espeon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/espeon/shiny.pal"
-INCLUDE "gfx/pokemon/umbreon/normal.pal"
+INCBIN "gfx/pokemon/umbreon/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/umbreon/shiny.pal"
-INCLUDE "gfx/pokemon/murkrow/normal.pal"
+INCBIN "gfx/pokemon/murkrow/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/murkrow/shiny.pal"
-INCLUDE "gfx/pokemon/slowking/normal.pal"
+INCBIN "gfx/pokemon/slowking/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slowking/shiny.pal"
-INCLUDE "gfx/pokemon/misdreavus/normal.pal"
+INCBIN "gfx/pokemon/misdreavus/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/misdreavus/shiny.pal"
-INCLUDE "gfx/pokemon/unown/normal.pal"
+INCLUDE "gfx/pokemon/unown/normal.pal" ; not .gbcpal
 INCLUDE "gfx/pokemon/unown/shiny.pal"
-INCLUDE "gfx/pokemon/wobbuffet/normal.pal"
+INCBIN "gfx/pokemon/wobbuffet/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/wobbuffet/shiny.pal"
-INCLUDE "gfx/pokemon/girafarig/normal.pal"
+INCBIN "gfx/pokemon/girafarig/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/girafarig/shiny.pal"
-INCLUDE "gfx/pokemon/pineco/normal.pal"
+INCBIN "gfx/pokemon/pineco/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pineco/shiny.pal"
-INCLUDE "gfx/pokemon/forretress/normal.pal"
+INCBIN "gfx/pokemon/forretress/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/forretress/shiny.pal"
-INCLUDE "gfx/pokemon/dunsparce/normal.pal"
+INCBIN "gfx/pokemon/dunsparce/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/dunsparce/shiny.pal"
-INCLUDE "gfx/pokemon/gligar/normal.pal"
+INCBIN "gfx/pokemon/gligar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/gligar/shiny.pal"
-INCLUDE "gfx/pokemon/steelix/normal.pal"
+INCBIN "gfx/pokemon/steelix/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/steelix/shiny.pal"
-INCLUDE "gfx/pokemon/snubbull/normal.pal"
+INCBIN "gfx/pokemon/snubbull/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/snubbull/shiny.pal"
-INCLUDE "gfx/pokemon/granbull/normal.pal"
+INCBIN "gfx/pokemon/granbull/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/granbull/shiny.pal"
-INCLUDE "gfx/pokemon/qwilfish/normal.pal"
+INCBIN "gfx/pokemon/qwilfish/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/qwilfish/shiny.pal"
-INCLUDE "gfx/pokemon/scizor/normal.pal"
+INCBIN "gfx/pokemon/scizor/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/scizor/shiny.pal"
-INCLUDE "gfx/pokemon/shuckle/normal.pal"
+INCBIN "gfx/pokemon/shuckle/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/shuckle/shiny.pal"
-INCLUDE "gfx/pokemon/heracross/normal.pal"
+INCBIN "gfx/pokemon/heracross/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/heracross/shiny.pal"
-INCLUDE "gfx/pokemon/sneasel/normal.pal"
+INCBIN "gfx/pokemon/sneasel/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/sneasel/shiny.pal"
-INCLUDE "gfx/pokemon/teddiursa/normal.pal"
+INCBIN "gfx/pokemon/teddiursa/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/teddiursa/shiny.pal"
-INCLUDE "gfx/pokemon/ursaring/normal.pal"
+INCBIN "gfx/pokemon/ursaring/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ursaring/shiny.pal"
-INCLUDE "gfx/pokemon/slugma/normal.pal"
+INCBIN "gfx/pokemon/slugma/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/slugma/shiny.pal"
-INCLUDE "gfx/pokemon/magcargo/normal.pal"
+INCBIN "gfx/pokemon/magcargo/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magcargo/shiny.pal"
-INCLUDE "gfx/pokemon/swinub/normal.pal"
+INCBIN "gfx/pokemon/swinub/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/swinub/shiny.pal"
-INCLUDE "gfx/pokemon/piloswine/normal.pal"
+INCBIN "gfx/pokemon/piloswine/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/piloswine/shiny.pal"
-INCLUDE "gfx/pokemon/corsola/normal.pal"
+INCBIN "gfx/pokemon/corsola/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/corsola/shiny.pal"
-INCLUDE "gfx/pokemon/remoraid/normal.pal"
+INCBIN "gfx/pokemon/remoraid/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/remoraid/shiny.pal"
-INCLUDE "gfx/pokemon/octillery/normal.pal"
+INCBIN "gfx/pokemon/octillery/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/octillery/shiny.pal"
-INCLUDE "gfx/pokemon/delibird/normal.pal"
+INCBIN "gfx/pokemon/delibird/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/delibird/shiny.pal"
-INCLUDE "gfx/pokemon/mantine/normal.pal"
+INCBIN "gfx/pokemon/mantine/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/mantine/shiny.pal"
-INCLUDE "gfx/pokemon/skarmory/normal.pal"
+INCBIN "gfx/pokemon/skarmory/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/skarmory/shiny.pal"
-INCLUDE "gfx/pokemon/houndour/normal.pal"
+INCBIN "gfx/pokemon/houndour/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/houndour/shiny.pal"
-INCLUDE "gfx/pokemon/houndoom/normal.pal"
+INCBIN "gfx/pokemon/houndoom/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/houndoom/shiny.pal"
-INCLUDE "gfx/pokemon/kingdra/normal.pal"
+INCBIN "gfx/pokemon/kingdra/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/kingdra/shiny.pal"
-INCLUDE "gfx/pokemon/phanpy/normal.pal"
+INCBIN "gfx/pokemon/phanpy/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/phanpy/shiny.pal"
-INCLUDE "gfx/pokemon/donphan/normal.pal"
+INCBIN "gfx/pokemon/donphan/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/donphan/shiny.pal"
-INCLUDE "gfx/pokemon/porygon2/normal.pal"
+INCBIN "gfx/pokemon/porygon2/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/porygon2/shiny.pal"
-INCLUDE "gfx/pokemon/stantler/normal.pal"
+INCBIN "gfx/pokemon/stantler/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/stantler/shiny.pal"
-INCLUDE "gfx/pokemon/smeargle/normal.pal"
+INCBIN "gfx/pokemon/smeargle/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/smeargle/shiny.pal"
-INCLUDE "gfx/pokemon/tyrogue/normal.pal"
+INCBIN "gfx/pokemon/tyrogue/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tyrogue/shiny.pal"
-INCLUDE "gfx/pokemon/hitmontop/normal.pal"
+INCBIN "gfx/pokemon/hitmontop/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/hitmontop/shiny.pal"
-INCLUDE "gfx/pokemon/smoochum/normal.pal"
+INCBIN "gfx/pokemon/smoochum/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/smoochum/shiny.pal"
-INCLUDE "gfx/pokemon/elekid/normal.pal"
+INCBIN "gfx/pokemon/elekid/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/elekid/shiny.pal"
-INCLUDE "gfx/pokemon/magby/normal.pal"
+INCBIN "gfx/pokemon/magby/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/magby/shiny.pal"
-INCLUDE "gfx/pokemon/miltank/normal.pal"
+INCBIN "gfx/pokemon/miltank/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/miltank/shiny.pal"
-INCLUDE "gfx/pokemon/blissey/normal.pal"
+INCBIN "gfx/pokemon/blissey/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/blissey/shiny.pal"
-INCLUDE "gfx/pokemon/raikou/normal.pal"
+INCBIN "gfx/pokemon/raikou/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/raikou/shiny.pal"
-INCLUDE "gfx/pokemon/entei/normal.pal"
+INCBIN "gfx/pokemon/entei/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/entei/shiny.pal"
-INCLUDE "gfx/pokemon/suicune/normal.pal"
+INCBIN "gfx/pokemon/suicune/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/suicune/shiny.pal"
-INCLUDE "gfx/pokemon/larvitar/normal.pal"
+INCBIN "gfx/pokemon/larvitar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/larvitar/shiny.pal"
-INCLUDE "gfx/pokemon/pupitar/normal.pal"
+INCBIN "gfx/pokemon/pupitar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/pupitar/shiny.pal"
-INCLUDE "gfx/pokemon/tyranitar/normal.pal"
+INCBIN "gfx/pokemon/tyranitar/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/tyranitar/shiny.pal"
-INCLUDE "gfx/pokemon/lugia/normal.pal"
+INCBIN "gfx/pokemon/lugia/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/lugia/shiny.pal"
-INCLUDE "gfx/pokemon/ho_oh/normal.pal"
+INCBIN "gfx/pokemon/ho_oh/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/ho_oh/shiny.pal"
-INCLUDE "gfx/pokemon/celebi/normal.pal"
+INCBIN "gfx/pokemon/celebi/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/celebi/shiny.pal"
 
 ; 252
@@ -518,7 +521,7 @@ INCLUDE "gfx/pokemon/celebi/shiny.pal"
 	RGB 30, 26, 11
 	RGB 23, 16, 00
 
-INCLUDE "gfx/pokemon/egg/normal.pal"
+INCBIN "gfx/pokemon/egg/normal.gbcpal", middle_colors
 INCLUDE "gfx/pokemon/egg/shiny.pal"
 
 ; 254

--- a/data/trainers/palettes.asm
+++ b/data/trainers/palettes.asm
@@ -1,73 +1,76 @@
 TrainerPalettes:
 ; entries correspond to trainer classes
 
+; Each .gbcpal is generated from the corresponding .png, and
+; only the middle two colors are included, not black or white.
+
 PlayerPalette: ; Chris uses the same colors as Cal
-INCLUDE "gfx/trainers/cal.pal"
+INCBIN "gfx/trainers/cal.gbcpal", middle_colors
 KrisPalette: ; Kris shares Falkner's palette
-INCLUDE "gfx/trainers/falkner.pal"
-INCLUDE "gfx/trainers/whitney.pal"
-INCLUDE "gfx/trainers/bugsy.pal"
-INCLUDE "gfx/trainers/morty.pal"
-INCLUDE "gfx/trainers/pryce.pal"
-INCLUDE "gfx/trainers/jasmine.pal"
-INCLUDE "gfx/trainers/chuck.pal"
-INCLUDE "gfx/trainers/clair.pal"
-INCLUDE "gfx/trainers/rival1.pal"
-INCLUDE "gfx/trainers/oak.pal"
-INCLUDE "gfx/trainers/will.pal"
-INCLUDE "gfx/trainers/cal.pal"
-INCLUDE "gfx/trainers/bruno.pal"
-INCLUDE "gfx/trainers/karen.pal"
-INCLUDE "gfx/trainers/koga.pal"
-INCLUDE "gfx/trainers/champion.pal"
-INCLUDE "gfx/trainers/brock.pal"
-INCLUDE "gfx/trainers/misty.pal"
-INCLUDE "gfx/trainers/lt_surge.pal"
-INCLUDE "gfx/trainers/scientist.pal"
-INCLUDE "gfx/trainers/erika.pal"
-INCLUDE "gfx/trainers/youngster.pal"
-INCLUDE "gfx/trainers/schoolboy.pal"
-INCLUDE "gfx/trainers/bird_keeper.pal"
-INCLUDE "gfx/trainers/lass.pal"
-INCLUDE "gfx/trainers/janine.pal"
-INCLUDE "gfx/trainers/cooltrainer_m.pal"
-INCLUDE "gfx/trainers/cooltrainer_f.pal"
-INCLUDE "gfx/trainers/beauty.pal"
-INCLUDE "gfx/trainers/pokemaniac.pal"
-INCLUDE "gfx/trainers/grunt_m.pal"
-INCLUDE "gfx/trainers/gentleman.pal"
-INCLUDE "gfx/trainers/skier.pal"
-INCLUDE "gfx/trainers/teacher.pal"
-INCLUDE "gfx/trainers/sabrina.pal"
-INCLUDE "gfx/trainers/bug_catcher.pal"
-INCLUDE "gfx/trainers/fisher.pal"
-INCLUDE "gfx/trainers/swimmer_m.pal"
-INCLUDE "gfx/trainers/swimmer_f.pal"
-INCLUDE "gfx/trainers/sailor.pal"
-INCLUDE "gfx/trainers/super_nerd.pal"
-INCLUDE "gfx/trainers/rival2.pal"
-INCLUDE "gfx/trainers/guitarist.pal"
-INCLUDE "gfx/trainers/hiker.pal"
-INCLUDE "gfx/trainers/biker.pal"
-INCLUDE "gfx/trainers/blaine.pal"
-INCLUDE "gfx/trainers/burglar.pal"
-INCLUDE "gfx/trainers/firebreather.pal"
-INCLUDE "gfx/trainers/juggler.pal"
-INCLUDE "gfx/trainers/blackbelt_t.pal"
-INCLUDE "gfx/trainers/executive_m.pal"
-INCLUDE "gfx/trainers/psychic_t.pal"
-INCLUDE "gfx/trainers/picnicker.pal"
-INCLUDE "gfx/trainers/camper.pal"
-INCLUDE "gfx/trainers/executive_f.pal"
-INCLUDE "gfx/trainers/sage.pal"
-INCLUDE "gfx/trainers/medium.pal"
-INCLUDE "gfx/trainers/boarder.pal"
-INCLUDE "gfx/trainers/pokefan_m.pal"
-INCLUDE "gfx/trainers/kimono_girl.pal"
-INCLUDE "gfx/trainers/twins.pal"
-INCLUDE "gfx/trainers/pokefan_f.pal"
-INCLUDE "gfx/trainers/red.pal"
-INCLUDE "gfx/trainers/blue.pal"
-INCLUDE "gfx/trainers/officer.pal"
-INCLUDE "gfx/trainers/grunt_f.pal"
-INCLUDE "gfx/trainers/mysticalman.pal"
+INCBIN "gfx/trainers/falkner.gbcpal", middle_colors
+INCBIN "gfx/trainers/whitney.gbcpal", middle_colors
+INCBIN "gfx/trainers/bugsy.gbcpal", middle_colors
+INCBIN "gfx/trainers/morty.gbcpal", middle_colors
+INCBIN "gfx/trainers/pryce.gbcpal", middle_colors
+INCBIN "gfx/trainers/jasmine.gbcpal", middle_colors
+INCBIN "gfx/trainers/chuck.gbcpal", middle_colors
+INCBIN "gfx/trainers/clair.gbcpal", middle_colors
+INCBIN "gfx/trainers/rival1.gbcpal", middle_colors
+INCBIN "gfx/trainers/oak.gbcpal", middle_colors
+INCBIN "gfx/trainers/will.gbcpal", middle_colors
+INCBIN "gfx/trainers/cal.gbcpal", middle_colors
+INCBIN "gfx/trainers/bruno.gbcpal", middle_colors
+INCBIN "gfx/trainers/karen.gbcpal", middle_colors
+INCBIN "gfx/trainers/koga.gbcpal", middle_colors
+INCBIN "gfx/trainers/champion.gbcpal", middle_colors
+INCBIN "gfx/trainers/brock.gbcpal", middle_colors
+INCBIN "gfx/trainers/misty.gbcpal", middle_colors
+INCBIN "gfx/trainers/lt_surge.gbcpal", middle_colors
+INCBIN "gfx/trainers/scientist.gbcpal", middle_colors
+INCBIN "gfx/trainers/erika.gbcpal", middle_colors
+INCBIN "gfx/trainers/youngster.gbcpal", middle_colors
+INCBIN "gfx/trainers/schoolboy.gbcpal", middle_colors
+INCBIN "gfx/trainers/bird_keeper.gbcpal", middle_colors
+INCBIN "gfx/trainers/lass.gbcpal", middle_colors
+INCBIN "gfx/trainers/janine.gbcpal", middle_colors
+INCBIN "gfx/trainers/cooltrainer_m.gbcpal", middle_colors
+INCBIN "gfx/trainers/cooltrainer_f.gbcpal", middle_colors
+INCBIN "gfx/trainers/beauty.gbcpal", middle_colors
+INCBIN "gfx/trainers/pokemaniac.gbcpal", middle_colors
+INCBIN "gfx/trainers/grunt_m.gbcpal", middle_colors
+INCBIN "gfx/trainers/gentleman.gbcpal", middle_colors
+INCBIN "gfx/trainers/skier.gbcpal", middle_colors
+INCBIN "gfx/trainers/teacher.gbcpal", middle_colors
+INCBIN "gfx/trainers/sabrina.gbcpal", middle_colors
+INCBIN "gfx/trainers/bug_catcher.gbcpal", middle_colors
+INCBIN "gfx/trainers/fisher.gbcpal", middle_colors
+INCBIN "gfx/trainers/swimmer_m.gbcpal", middle_colors
+INCBIN "gfx/trainers/swimmer_f.gbcpal", middle_colors
+INCBIN "gfx/trainers/sailor.gbcpal", middle_colors
+INCBIN "gfx/trainers/super_nerd.gbcpal", middle_colors
+INCBIN "gfx/trainers/rival2.gbcpal", middle_colors
+INCBIN "gfx/trainers/guitarist.gbcpal", middle_colors
+INCBIN "gfx/trainers/hiker.gbcpal", middle_colors
+INCBIN "gfx/trainers/biker.gbcpal", middle_colors
+INCBIN "gfx/trainers/blaine.gbcpal", middle_colors
+INCBIN "gfx/trainers/burglar.gbcpal", middle_colors
+INCBIN "gfx/trainers/firebreather.gbcpal", middle_colors
+INCBIN "gfx/trainers/juggler.gbcpal", middle_colors
+INCBIN "gfx/trainers/blackbelt_t.gbcpal", middle_colors
+INCBIN "gfx/trainers/executive_m.gbcpal", middle_colors
+INCBIN "gfx/trainers/psychic_t.gbcpal", middle_colors
+INCBIN "gfx/trainers/picnicker.gbcpal", middle_colors
+INCBIN "gfx/trainers/camper.gbcpal", middle_colors
+INCBIN "gfx/trainers/executive_f.gbcpal", middle_colors
+INCBIN "gfx/trainers/sage.gbcpal", middle_colors
+INCBIN "gfx/trainers/medium.gbcpal", middle_colors
+INCBIN "gfx/trainers/boarder.gbcpal", middle_colors
+INCBIN "gfx/trainers/pokefan_m.gbcpal", middle_colors
+INCBIN "gfx/trainers/kimono_girl.gbcpal", middle_colors
+INCBIN "gfx/trainers/twins.gbcpal", middle_colors
+INCBIN "gfx/trainers/pokefan_f.gbcpal", middle_colors
+INCBIN "gfx/trainers/red.gbcpal", middle_colors
+INCBIN "gfx/trainers/blue.gbcpal", middle_colors
+INCBIN "gfx/trainers/officer.gbcpal", middle_colors
+INCBIN "gfx/trainers/grunt_f.gbcpal", middle_colors
+INCBIN "gfx/trainers/mysticalman.gbcpal", middle_colors

--- a/macros/gfx.asm
+++ b/macros/gfx.asm
@@ -17,3 +17,8 @@ color    EQUS "+ PAL_COLOR_SIZE *"
 
 tiles EQUS "* LEN_2BPP_TILE"
 tile  EQUS "+ LEN_2BPP_TILE *"
+
+; extracts the middle two colors from a 2bpp binary palette
+; example usage:
+; INCBIN "foo.gbcpal", middle_colors
+middle_colors EQUS "PAL_COLOR_SIZE, PAL_COLOR_SIZE * 2"


### PR DESCRIPTION
This avoids overwriting a .pal file from a .png with the same name.  
It also prevents people from trying to edit generated .pal files.