### PR TITLE
Miscellaneous updates and corrections

### DIFF
--- a/audio/sfx.asm
+++ b/audio/sfx.asm
@@ -3327,7 +3327,7 @@ Sfx_DexFanfare170199_Ch8:
 	note B_, 16
 	sound_ret
 
-	db $fd
+	db sound_loop_cmd
 
 Sfx_DexFanfare200229:
 	channel_count 4

--- a/audio/sfx.asm
+++ b/audio/sfx.asm
@@ -1057,7 +1057,7 @@ Sfx_RegisterPhoneNumber_Ch5:
 	rest 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_RegisterPhoneNumber_Ch6:
 	toggle_sfx
@@ -1081,7 +1081,7 @@ Sfx_RegisterPhoneNumber_Ch6:
 	rest 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_RegisterPhoneNumber_Ch7:
 	toggle_sfx
@@ -1102,7 +1102,7 @@ Sfx_RegisterPhoneNumber_Ch7:
 	rest 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_RegisterPhoneNumber_Ch8:
 	toggle_sfx
@@ -1113,7 +1113,7 @@ Sfx_RegisterPhoneNumber_Ch8:
 	rest 16
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_3rdPlace:
 	channel_count 3
@@ -1138,7 +1138,7 @@ Sfx_3rdPlace_Ch5:
 	note D_, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_3rdPlace_Ch6:
 	toggle_sfx
@@ -1155,7 +1155,7 @@ Sfx_3rdPlace_Ch6:
 	note G_, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_3rdPlace_Ch7:
 	toggle_sfx
@@ -1172,7 +1172,7 @@ Sfx_3rdPlace_Ch7:
 	note B_, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetEgg:
 	channel_count 4
@@ -1211,7 +1211,7 @@ Sfx_GetEgg_Ch5:
 	rest 9
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetEgg_Ch6:
 	toggle_sfx
@@ -1240,7 +1240,7 @@ Sfx_GetEgg_Ch6:
 	rest 9
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetEgg_Ch7:
 	toggle_sfx
@@ -1259,7 +1259,7 @@ Sfx_GetEgg_Ch7:
 	rest 9
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetEgg_Ch8:
 	toggle_sfx
@@ -1271,7 +1271,7 @@ Sfx_GetEgg_Ch8:
 	rest 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_MoveDeleted:
 	channel_count 4
@@ -1308,7 +1308,7 @@ Sfx_MoveDeleted_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_MoveDeleted_Ch6:
 	toggle_sfx
@@ -1344,7 +1344,7 @@ Sfx_MoveDeleted_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_MoveDeleted_Ch7:
 	toggle_sfx
@@ -1371,7 +1371,7 @@ Sfx_MoveDeleted_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_MoveDeleted_Ch8:
 	toggle_sfx
@@ -1383,7 +1383,7 @@ Sfx_MoveDeleted_Ch8:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_2ndPlace:
 	channel_count 4
@@ -1424,7 +1424,7 @@ Sfx_2ndPlace_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_2ndPlace_Ch6:
 	toggle_sfx
@@ -1448,7 +1448,7 @@ Sfx_2ndPlace_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_2ndPlace_Ch7:
 	toggle_sfx
@@ -1486,7 +1486,7 @@ Sfx_2ndPlace_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_2ndPlace_Ch8:
 	toggle_sfx
@@ -1501,7 +1501,7 @@ Sfx_2ndPlace_branch_f0fd7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_1stPlace:
 	channel_count 4
@@ -1549,7 +1549,7 @@ Sfx_1stPlace_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_1stPlace_Ch6:
 	toggle_sfx
@@ -1573,7 +1573,7 @@ Sfx_1stPlace_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_1stPlace_Ch7:
 	toggle_sfx
@@ -1597,7 +1597,7 @@ Sfx_1stPlace_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_1stPlace_Ch8:
 	toggle_sfx
@@ -1618,7 +1618,7 @@ Sfx_1stPlace_Ch8:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_ChooseACard:
 	channel_count 4
@@ -1671,7 +1671,7 @@ Sfx_ChooseACard_Ch5:
 	rest 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_ChooseACard_Ch6:
 	toggle_sfx
@@ -1703,7 +1703,7 @@ Sfx_ChooseACard_Ch6:
 	rest 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_ChooseACard_Ch7:
 	toggle_sfx
@@ -1739,7 +1739,7 @@ Sfx_ChooseACard_Ch7:
 	rest 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_ChooseACard_Ch8:
 	toggle_sfx
@@ -1764,7 +1764,7 @@ Sfx_ChooseACard_Ch8:
 	note B_, 16
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetTm:
 	channel_count 4
@@ -1797,7 +1797,7 @@ Sfx_GetTm_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetTm_Ch6:
 	toggle_sfx
@@ -1820,7 +1820,7 @@ Sfx_GetTm_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetTm_Ch7:
 	toggle_sfx
@@ -1851,7 +1851,7 @@ Sfx_GetTm_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetTm_Ch8:
 	toggle_sfx
@@ -1871,7 +1871,7 @@ Sfx_GetTm_Ch8:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetBadge:
 	channel_count 4
@@ -1899,7 +1899,7 @@ Sfx_GetBadge_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetBadge_branch_f11aa:
 	rest 5
@@ -1970,7 +1970,7 @@ Sfx_GetBadge_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetBadge_Ch7:
 	toggle_sfx
@@ -2009,7 +2009,7 @@ Sfx_GetBadge_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_GetBadge_Ch8:
 	toggle_sfx
@@ -2035,7 +2035,7 @@ Sfx_GetBadge_branch_f1220:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_QuitSlots:
 	channel_count 4
@@ -2074,7 +2074,7 @@ Sfx_QuitSlots_Ch5:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_QuitSlots_Ch6:
 	toggle_sfx
@@ -2101,7 +2101,7 @@ Sfx_QuitSlots_Ch6:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_QuitSlots_Ch7:
 	toggle_sfx
@@ -2132,7 +2132,7 @@ Sfx_QuitSlots_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_QuitSlots_Ch8:
 	toggle_sfx
@@ -2152,7 +2152,7 @@ Sfx_QuitSlots_Ch8:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_Protect:
 	channel_count 2
@@ -3042,7 +3042,7 @@ Sfx_DexFanfareLessThan20_Ch5:
 	note D_, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfareLessThan20_Ch6:
 	toggle_sfx
@@ -3061,7 +3061,7 @@ Sfx_DexFanfareLessThan20_Ch6:
 	note F#, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfareLessThan20_Ch7:
 	toggle_sfx
@@ -3089,7 +3089,7 @@ Sfx_DexFanfareLessThan20_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfareLessThan20_Ch8:
 	toggle_sfx
@@ -3100,7 +3100,7 @@ Sfx_DexFanfareLessThan20_Ch8:
 	rest 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare140169:
 	channel_count 4
@@ -3136,7 +3136,7 @@ Sfx_DexFanfare140169_Ch5:
 	rest 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare140169_Ch6:
 	toggle_sfx
@@ -3162,7 +3162,7 @@ Sfx_DexFanfare140169_Ch6:
 	rest 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare140169_Ch7:
 	toggle_sfx
@@ -3196,7 +3196,7 @@ Sfx_DexFanfare140169_Ch7:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare140169_Ch8:
 	toggle_sfx
@@ -3213,7 +3213,7 @@ Sfx_DexFanfare140169_branch_f1945:
 	note D_, 8
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare170199:
 	channel_count 4
@@ -3249,7 +3249,7 @@ Sfx_DexFanfare170199_Ch5:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare170199_Ch6:
 	toggle_sfx
@@ -3277,7 +3277,7 @@ Sfx_DexFanfare170199_Ch6:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare170199_Ch7:
 	toggle_sfx
@@ -3305,7 +3305,7 @@ Sfx_DexFanfare170199_Ch7:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare170199_Ch8:
 	toggle_sfx
@@ -3327,7 +3327,7 @@ Sfx_DexFanfare170199_Ch8:
 	note B_, 16
 	sound_ret
 
-	db sound_loop_cmd
+	db sound_loop_cmd ; unused
 
 Sfx_DexFanfare200229:
 	channel_count 4
@@ -3361,7 +3361,7 @@ Sfx_DexFanfare200229_Ch5:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare200229_Ch6:
 	toggle_sfx
@@ -3384,7 +3384,7 @@ Sfx_DexFanfare200229_Ch6:
 	rest 4
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare200229_Ch7:
 	toggle_sfx
@@ -3428,7 +3428,7 @@ Sfx_DexFanfare200229_Ch7:
 	rest 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare200229_Ch8:
 	toggle_sfx
@@ -3457,7 +3457,7 @@ Sfx_DexFanfare200229_Ch8:
 	note B_, 12
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare230Plus:
 	channel_count 4
@@ -3512,7 +3512,7 @@ Sfx_DexFanfare230Plus_Ch5:
 	rest 2
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare230Plus_Ch6:
 	toggle_sfx
@@ -3547,7 +3547,7 @@ Sfx_DexFanfare230Plus_Ch6:
 	rest 2
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare230Plus_Ch7:
 	toggle_sfx
@@ -3596,7 +3596,7 @@ Sfx_DexFanfare230Plus_Ch7:
 	rest 2
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_DexFanfare230Plus_Ch8:
 	toggle_sfx
@@ -3632,7 +3632,7 @@ Sfx_DexFanfare230Plus_branch_f1b2b:
 	note D_, 6
 	sound_ret
 
-	toggle_sfx
+	toggle_sfx ; unused
 
 Sfx_NotVeryEffective:
 	channel_count 1

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -617,7 +617,7 @@ And edit [engine/pokegear/radio.asm](https://github.com/pret/pokecrystal/blob/ma
  	add hl, bc
  	add hl, bc
 +	add hl, bc
-+	b = bank
++	; b = bank
 +	ld a, BANK(PokedexDataPointerTable)
 +	call GetFarByte
 +	ld b, a

--- a/macros/code.asm
+++ b/macros/code.asm
@@ -51,7 +51,7 @@ calc_sine_wave: MACRO
 ; input: a = a signed 6-bit value
 ; output: a = d * sin(a * pi/32)
 	and %111111
-	cp  %100000
+	cp %100000
 	jr nc, .negative\@
 	call .apply\@
 	ld a, h

--- a/macros/wram.asm
+++ b/macros/wram.asm
@@ -238,6 +238,7 @@ link_battle_record: MACRO
 \1Wins::   dw
 \1Losses:: dw
 \1Draws::  dw
+\1End::
 ENDM
 
 trademon: MACRO

--- a/sram.asm
+++ b/sram.asm
@@ -125,12 +125,10 @@ SECTION "Active Box", SRAM
 sBox:: box sBox
 ; b160
 
-	ds $f4
+	ds $100
 
 
 SECTION "Link Battle Data", SRAM
-
-sLinkBattleResults:: ds $c
 
 sLinkBattleStats::
 sLinkBattleWins::   dw ; b260

--- a/wram.asm
+++ b/wram.asm
@@ -2851,15 +2851,15 @@ wCurMapData::
 
 wVisitedSpawns:: flag_array NUM_SPAWNS ; dca5
 
-wDigWarpNumber:: db ; dcaa
-wDigMapGroup::   db ; dcab
-wDigMapNumber::  db ; dcac
+wDigWarpNumber:: db ; dca9
+wDigMapGroup::   db ; dcaa
+wDigMapNumber::  db ; dcab
 
 ; used on maps like second floor pokécenter, which are reused, so we know which
 ; map to return to
-wBackupWarpNumber:: db ; dcad
-wBackupMapGroup::   db ; dcae
-wBackupMapNumber::  db ; dcaf
+wBackupWarpNumber:: db ; dcac
+wBackupMapGroup::   db ; dcad
+wBackupMapNumber::  db ; dcae
 
 	ds 3
 


### PR DESCRIPTION
The link battle−related changes are in regard to @entrpntr's comments on #709. They're far from clarifying what all the code is doing, but do introduce some named constants instead of repeating magic numbers, and get rid of the unnecessary `sLinkBattleStats` label.