### PR TITLE
Correct some bugfixes, add some compatibility extensions

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -168,7 +168,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ## Moves with a 100% secondary effect chance will not trigger it in 1/256 uses
 
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+*Fixing this bug **may** break compatibility with standard Pokémon Crystal for link battles.*
 
 ([Video](https://www.youtube.com/watch?v=mHkyO5T5wZU&t=206))
 
@@ -194,7 +194,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ret
 ```
 
-If you wish to keep compatibility with standard Pokémon Crystal, you can disable the fix during link battles by also applying the following edit in the same place:
+**Compatibility preservation:** If you wish to keep compatibility with standard Pokémon Crystal, you can disable the fix during link battles by also applying the following edit in the same place:
 
 ```diff
 +	ld a, [wLinkMode]

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -182,8 +182,8 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 +	; Thus chance will be subtracted from 0, guaranteeing a carry
 +	call c, BattleRandom
  	cp [hl]
-	pop hl
-	ret c
+ 	pop hl
+ 	ret c
 
  .failed
  	ld a, 1
@@ -199,12 +199,12 @@ If you wish to keep compatibility with standard Pokémon Crystal, you can disabl
 +	cp LINK_COLOSSEUM
 +	scf ; Force RNG to be called
 +	jr z, .nofix ; Don't apply fix in link battles, for compatibility
-	ld a, [hl]
-	sub 100 percent
-	; If chance was 100%, RNG won't be called (carry not set)
-	; Thus chance will be subtracted from 0, guaranteeing a carry
-+ .nofix
-	call c, BattleRandom
+ 	ld a, [hl]
+ 	sub 100 percent
+ 	; If chance was 100%, RNG won't be called (carry not set)
+ 	; Thus chance will be subtracted from 0, guaranteeing a carry
++.nofix
+ 	call c, BattleRandom
 ```
 
 ## Belly Drum sharply boosts Attack even with under 50% HP

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -175,22 +175,36 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```diff
 -	; BUG: 1/256 chance to fail even for a 100% effect chance,
 -	; since carry is not set if BattleRandom == [hl] == 255
+- 	call BattleRandom
 +	ld a, [hl]
-+	cp 100 percent
-+	jr z, .ok
- 	call BattleRandom
++	sub 100 percent
++	; If chance was 100%, RNG won't be called (carry not set)
++	; Thus chance will be subtracted from 0, guaranteeing a carry
++	call c, BattleRandom
  	cp [hl]
--	pop hl
--	ret c
-+	jr c, .ok
+	pop hl
+	ret c
 
  .failed
  	ld a, 1
  	ld [wEffectFailed], a
  	and a
-+.ok
-+	pop hl
  	ret
+```
+
+If you wish to keep compatibility with standard Pokémon Crystal, you can disable the fix during link battles by also applying the following edit in the same place:
+
+```diff
++	ld a, [wLinkMode]
++	cp LINK_COLOSSEUM
++	scf ; Force RNG to be called
++	jr z, .nofix ; Don't apply fix in link battles, for compatibility
+	ld a, [hl]
+	sub 100 percent
+	; If chance was 100%, RNG won't be called (carry not set)
+	; Thus chance will be subtracted from 0, guaranteeing a carry
++ .nofix
+	call c, BattleRandom
 ```
 
 ## Belly Drum sharply boosts Attack even with under 50% HP

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -89,6 +89,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 +	ld a, HIGH(MAX_STAT_VALUE)
 +	cp h
 +	jr c, .cap
++	ret nz
 +	ld a, LOW(MAX_STAT_VALUE)
 +	cp l
 +	ret nc

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -126,6 +126,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 +	ld a, HIGH(MAX_STAT_VALUE)
 +	cp b
 +	jr c, .cap
++	ret nz
 +	ld a, LOW(MAX_STAT_VALUE)
 +	cp c
 +	ret nc


### PR DESCRIPTION
The original fix was bugged (example: erroneous `pop hl` if `.failed` was jumped to).
Replaced with a less invasive fix, keeping all side effects from the original function; it's less intuitive, but more performant - and the tricky bit has been commented.
Also the new fix is more friendly to the compatibility patch I also added, by request of ShinyDragonHunter.