### PR TITLE
Fix Mac OSX install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,19 +57,14 @@ Now you're ready to [build **pokecrystal**](#build-pokecrystal).
 
 ## Mac OS X
 
+Install [**Homebrew**](https://brew.sh/). Follow the official instructions.
+
 Open **Terminal** and enter the following commands.
-
-To install the **Xcode Command Line Tools**:
-
-```bash
-xcode-select --install
-```
 
 To install **rgbds**:
 
 ```bash
-git clone --depth=1 https://github.com/rednex/rgbds
-sudo make -C rgbds CFLAGS=-O2 install
+brew install rgbds
 ```
 
 Now you're ready to [build **pokecrystal**](#build-pokecrystal).
@@ -91,7 +86,7 @@ To install **rgbds**:
 
 ```bash
 sudo apt-get install pkg-config flex bison libpng-dev
-git clone --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.3.9 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds CFLAGS=-O2 install
 ```
 
@@ -107,7 +102,7 @@ To install **rgbds**:
 
 ```bash
 sudo zypper install pkg-config flex bison libpng16-devel
-git clone --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.3.9 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds CFLAGS=-O2 install
 ```
 
@@ -125,7 +120,7 @@ Alternatively, to install **rgbds** manually:
 
 ```bash
 sudo pacman -S pkg-config flex bison libpng
-git clone --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.3.9 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds CFLAGS=-O2 install
 ```
 
@@ -162,7 +157,7 @@ If `rgbds` is not available, you'll also need these:
 To install **rgbds**:
 
 ```bash
-git clone --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.3.9 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds CFLAGS=-O2 install
 ```
 

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -136,15 +136,14 @@ Function140ae:
 .time_overflow
 	farcall ClearDailyTimers
 	farcall Function170923
-; mobile
-	ld a, 5 ; MBC30 bank used by JP Crystal; inaccessible by MBC3
+	ld a, BANK(s5_aa8c) ; and BANK(s5_b2fa)
 	call GetSRAMBank
-	ld a, [$aa8c] ; address of MBC30 bank
+	ld a, [s5_aa8c]
 	inc a
-	ld [$aa8c], a ; address of MBC30 bank
-	ld a, [$b2fa] ; address of MBC30 bank
+	ld [s5_aa8c], a
+	ld a, [s5_b2fa]
 	inc a
-	ld [$b2fa], a ; address of MBC30 bank
+	ld [s5_b2fa], a
 	call CloseSRAM
 	ret
 


### PR DESCRIPTION
Using homebrew since non-standard dependencies are required to install rgbds anyway.