### PR TITLE
Fix comments around BANK() statements

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -4154,7 +4154,7 @@ PursuitSwitch:
 	ld a, [wLastPlayerMon]
 	ld [wCurBattleMon], a
 .do_turn
-	ld a, BANK(DoPlayerTurn)
+	ld a, BANK(DoPlayerTurn) ; and BANK(DoEnemyTurn)
 	rst FarCall
 
 	ld a, BATTLE_VARS_MOVE
@@ -4404,7 +4404,7 @@ UseHeldStatusHealingItem:
 
 .got_pointer
 	call SwitchTurnCore
-	ld a, BANK(CalcEnemyStats)
+	ld a, BANK(CalcPlayerStats) ; and BANK(CalcEnemyStats)
 	rst FarCall
 	call SwitchTurnCore
 	call ItemRecoveryAnim

--- a/engine/battle/move_effects/present.asm
+++ b/engine/battle/move_effects/present.asm
@@ -59,7 +59,7 @@ BattleCommand_Present:
 	jr z, .got_hp_fn_pointer
 	ld hl, AICheckEnemyMaxHP
 .got_hp_fn_pointer
-	ld a, BANK(AICheckPlayerMaxHP)
+	ld a, BANK(AICheckPlayerMaxHP) ; and BANK(AICheckEnemyMaxHP)
 	rst FarCall
 	jr c, .already_fully_healed
 

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -1340,7 +1340,7 @@ BattleAnimAssignPals:
 	call DmgToCgbObjPals
 	ret
 
-ClearBattleAnims:
+ClearBattleAnims::
 ; Clear animation block
 	ld hl, wLYOverrides
 	ld bc, wBattleAnimEnd - wLYOverrides

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -19,7 +19,7 @@ _UnownPrinter:
 
 	ld de, UnownDexATile
 	ld hl, vTiles0 tile UNOWNSTAMP_BOLD_A
-	lb bc, BANK(UnownDexBTile), 1
+	lb bc, BANK(UnownDexATile), 1
 	call Request1bpp
 
 	ld de, UnownDexBTile

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -190,7 +190,8 @@ GetBattleAnimPointer::
 	ld a, [hl]
 	ld [wBattleAnimAddress + 1], a
 
-	ld a, BANK(BattleAnimCommands)
+	; ClearBattleAnims is the only function that calls this...
+	ld a, BANK(ClearBattleAnims)
 	rst Bankswitch
 
 	ret

--- a/home/init.asm
+++ b/home/init.asm
@@ -97,7 +97,7 @@ Init::
 	call ClearSprites
 	call ClearsScratch
 
-	ld a, BANK(WriteOAMDMACodeToHRAM)
+	ld a, BANK(GameInit) ; and BANK(WriteOAMDMACodeToHRAM)
 	rst Bankswitch
 
 	call WriteOAMDMACodeToHRAM

--- a/home/scrolling_menu.asm
+++ b/home/scrolling_menu.asm
@@ -3,7 +3,7 @@ ScrollingMenu::
 	ldh a, [hROMBank]
 	push af
 
-	ld a, BANK(_ScrollingMenu)
+	ld a, BANK(_ScrollingMenu) ; and BANK(_InitScrollingMenu)
 	rst Bankswitch
 
 	call _InitScrollingMenu


### PR DESCRIPTION
Found a couple BANK()s that reference multiple labels.