### PR TITLE
Fix wram labeling for wPCItems

### DIFF
--- a/engine/events/mom_phone.asm
+++ b/engine/events/mom_phone.asm
@@ -147,7 +147,7 @@ Mom_GiveItemOrDoll:
 	ld [wCurItem], a
 	ld a, 1
 	ld [wItemQuantityChangeBuffer], a
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call ReceiveItem
 	ret
 

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -354,7 +354,7 @@ PlayerWithdrawItemMenu:
 	ld [wItemQuantityChangeBuffer], a
 	ld a, [wBuffer2]
 	ld [wCurItemQuantity], a
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call TossItem
 	predef PartyMonItemName
 	ld hl, .WithdrewText
@@ -390,7 +390,7 @@ PlayerTossItemMenu:
 .loop
 	call PCItemsJoypad
 	jr c, .quit
-	ld de, wPCItems
+	ld de, wNumPCItems
 	farcall TossItemFromPC
 	jr .loop
 
@@ -509,7 +509,7 @@ PlayerDepositItemMenu:
 	ld [wBuffer1], a
 	ld a, [wCurItemQuantity]
 	ld [wBuffer2], a
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call ReceiveItem
 	jr nc, .NoRoomInPC
 	ld a, [wBuffer1]
@@ -628,7 +628,7 @@ PCItemsJoypad:
 	db SCROLLINGMENU_ENABLE_SELECT | SCROLLINGMENU_ENABLE_FUNCTION3 | SCROLLINGMENU_DISPLAY_ARROWS ; flags
 	db 4, 8 ; rows/cols?
 	db 2 ; horizontal spacing?
-	dbw 0, wPCItems
+	dbw 0, wNumPCItems
 	dba PlaceMenuItemName
 	dba PlaceMenuItemQuantity
 	dba UpdateItemDescription

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -145,10 +145,10 @@ GetPocketCapacity:
 .not_bag
 	ld c, MAX_PC_ITEMS
 	ld a, e
-	cp LOW(wPCItems)
+	cp LOW(wNumPCItems)
 	jr nz, .not_pc
 	ld a, d
-	cp HIGH(wPCItems)
+	cp HIGH(wNumPCItems)
 	ret z
 
 .not_pc

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -151,7 +151,7 @@ _ResetWRAM:
 	ld hl, wNumBalls
 	call .InitList
 
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call .InitList
 
 	xor a

--- a/mobile/mobile_12_2.asm
+++ b/mobile/mobile_12_2.asm
@@ -158,7 +158,7 @@ MobileCheckOwnMonAnywhere:
 UnusedFindItemInPCOrBag:
 	ld a, [wScriptVar]
 	ld [wCurItem], a
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call CheckItem
 	jr c, .found
 

--- a/mobile/mobile_5f.asm
+++ b/mobile/mobile_5f.asm
@@ -2664,7 +2664,7 @@ Function17e165:
 	pop hl
 	jr c, .asm_17e195
 	push hl
-	ld hl, wPCItems
+	ld hl, wNumPCItems
 	call CheckItem
 	pop hl
 	jr c, .asm_17e195

--- a/wram.asm
+++ b/wram.asm
@@ -2513,10 +2513,9 @@ wNumBalls:: db ; d8d7
 wBalls:: ds MAX_BALLS * 2 + 1 ; d8d8
 wBallsEnd::
 
+wNumPCItems:: db
 wPCItems:: ds MAX_PC_ITEMS * 2 + 1 ; d8f1
 wPCItemsEnd::
-
-	ds 1
 
 wPokegearFlags::
 ; bit 0: map


### PR DESCRIPTION
They were incorrectly labeled. The correct labeling is similar to other item pockets.