### PR TITLE
Add and simplify bugfixes in bugs_and_glitches.md

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -14,7 +14,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 
 ## Contents
-
+- [Berserk Gene's confusion isn't permanent](#berserk-genes-confusion-isnt-permanent)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
 - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
@@ -75,6 +75,14 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
 - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
 
+
+## Berserk Gene's confusion isn't permanent
+
+*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+
+([Video](https://youtube.com/watch?v=Pru3mohq20A))
+
+**Fix:** TBD
 
 ## Thick Club and Light Ball can make (Special) Attack wrap around above 1024
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -767,7 +767,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ([Video]())
 
-**Fix:** Edit `EnemyUsedFullRestore` and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
+**Fix:** Edit `EnemyUsedFullRestore`, `EnemyUsedFullHeal`, and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
 ```diff
 EnemyUsedFullRestore:
@@ -778,6 +778,17 @@ EnemyUsedFullRestore:
 -	res SUBSTATUS_CONFUSED, [hl]
 	xor a
 	ld [wEnemyConfuseCount], a
+```
+
+```diff
+EnemyUsedFullHeal:
+	call AIUsedItemSound
+	call AI_HealStatus
+	ld a, FULL_HEAL
++	ld [wCurEnemyItem], a
++	xor a
++	ld [wEnemyConfuseCount], a
+	jp PrintText_UsedItemOn_AND_AIUpdateHUD
 ```
 
 ```diff

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -86,33 +86,22 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 **Fix:** Edit `HandleBerserkGene` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm)
 
 ```diff
-	ld h, d
-    	ld l, e
-    	ld a, b
-    	call GetPartyLocation
-    	xor a
-    	ld [hl], a
-    	ld a, BATTLE_VARS_SUBSTATUS3
-    	call GetBattleVarAddr
-    	push af
-+    	push bc
-+    	ld bc, wEnemyConfuseCount
-+    	ldh a, [hBattleTurn]
-+    	and a
-+    	jr z, .got_confuse_count
-+    	ld bc, wPlayerConfuseCount
-+
-+.got_confuse_count
-    	set SUBSTATUS_CONFUSED, [hl]
-+    	; confused for 2-5 turns
-+    	call BattleRandom
-+    	and %11
-+    	inc a
-+    	inc a
-+    	ld [bc], a
-+    	pop bc
-    	ld a, BATTLE_VARS_MOVE_ANIM
-    	call GetBattleVarAddr
+     ld a, BATTLE_VARS_SUBSTATUS3
+     call GetBattleVarAddr
+     push af
+     set SUBSTATUS_CONFUSED, [hl]
++    ld a, [hBattleTurn]
++    and a
++    ld hl, wEnemyConfuseCount
++    jr z, .set_confuse_count
++    ld hl, wPlayerConfuseCount
++.set_confuse_count
++    call BattleRandom
++    and %11
++    add a, 2
++    ld [hl], a
+     ld a, BATTLE_VARS_MOVE_ANIM
+     call GetBattleVarAddr
 ```
 
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1853,8 +1853,9 @@ This supports up to six entries.
  	ld de, 3
  	ld hl, .pointers
  	call IsInArray
- 	jr nc, .nope
+- 	jr nc, .nope
  	pop bc
++	jr nc, .nope
 
  	inc hl
  	ld a, [hli]
@@ -1864,7 +1865,6 @@ This supports up to six entries.
 
  .nope
 -	; pop bc
-+	pop bc
  	xor a
  	ret
 ```

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -696,7 +696,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=322))
 
-**Fix:** Edit `AI_HealStatus` and `EnemyUsedFullRestore` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
+**Fix:** Edit `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
 ```diff
  AI_HealStatus:
@@ -723,7 +723,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ([Video]())
 
-**Fix:** Edit `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
+**Fix:** Edit `AI_HealStatus` and `EnemyUsedFullRestore` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
 
 ```diff

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -524,8 +524,7 @@ ValidateSave:
 	ld [sCheckValue1], a
 	ld a, SAVE_CHECK_VALUE_2
 	ld [sCheckValue2], a
-	call CloseSRAM
-	ret
+	jp CloseSRAM
 
 +InvalidateSave:
 +	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
@@ -533,8 +532,7 @@ ValidateSave:
 +	xor a
 +	ld [sCheckValue1], a
 +	ld [sCheckValue2], a
-+	call CloseSRAM
-+	ret
++	jp CloseSRAM
 ```
 
 ```diff
@@ -545,8 +543,7 @@ ValidateBackupSave:
 	ld [sBackupCheckValue1], a
 	ld a, SAVE_CHECK_VALUE_2
 	ld [sBackupCheckValue2], a
-	call CloseSRAM
-	ret
+	jp CloseSRAM
 
 +InvalidateBackupSave:
 +	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
@@ -554,8 +551,7 @@ ValidateBackupSave:
 +	xor a
 +	ld [sBackupCheckValue1], a
 +	ld [sBackupCheckValue2], a
-+	call CloseSRAM
-+	ret
++	jp CloseSRAM
 ```
 
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -83,7 +83,37 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 ([Video](https://youtube.com/watch?v=Pru3mohq20A))
 
-**Fix:** TBD
+**Fix:** Edit `HandleBerserkGene` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm)
+
+```diff
+	ld h, d
+    	ld l, e
+    	ld a, b
+    	call GetPartyLocation
+    	xor a
+    	ld [hl], a
+    	ld a, BATTLE_VARS_SUBSTATUS3
+    	call GetBattleVarAddr
+    	push af
++    	push bc
++    	ld bc, wEnemyConfuseCount
++    	ldh a, [hBattleTurn]
++    	and a
++    	jr z, .got_confuse_count
++    	ld bc, wPlayerConfuseCount
++
++.got_confuse_count
+    	set SUBSTATUS_CONFUSED, [hl]
++    	; confused for 2-5 turns
++    	call BattleRandom
++    	and %11
++    	inc a
++    	inc a
++    	ld [bc], a
++    	pop bc
+    	ld a, BATTLE_VARS_MOVE_ANIM
+    	call GetBattleVarAddr
+```
 
 
 ## Thick Club and Light Ball can make (Special) Attack wrap around above 1024

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -35,7 +35,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - ["Smart" AI encourages Mean Look if its own Pokémon is badly poisoned](#smart-ai-encourages-mean-look-if-its-own-pokémon-is-badly-poisoned)
 - [AI makes a false assumption about `CheckTypeMatchup`](#ai-makes-a-false-assumption-about-checktypematchup)
 - [NPC use of Full Heal or Full Restore does not cure Nightmare status](#npc-use-of-full-heal-or-full-restore-does-not-cure-nightmare-status)
-- [NPC use of Full Heal does not cure confusion status]#npc-use-of-full-heal-does-not-cure-confusion-status)
+- [NPC use of Full Heal does not cure confusion status](#npc-use-of-full-heal-does-not-cure-confusion-status)
 - [HP bar animation is slow for high HP](#hp-bar-animation-is-slow-for-high-hp)
 - [HP bar animation off-by-one error for low HP](#hp-bar-animation-off-by-one-error-for-low-hp)
 - [Experience underflow for level 1 Pokémon with Medium-Slow growth rate](#experience-underflow-for-level-1-pokémon-with-medium-slow-growth-rate)

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -84,6 +84,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 **Fix:** TBD
 
+
 ## Thick Club and Light Ball can make (Special) Attack wrap around above 1024
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -739,7 +739,6 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 **Fix:** Edit `EnemyUsedFullRestore` and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
-
 ```diff
 EnemyUsedFullRestore:
 	call AI_HealStatus

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -15,6 +15,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 ## Contents
 
+- [The S.S. Aqua and the ports have you white out to your cabin or either the Vermilion or Olivine Pokémon Centers even if you saved somewhere else](#the-s.s.-aqua-and-the-ports-have-you-white-out-to-your-cabin-or-either-the-vermilion-or-olivine-pokémon-centers-even-if-you-saved-somewhere-else)
 - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
 - [A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves](#a-transformed-pokémon-knowing-sketch-can-give-itself-otherwise-unobtainable-moves)
 - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
@@ -80,13 +81,61 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
 
 
+## The S.S. Aqua and the ports have you white out to your cabin or either the Vermilion or Olivine Pokémon Centers even if you saved somewhere else
+
+([Video](https://www.youtube.com/watch?v=Va3pzlujwE4))
+
+**Fix:** Edit `.LeaveFastShipScript` in [maps/OlivinePort.asm](https://github.com/pret/pokecrystal/blob/master/maps/OlivinePort.asm) and [maps/VermilionPort.asm](https://github.com/pret/pokecrystal/blob/master/maps/VermilionPort.asm)
+
+```diff
+	applymovement PLAYER, MovementData_0x74a32
+	appear OLIVINEPORT_SAILOR1
+	setscene SCENE_DEFAULT
+	setevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_1
+-	blackoutmod OLIVINE_CITY
+	end
+```
+
+```diff
+	applymovement PLAYER, MovementData_0x74ef3
+	appear VERMILIONPORT_SAILOR1
+	setscene SCENE_DEFAULT
+	setevent EVENT_FAST_SHIP_CABINS_SE_SSE_CAPTAINS_CABIN_TWIN_1
+	setevent EVENT_FAST_SHIP_CABINS_SE_SSE_GENTLEMAN
+	setevent EVENT_FAST_SHIP_PASSENGERS_FIRST_TRIP
+	clearevent EVENT_OLIVINE_PORT_PASSAGE_POKEFAN_M
+	setevent EVENT_FAST_SHIP_FIRST_TIME
+	setevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_1
+-	blackoutmod VERMILION_CITY
+	end
+```
+
+Also edit `.EnterFastShipScript` in [maps/FastShip1F.asm](https://github.com/pret/pokecrystal/blob/master/maps/FastShip1F.asm)
+
+```diff
+	applymovement FASTSHIP1F_SAILOR1, MovementData_0x7520e
+	applymovement PLAYER, MovementData_0x75217
+	applymovement FASTSHIP1F_SAILOR1, MovementData_0x75211
+	pause 30
+	playsound SFX_BOAT
+	earthquake 30
+-	blackoutmod FAST_SHIP_CABINS_SW_SSW_NW
+	clearevent EVENT_FAST_SHIP_HAS_ARRIVED
+	checkevent EVENT_FAST_SHIP_FIRST_TIME
+	iftrue .SkipGrandpa
+	setscene SCENE_FASTSHIP1F_MEET_GRANDPA
+	end
+```
+
+
 ## Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
 
 ([Video](https://youtube.com/watch?v=Pru3mohq20A))
 
-**Fix:** Edit `HandleBerserkGene` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm) (This makes the Berserk Gene use the regular confusion formula (2-5 turns))
+**Fix:** Edit `HandleBerserkGene` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
+(This makes the Berserk Gene use the regular confusion formula (2-5 turns))
 
 ```diff
      ld a, BATTLE_VARS_SUBSTATUS3

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -737,13 +737,13 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ld [hl], a
  	ld [wEnemyMonStatus], a
 -	; Bug: this should reset SUBSTATUS_NIGHTMARE
--	; Uncomment the former 2 lines below to fix
-	; This should also reset SUBSTATUS_CONFUSED
-	; Uncomment the latter 2 lines below to fix
+-	; Uncomment the 2 lines below to fix
 -	; ld hl, wEnemySubStatus1
 -	; res SUBSTATUS_NIGHTMARE, [hl]
 +	ld hl, wEnemySubStatus1
 +	res SUBSTATUS_NIGHTMARE, [hl]
+	; This should also reset SUBSTATUS_CONFUSED
+	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus3
 	; res SUBSTATUS_CONFUSED, [hl]
  	ld hl, wEnemySubStatus5
@@ -790,11 +790,11 @@ EnemyUsedFullHeal:
  	ld [hl], a
  	ld [wEnemyMonStatus], a
 	; Bug: this should reset SUBSTATUS_NIGHTMARE
-	; Uncomment the former 2 lines below to fix
--	; This should also reset SUBSTATUS_CONFUSED
--	; Uncomment the latter 2 lines below to fix
+	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
+-	; This should also reset SUBSTATUS_CONFUSED
+-	; Uncomment the 2 lines below to fix
 -	; ld hl, wEnemySubStatus3
 -	; res SUBSTATUS_CONFUSED, [hl]
 +	ld hl, wEnemySubStatus3

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -14,7 +14,8 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 
 ## Contents
-- [Berserk Gene's confusion isn't permanent](#berserk-genes-confusion-isnt-permanent)
+
+- [Berserk Gene's confusion lasts for 256 turns](#berserk-genes-confusion-lasts-for-256-turns)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
 - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
@@ -76,7 +77,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
 
 
-## Berserk Gene's confusion isn't permanent
+## Berserk Gene's confusion lasts for 256 turns
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -716,12 +716,15 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	xor a
  	ld [hl], a
  	ld [wEnemyMonStatus], a
--	; Bug: this should reset SUBSTATUS_NIGHTMARE too
+-	; Bug: this should reset SUBSTATUS_NIGHTMARE
+-	; and SUBSTATUS_CONFUSED too
 -	; Uncomment the lines below to fix
 -	; ld hl, wEnemySubStatus1
 -	; res SUBSTATUS_NIGHTMARE, [hl]
 +	ld hl, wEnemySubStatus1
 +	res SUBSTATUS_NIGHTMARE, [hl]
+	; ld hl, wEnemySubStatus3
+	; res SUBSTATUS_CONFUSED, [hl]
  	ld hl, wEnemySubStatus5
  	res SUBSTATUS_TOXIC, [hl]
  	ret
@@ -732,7 +735,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ([Video]())
 
-**Fix:** Edit `AI_HealStatus` and `EnemyUsedFullRestore` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
+**Fix:** Edit `EnemyUsedFullRestore` and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
 
 ```diff
@@ -755,10 +758,13 @@ EnemyUsedFullRestore:
  	xor a
  	ld [hl], a
  	ld [wEnemyMonStatus], a
-	; Bug: this should reset SUBSTATUS_NIGHTMARE too
+	; Bug: this should reset SUBSTATUS_NIGHTMARE
+	; and SUBSTATUS_CONFUSED too
 	; Uncomment the lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
+-	; ld hl, wEnemySubStatus3
+-	; res SUBSTATUS_CONFUSED, [hl]
 +	ld hl, wEnemySubStatus3
 +	res SUBSTATUS_CONFUSED, [hl]
  	ld hl, wEnemySubStatus5

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -129,7 +129,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
 
-([Video](TBA))
+([Video](https://cdn.discordapp.com/attachments/487424856913346580/653998883185360913/death_metal.mp4))
 
 **Fix:** Edit `CheckFaint_PlayerThenEnemy` and `CheckFaint_EnemyThenPlayer` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -742,7 +742,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 -	; res SUBSTATUS_NIGHTMARE, [hl]
 +	ld hl, wEnemySubStatus1
 +	res SUBSTATUS_NIGHTMARE, [hl]
-	; This should also reset SUBSTATUS_CONFUSED
+	; Bug: this should reset SUBSTATUS_CONFUSED
 	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus3
 	; res SUBSTATUS_CONFUSED, [hl]
@@ -793,7 +793,7 @@ EnemyUsedFullHeal:
 	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
--	; This should also reset SUBSTATUS_CONFUSED
+-	; Bug: this should reset SUBSTATUS_CONFUSED
 -	; Uncomment the 2 lines below to fix
 -	; ld hl, wEnemySubStatus3
 -	; res SUBSTATUS_CONFUSED, [hl]

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -16,7 +16,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ## Contents
 
 - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
-- [A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves](a-transformed-pokémon-knowing-sketch-can-give-itself-otherwise-unobtainable-moves)
+- [A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves](#a-transformed-pokémon-knowing-sketch-can-give-itself-otherwise-unobtainable-moves)
 - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -83,7 +83,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 ([Video](https://youtube.com/watch?v=Pru3mohq20A))
 
-**Fix:** Edit `HandleBerserkGene` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm)
+**Fix:** Edit `HandleBerserkGene` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
 
 ```diff
      ld a, BATTLE_VARS_SUBSTATUS3

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -15,7 +15,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 ## Contents
 
-- [Berserk Gene's confusion lasts for 256 turns](#berserk-genes-confusion-lasts-for-256-turns)
+- [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
 - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
@@ -77,13 +77,13 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
 
 
-## Berserk Gene's confusion lasts for 256 turns
+## Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
 
 ([Video](https://youtube.com/watch?v=Pru3mohq20A))
 
-**Fix:** Edit `HandleBerserkGene` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
+**Fix:** Edit `HandleBerserkGene` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm) (This makes the Berserk Gene use the regular confusion formula (2-5 turns))
 
 ```diff
      ld a, BATTLE_VARS_SUBSTATUS3

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -23,7 +23,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [Moves with a 100% secondary effect chance will not trigger it in 1/256 uses](#moves-with-a-100-secondary-effect-chance-will-not-trigger-it-in-1256-uses)
 - [Belly Drum sharply boosts Attack even with under 50% HP](#belly-drum-sharply-boosts-attack-even-with-under-50-hp)
 - [Confusion damage is affected by type-boosting items and Explosion/Self-Destruct doubling](#confusion-damage-is-affected-by-type-boosting-items-and-explosionself-destruct-doubling)
-- [Saves can be corrupted in such a way as to glitch the game](#saves-can-be-corrupted-in-such-a-way-as-to-glitch-the-game)
+- [Saves corrupted by mid-save shutoff are not handled](#saves-corrupted-by-mid-save-shutoff-are-not-handled)
 - [Moves that lower Defense can do so after breaking a Substitute](#moves-that-lower-defense-can-do-so-after-breaking-a-substitute)
 - [Counter and Mirror Coat still work if the opponent uses an item](#counter-and-mirror-coat-still-work-if-the-opponent-uses-an-item)
 - [A Disabled but PP Up–enhanced move may not trigger Struggle](#a-disabled-but-pp-upenhanced-move-may-not-trigger-struggle)
@@ -392,7 +392,7 @@ Then edit four routines in [engine/battle/effect_commands.asm](https://github.co
 ```
 
 
-## Saves can be corrupted in such a way as to glitch the game
+## Saves corrupted by mid-save shutoff are not handled
 
 ([Video 1](https://www.youtube.com/watch?v=ukqtK0l6bu0))
 ([Video 2](https://www.youtube.com/watch?v=c2zHd1BPtvc))
@@ -459,7 +459,8 @@ ValidateSave:
 	ld [sCheckValue1], a
 	ld a, SAVE_CHECK_VALUE_2
 	ld [sCheckValue2], a
-	jp CloseSRAM
+	call CloseSRAM
+	ret
 
 +InvalidateSave:
 +	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
@@ -467,7 +468,8 @@ ValidateSave:
 +	xor a
 +	ld [sCheckValue1], a
 +	ld [sCheckValue2], a
-+	jp CloseSRAM
++	call CloseSRAM
++	ret
 ```
 
 ```diff
@@ -478,7 +480,8 @@ ValidateBackupSave:
 	ld [sBackupCheckValue1], a
 	ld a, SAVE_CHECK_VALUE_2
 	ld [sBackupCheckValue2], a
-	jp CloseSRAM
+	call CloseSRAM
+	ret
 
 +InvalidateBackupSave:
 +	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
@@ -486,7 +489,8 @@ ValidateBackupSave:
 +	xor a
 +	ld [sBackupCheckValue1], a
 +	ld [sBackupCheckValue2], a
-+	jp CloseSRAM
++	call CloseSRAM
++	ret
 ```
 
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -718,8 +718,9 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ld [hl], a
  	ld [wEnemyMonStatus], a
 -	; Bug: this should reset SUBSTATUS_NIGHTMARE
--	; and SUBSTATUS_CONFUSED too
--	; Uncomment the lines below to fix
+-	; Uncomment the former 2 lines below to fix
+	; This should also reset SUBSTATUS_CONFUSED
+	; Uncomment the latter 2 lines below to fix
 -	; ld hl, wEnemySubStatus1
 -	; res SUBSTATUS_NIGHTMARE, [hl]
 +	ld hl, wEnemySubStatus1
@@ -760,8 +761,9 @@ EnemyUsedFullRestore:
  	ld [hl], a
  	ld [wEnemyMonStatus], a
 	; Bug: this should reset SUBSTATUS_NIGHTMARE
-	; and SUBSTATUS_CONFUSED too
-	; Uncomment the lines below to fix
+	; Uncomment the former 2 lines below to fix
+-	; This should also reset SUBSTATUS_CONFUSED
+-	; Uncomment the latter 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
 -	; ld hl, wEnemySubStatus3

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -16,6 +16,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ## Contents
 
 - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
+- [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
 - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
@@ -103,6 +104,52 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 +    ld [hl], a
      ld a, BATTLE_VARS_MOVE_ANIM
      call GetBattleVarAddr
+```
+
+
+## Perish Song and Spikes can leave a Pokémon with 0 HP and not faint
+
+*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+
+([Video]TBA))
+
+**Fix:** Edit `CheckFaint_PlayerThenEnemy` and `CheckFaint_EnemyThenPlayer` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
+
+```diff
+ 	jp HandleEncore
+ 
++HasAnyoneFainted:
++	call HasPlayerFainted
++	call nz, HasEnemyFainted
++	ret
++
+CheckFaint_PlayerThenEnemy:
++.faint_loop
++	call .Function
++	ret c
++	call HasAnyoneFainted
++	ret nz
++	jr .faint_loop
++
++.Function:
+ 	call HasPlayerFainted
+ 	jr nz, .PlayerNotFainted
+ 	call HandlePlayerMonFaint
+```
+
+```diff
+CheckFaint_EnemyThenPlayer:
++.faint_loop
++	call .Function
++	ret c
++	call HasAnyoneFainted
++	ret nz
++	jr .faint_loop
++
++.Function:
+ 	call HasEnemyFainted
+ 	jr nz, .EnemyNotFainted
+ 	call HandleEnemyMonFaint
 ```
 
 
@@ -857,7 +904,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ## NPC use of Full Heal does not cure confusion status
 
-([Video]())
+([Video](TBA))
 
 **Fix:** Edit `EnemyUsedFullRestore`, `EnemyUsedFullHeal`, and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -15,7 +15,6 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 ## Contents
 
-- [The S.S. Aqua and the ports have you white out to your cabin or either the Vermilion or Olivine Pokémon Centers even if you saved somewhere else](#the-s.s.-aqua-and-the-ports-have-you-white-out-to-your-cabin-or-either-the-vermilion-or-olivine-pokémon-centers-even-if-you-saved-somewhere-else)
 - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
 - [A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves](#a-transformed-pokémon-knowing-sketch-can-give-itself-otherwise-unobtainable-moves)
 - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
@@ -79,53 +78,6 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 - [`TryObjectEvent` arbitrary code execution](#tryobjectevent-arbitrary-code-execution)
 - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
 - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
-
-
-## The S.S. Aqua and the ports have you white out to your cabin or either the Vermilion or Olivine Pokémon Centers even if you saved somewhere else
-
-([Video](https://www.youtube.com/watch?v=Va3pzlujwE4))
-
-**Fix:** Edit `.LeaveFastShipScript` in [maps/OlivinePort.asm](https://github.com/pret/pokecrystal/blob/master/maps/OlivinePort.asm) and [maps/VermilionPort.asm](https://github.com/pret/pokecrystal/blob/master/maps/VermilionPort.asm)
-
-```diff
-	applymovement PLAYER, MovementData_0x74a32
-	appear OLIVINEPORT_SAILOR1
-	setscene SCENE_DEFAULT
-	setevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_1
--	blackoutmod OLIVINE_CITY
-	end
-```
-
-```diff
-	applymovement PLAYER, MovementData_0x74ef3
-	appear VERMILIONPORT_SAILOR1
-	setscene SCENE_DEFAULT
-	setevent EVENT_FAST_SHIP_CABINS_SE_SSE_CAPTAINS_CABIN_TWIN_1
-	setevent EVENT_FAST_SHIP_CABINS_SE_SSE_GENTLEMAN
-	setevent EVENT_FAST_SHIP_PASSENGERS_FIRST_TRIP
-	clearevent EVENT_OLIVINE_PORT_PASSAGE_POKEFAN_M
-	setevent EVENT_FAST_SHIP_FIRST_TIME
-	setevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_1
--	blackoutmod VERMILION_CITY
-	end
-```
-
-Also edit `.EnterFastShipScript` in [maps/FastShip1F.asm](https://github.com/pret/pokecrystal/blob/master/maps/FastShip1F.asm)
-
-```diff
-	applymovement FASTSHIP1F_SAILOR1, MovementData_0x7520e
-	applymovement PLAYER, MovementData_0x75217
-	applymovement FASTSHIP1F_SAILOR1, MovementData_0x75211
-	pause 30
-	playsound SFX_BOAT
-	earthquake 30
--	blackoutmod FAST_SHIP_CABINS_SW_SSW_NW
-	clearevent EVENT_FAST_SHIP_HAS_ARRIVED
-	checkevent EVENT_FAST_SHIP_FIRST_TIME
-	iftrue .SkipGrandpa
-	setscene SCENE_FASTSHIP1F_MEET_GRANDPA
-	end
-```
 
 
 ## Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -16,6 +16,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ## Contents
 
 - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
+- [A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves](a-transformed-pokémon-knowing-sketch-can-give-itself-otherwise-unobtainable-moves)
 - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
 - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
 - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
@@ -104,6 +105,23 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 +    ld [hl], a
      ld a, BATTLE_VARS_MOVE_ANIM
      call GetBattleVarAddr
+```
+
+
+## A Transformed Pokémon knowing Sketch can give itself otherwise unobtainable moves
+
+([Video](https://www.youtube.com/watch?v=AFiBxAOkCGI))
+
+**Fix:** Edit `BattleCommand_Sketch` in [engine/battle/move_effects/sketch.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/move_effects/sketch.asm)
+
+```diff
+-; If the opponent is transformed, fail.
++; If the user is transformed, fail.
+-       ld a, BATTLE_VARS_SUBSTATUS5_OPP
++       ld a, BATTLE_VARS_SUBSTATUS5
+        call GetBattleVarAddr
+        bit SUBSTATUS_TRANSFORMED, [hl]
+        jp nz, .fail
 ```
 
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -129,7 +129,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 *Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
 
-([Video]TBA))
+([Video](TBA))
 
 **Fix:** Edit `CheckFaint_PlayerThenEnemy` and `CheckFaint_EnemyThenPlayer` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm)
 

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -726,11 +726,11 @@ AI_HealStatus:
 	ld [hl], a
 	ld [wEnemyMonStatus], a
 	; Bug: this should reset SUBSTATUS_NIGHTMARE
-	; Uncomment the former 2 lines below to fix
-	; This should also reset SUBSTATUS_CONFUSED
-	; Uncomment the latter 2 lines below to fix
+	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
+	; This should also reset SUBSTATUS_CONFUSED
+	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus3
 	; res SUBSTATUS_CONFUSED, [hl]
 	ld hl, wEnemySubStatus5

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -729,7 +729,7 @@ AI_HealStatus:
 	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
-	; This should also reset SUBSTATUS_CONFUSED
+	; Bug: this should reset SUBSTATUS_CONFUSED
 	; Uncomment the 2 lines below to fix
 	; ld hl, wEnemySubStatus3
 	; res SUBSTATUS_CONFUSED, [hl]

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -726,8 +726,9 @@ AI_HealStatus:
 	ld [hl], a
 	ld [wEnemyMonStatus], a
 	; Bug: this should reset SUBSTATUS_NIGHTMARE
-	; and SUBSTATUS_CONFUSED too
-	; Uncomment the lines below to fix
+	; Uncomment the former 2 lines below to fix
+	; This should also reset SUBSTATUS_CONFUSED
+	; Uncomment the latter 2 lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
 	; ld hl, wEnemySubStatus3

--- a/engine/battle/ai/items.asm
+++ b/engine/battle/ai/items.asm
@@ -725,10 +725,13 @@ AI_HealStatus:
 	xor a
 	ld [hl], a
 	ld [wEnemyMonStatus], a
-	; Bug: this should reset SUBSTATUS_NIGHTMARE too
+	; Bug: this should reset SUBSTATUS_NIGHTMARE
+	; and SUBSTATUS_CONFUSED too
 	; Uncomment the lines below to fix
 	; ld hl, wEnemySubStatus1
 	; res SUBSTATUS_NIGHTMARE, [hl]
+	; ld hl, wEnemySubStatus3
+	; res SUBSTATUS_CONFUSED, [hl]
 	ld hl, wEnemySubStatus5
 	res SUBSTATUS_TOXIC, [hl]
 	ret


### PR DESCRIPTION
Simplified the `BattleCheckTypeMatchup` fix as well as added a fix for the Full Heal not curing AI confusion. Also made fixes for virtually every glitch known to occur with Crystal, which also fixes issue #666 as a result.