### PR TITLE
bugs_and_glitches.md: Minor formatting fixes

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -307,8 +307,8 @@ Then edit four routines in [engine/battle/effect_commands.asm](https://github.co
 
  	ld hl, HurtItselfText
  	call StdBattleTextBox
- 	call HitSelfInConfusion
 
+ 	call HitSelfInConfusion
 -	call BattleCommand_DamageCalc
 +	call ConfusionDamageCalc
  	call BattleCommand_LowerSub

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1327,22 +1327,22 @@ The exact cause of this bug is unknown.
 
 This is a mistake with the “`…`” tile in [gfx/battle/hp_exp_bar_border.png](https://github.com/pret/pokecrystal/blob/master/gfx/battle/hp_exp_bar_border.png):
 
-![image](https://raw.githubusercontent.com/pret/pokecrystal/blob/master/gfx/battle/hp_exp_bar_border.png)
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/battle/hp_exp_bar_border.png)
 
 **Fix:** Lower the ellipsis by two pixels:
 
-![image](https://raw.githubusercontent.com/pret/pokecrystal/blob/master/docs/images/hp_exp_bar_border.png)
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/hp_exp_bar_border.png)
 
 
 ## Two tiles in the `port` tileset are drawn incorrectly
 
 This is a mistake with the left-hand warp carpet corner tiles in [gfx/tilesets/port.png](https://github.com/pret/pokecrystal/blob/master/gfx/tilesets/port.png):
 
-![image](https://raw.githubusercontent.com/pret/pokecrystal/blob/master/gfx/tilesets/port.png)
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/tilesets/port.png)
 
 **Fix:** Adjust them to match the right-hand corner tiles:
 
-![image](https://raw.githubusercontent.com/pret/pokecrystal/blob/master/docs/images/port.png)
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/port.png)
 
 
 ## `LoadMetatiles` wraps around past 128 blocks


### PR DESCRIPTION
Updated a "suggested diff" for a bugfix described in the docs.

I updated the docs' "suggested diff" to match the placement of newlines in the asm file it applies to (around here in the source file): 

https://github.com/pret/pokecrystal/blob/2deb46b3f3daf3690becce5917b7ffc63c91d2e7/engine/battle/effect_commands.asm#L508

###### _(I hope I don't drive anyone crazy trying to review a diff of a diff in this PR.)_

Edit 12 March: Also contains other small fixes as I find them.