### PR TITLE
Optimize the Perish Song+Spikes glitch fix

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -94,8 +94,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 +HasAnyoneFainted:
 +	call HasPlayerFainted
-+	call nz, HasEnemyFainted
-+	ret
++	jp nz, HasEnemyFainted
 +
  CheckFaint_PlayerThenEnemy:
 +.faint_loop


### PR DESCRIPTION
This particular bugfix can be optimized by one line, which has been done here in this PR. References the glitch in issue #666.