### PR TITLE
Fix swapped comments in data/trainers/dvs.asm

### DIFF
--- a/data/trainers/dvs.asm
+++ b/data/trainers/dvs.asm
@@ -2,8 +2,8 @@ TrainerClassDVs:
 ; entries correspond to trainer classes (see constants/trainer_constants.asm)
 	;  atk,def,spd,spc
 	dn  9, 10,  7,  7 ; FALKNER
-	dn  8,  8,  8,  8 ; BUGSY
-	dn  9,  8,  8,  8 ; WHITNEY
+	dn  8,  8,  8,  8 ; WHITNEY
+	dn  9,  8,  8,  8 ; BUGSY
 	dn  9,  8,  8,  8 ; MORTY
 	dn  9,  8,  8,  8 ; PRYCE
 	dn  9,  8,  8,  8 ; JASMINE


### PR DESCRIPTION
Noticed this while working on https://github.com/pret/pokegold/pull/10.

In battle, enemy trainer class ID is at `0xd22f` and their DVs are at `0xd20c`.

Bugsy has trainer class id 3 and his DVs are 9/8/8/8.
Whitney has trainer class id 2 and her DVs are 8/8/8/8.