### PR TITLE
Update bug fix for AI CheckTypeMatchup assumption

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -670,8 +670,10 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ld hl, wEnemyMonType1
  	ldh a, [hBattleTurn]
  	and a
- 	jr z, CheckTypeMatchup
+-	jr z, CheckTypeMatchup
++	jr z, .getType
  	ld hl, wBattleMonType1
++.getType
 +	ld a, BATTLE_VARS_MOVE_TYPE
 +	call GetBattleVar ; preserves hl, de, and bc
  CheckTypeMatchup:

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -671,9 +671,9 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ldh a, [hBattleTurn]
  	and a
 -	jr z, CheckTypeMatchup
-+	jr z, .getType
++	jr z, .get_type
  	ld hl, wBattleMonType1
-+.getType
++.get_type
 +	ld a, BATTLE_VARS_MOVE_TYPE
 +	call GetBattleVar ; preserves hl, de, and bc
  CheckTypeMatchup:


### PR DESCRIPTION
The bug fix caused all player moves to have Normal-type effectiveness