### PR TITLE
Optimize the Perish Song+Spikes glitch fix (redux)

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -94,8 +94,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 
 +HasAnyoneFainted:
 +	call HasPlayerFainted
-+	call nz, HasEnemyFainted
-+	ret
++	jp nz, HasEnemyFainted
 +
  CheckFaint_PlayerThenEnemy:
 +.faint_loop

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -95,6 +95,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 +HasAnyoneFainted:
 +	call HasPlayerFainted
 +	jp nz, HasEnemyFainted
++	ret
 +
  CheckFaint_PlayerThenEnemy:
 +.faint_loop


### PR DESCRIPTION
Screwed up and deleted a `ret` I shouldn't've in the last PR (#678). This should be fixed now.