### PR TITLE
Update the header structure

### DIFF
--- a/home/header.asm
+++ b/home/header.asm
@@ -56,14 +56,15 @@ SECTION "joypad", ROM0[$0060]
 	jp Joypad
 
 
-; Game Boy cartridge header
-
 SECTION "Header", ROM0[$0100]
 
 Start::
+; Nintendo requires all Game Boy ROMs to begin with a nop ($00) and a jp ($C3)
+; to the starting address.
 	nop
 	jp _Start
 
-; The cartridge header data is filled in by rgbfix.
-; This makes sure it doesn't get used.
-	ds $0150 - @
+; The Game Boy cartridge header data is patched over by rgbfix.
+; This makes sure it doesn't get used for anything else.
+
+	ds $0150 - @, $00


### PR DESCRIPTION
$0100–$0150 is "the cartridge header"; but only $0100–$0103 is the entry point code, $0104–$0150 is reserved to be patched by rgbfix.

People can add more code in all of the rst and interrupt sections, particularly `"joypad"`, which has 157 free bytes. This prevents them from accidentally doing the same after `Start`.

Also if they change the padding byte, like to $ff, rgbfix will still fill the header with $00s.