### PR TITLE
Clean up some percentage values

### DIFF
--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -27,11 +27,11 @@ BASE_TMHM        EQUS "(wBaseTMHM - wCurBaseData)"
 BASE_DATA_SIZE   EQUS "(wCurBaseDataEnd - wCurBaseData)"
 
 ; gender ratio constants
-GENDER_F0      EQU 0 percent
-GENDER_F12_5   EQU 12 percent + 1
-GENDER_F25     EQU 25 percent
-GENDER_F50     EQU 50 percent
-GENDER_F75     EQU 75 percent
+GENDER_F0      EQU   0 percent
+GENDER_F12_5   EQU  12 percent + 1
+GENDER_F25     EQU  25 percent
+GENDER_F50     EQU  50 percent
+GENDER_F75     EQU  75 percent
 GENDER_F100    EQU 100 percent - 1
 GENDER_UNKNOWN EQU -1
 

--- a/data/battle/critical_hit_chances.asm
+++ b/data/battle/critical_hit_chances.asm
@@ -1,8 +1,8 @@
 CriticalHitChances:
-	db  7 percent     ;  0
-	db 12 percent + 2 ; +1
-	db 25 percent + 1 ; +2
-	db 33 percent + 1 ; +3
-	db 50 percent + 1 ; +4
-	db 50 percent + 1 ; +5
-	db 50 percent + 1 ; +6
+	db 1 out_of 15 ;  0
+	db 1 out_of 8  ; +1
+	db 1 out_of 4  ; +2
+	db 1 out_of 3  ; +3
+	db 1 out_of 2  ; +4
+	db 1 out_of 2  ; +5
+	db 1 out_of 2  ; +6

--- a/data/events/happiness_probabilities.asm
+++ b/data/events/happiness_probabilities.asm
@@ -1,12 +1,12 @@
 HappinessData_OlderHaircutBrother:
-	db $4c, 2, HAPPINESS_OLDERCUT1 ; 30% chance
-	db $80, 3, HAPPINESS_OLDERCUT2 ; 50% chance
-	db $ff, 4, HAPPINESS_OLDERCUT3 ; 20% chance
+	db  30 percent,     2, HAPPINESS_OLDERCUT1 ; 30% chance
+	db  50 percent + 1, 3, HAPPINESS_OLDERCUT2 ; 50% chance
+	db 100 percent,     4, HAPPINESS_OLDERCUT3 ; 20% chance
 
 HappinessData_YoungerHaircutBrother:
-	db $9a, 2, HAPPINESS_YOUNGCUT1 ; 60% chance
-	db $4c, 3, HAPPINESS_YOUNGCUT2 ; 30% chance
-	db $ff, 4, HAPPINESS_YOUNGCUT3 ; 10% chance
+	db  60 percent + 1, 2, HAPPINESS_YOUNGCUT1 ; 60% chance
+	db  30 percent,     3, HAPPINESS_YOUNGCUT2 ; 30% chance
+	db 100 percent,     4, HAPPINESS_YOUNGCUT3 ; 10% chance
 
 HappinessData_DaisysGrooming:
-	db $ff, 2, HAPPINESS_GROOMING ; 99.6% chance
+	db 100 percent,     2, HAPPINESS_GROOMING ; 99.6% chance

--- a/data/moves/magnitude_power.asm
+++ b/data/moves/magnitude_power.asm
@@ -1,9 +1,9 @@
 MagnitudePower:
 	; chance, power, magnitude #
-	db  13,  10,  4
-	db  38,  30,  5
-	db  89,  50,  6
-	db 166,  70,  7
-	db 217,  90,  8
-	db 242, 110,  9
-	db 255, 150, 10
+	db   5 percent + 1,  10,  4 ; 5%
+	db  15 percent,      30,  5 ; 10%
+	db  35 percent,      50,  6 ; 20%
+	db  65 percent + 1,  70,  7 ; 30%
+	db  85 percent + 1,  90,  8 ; 20%
+	db  95 percent,     110,  9 ; 10%
+	db 100 percent,     150, 10 ; 5%

--- a/data/moves/present_power.asm
+++ b/data/moves/present_power.asm
@@ -1,6 +1,6 @@
 PresentPower:
 	; chance, power
-	db 40 percent,     40 ; 40%
-	db 70 percent + 1, 80 ; 30%
-	db 80 percent,    120 ; 10%
+	db 40 percent,     40 ; 40% chance
+	db 70 percent + 1, 80 ; 30% chance
+	db 80 percent,    120 ; 10% chance
 	db -1                 ; 20% chance to heal instead

--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -1198,6 +1198,7 @@ GrimerEvosAttacks:
 
 MukEvosAttacks:
 	db 0 ; no more evolutions
+	; moves are not sorted by level
 	db 1, POISON_GAS
 	db 1, POUND
 	db 1, HARDEN

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1,5 +1,6 @@
 AIScoring: ; used only for BANK(AIScoring)
 
+
 AI_Basic:
 ; Don't do anything redundant:
 ;  -Using status-only moves if the player can't be statused
@@ -458,15 +459,15 @@ AI_Smart_LockOn:
 
 .asm_38834
 	ld a, [wPlayerEvaLevel]
-	cp $a
+	cp BASE_STAT_LEVEL + 3
 	jr nc, .asm_3887a
-	cp $8
+	cp BASE_STAT_LEVEL + 1
 	jr nc, .asm_38875
 
 	ld a, [wEnemyAccLevel]
-	cp $5
+	cp BASE_STAT_LEVEL - 2
 	jr c, .asm_3887a
-	cp $7
+	cp BASE_STAT_LEVEL
 	jr c, .asm_38875
 
 	ld hl, wEnemyMonMoves
@@ -572,7 +573,7 @@ AI_Smart_Selfdestruct:
 ; If enemy's HP is between 25% and 50%,
 ; over 90% chance to greatly discourage this move.
 	call Random
-	cp 9 percent - 2
+	cp 8 percent
 	ret c
 
 .asm_388c6
@@ -596,7 +597,7 @@ AI_Smart_DreamEater:
 AI_Smart_EvasionUp:
 ; Dismiss this move if enemy's evasion can't raise anymore.
 	ld a, [wEnemyEvaLevel]
-	cp $d
+	cp MAX_STAT_LEVEL
 	jp nc, AIDiscourageMove
 
 ; If enemy's HP is full...
@@ -707,12 +708,12 @@ AI_Smart_AlwaysHit:
 
 ; ...enemy's accuracy level has been lowered three or more stages
 	ld a, [wEnemyAccLevel]
-	cp $5
+	cp BASE_STAT_LEVEL - 2
 	jr c, .asm_38954
 
 ; ...or player's evasion level has been raised three or more stages.
 	ld a, [wPlayerEvaLevel]
-	cp $a
+	cp BASE_STAT_LEVEL + 3
 	ret c
 
 .asm_38954
@@ -872,12 +873,12 @@ AI_Smart_ResetStats:
 ; 85% chance to encourage this move if any of enemy's stat levels is lower than -2.
 	push hl
 	ld hl, wEnemyAtkLevel
-	ld c, $8
+	ld c, NUM_LEVEL_STATS
 .asm_389fb
 	dec c
 	jr z, .asm_38a05
 	ld a, [hli]
-	cp $5
+	cp BASE_STAT_LEVEL - 2
 	jr c, .asm_38a12
 	jr .asm_389fb
 
@@ -889,7 +890,7 @@ AI_Smart_ResetStats:
 	dec c
 	jr z, .asm_38a1b
 	ld a, [hli]
-	cp $a
+	cp BASE_STAT_LEVEL + 3
 	jr c, .asm_38a0a
 
 .asm_38a12
@@ -1108,12 +1109,12 @@ AI_Smart_SpDefenseUp2:
 
 ; Discourage this move if enemy's special defense level is higher than +3.
 	ld a, [wEnemySDefLevel]
-	cp $b
+	cp BASE_STAT_LEVEL + 4
 	jr nc, .asm_38b10
 
 ; 80% chance to greatly encourage this move if
 ; enemy's Special Defense level is lower than +2, and the player is of a special type.
-	cp $9
+	cp BASE_STAT_LEVEL + 2
 	ret nc
 
 	ld a, [wBattleMonType1]
@@ -1252,11 +1253,11 @@ AI_Smart_Rage:
 ; Encourage this move based on Rage's counter.
 .asm_38b8c
 	ld a, [wEnemyRageCounter]
-	cp $2
+	cp 2
 	ret c
 	dec [hl]
 	ld a, [wEnemyRageCounter]
-	cp $3
+	cp 3
 	ret c
 	dec [hl]
 	ret
@@ -1328,7 +1329,7 @@ AI_Smart_Mimic:
 AI_Smart_Counter:
 	push hl
 	ld hl, wPlayerUsedMoves
-	ld c, 4
+	ld c, NUM_MOVES
 	ld b, 0
 
 .asm_38bf9
@@ -1467,8 +1468,8 @@ AI_Smart_SleepTalk:
 ; Greatly discourage this move otherwise.
 
 	ld a, [wEnemyMonStatus]
-	and $7
-	cp $1
+	and SLP
+	cp 1
 	jr z, .asm_38cc7
 
 	dec [hl]
@@ -1529,9 +1530,9 @@ AI_Smart_Spite:
 .asm_38cfb
 	pop hl
 	ld a, [de]
-	cp $6
+	cp 6
 	jr c, .asm_38d0d
-	cp $f
+	cp 15
 	jr nc, .asm_38d0b
 
 	call Random
@@ -1828,9 +1829,9 @@ AI_Smart_Curse:
 	jr nc, .asm_38e93
 
 	ld a, [wEnemyAtkLevel]
-	cp $b
+	cp BASE_STAT_LEVEL + 4
 	jr nc, .asm_38e93
-	cp $9
+	cp BASE_STAT_LEVEL + 2
 	ret nc
 
 	ld a, [wBattleMonType1]
@@ -1954,10 +1955,10 @@ AI_Smart_Protect:
 
 AI_Smart_Foresight:
 	ld a, [wEnemyAccLevel]
-	cp $5
+	cp BASE_STAT_LEVEL - 2
 	jr c, .asm_38f41
 	ld a, [wPlayerEvaLevel]
-	cp $a
+	cp BASE_STAT_LEVEL + 3
 	jr nc, .asm_38f41
 
 	ld a, [wBattleMonType1]
@@ -2417,7 +2418,7 @@ AI_Smart_BellyDrum:
 ; Else, discourage this move if enemy's HP is not full.
 
 	ld a, [wEnemyAtkLevel]
-	cp $a
+	cp BASE_STAT_LEVEL + 3
 	jr nc, .asm_3914d
 
 	call AICheckEnemyMaxHP
@@ -2472,12 +2473,12 @@ AI_Smart_PsychUp:
 
 ; Else, 80% chance to encourage this move unless player's accuracy level is lower than -1...
 	ld a, [wPlayerAccLevel]
-	cp $6
+	cp BASE_STAT_LEVEL - 1
 	ret c
 
 ; ...or enemy's evasion level is higher than +0.
 	ld a, [wEnemyEvaLevel]
-	cp $8
+	cp BASE_STAT_LEVEL + 1
 	ret nc
 
 	call AI_80_20
@@ -2494,8 +2495,8 @@ AI_Smart_PsychUp:
 AI_Smart_MirrorCoat:
 	push hl
 	ld hl, wPlayerUsedMoves
-	ld c, $4
-	ld b, $0
+	ld c, NUM_MOVES
+	ld b, 0
 
 .asm_39193
 	ld a, [hli]
@@ -2828,7 +2829,7 @@ AIHasMoveInArray:
 
 .next
 	ld a, [hli]
-	cp $ff
+	cp -1
 	jr z, .done
 
 	ld b, a

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6200,7 +6200,7 @@ LoadEnemyMon:
 	jr z, .Happiness
 ; 40% chance of not flooring
 	call Random
-	cp 40 percent - 2
+	cp 39 percent + 1
 	jr c, .Happiness
 ; Try again if length < 1024 mm (i.e. if HIGH(length) < 3 feet)
 	ld a, [wMagikarpLength]

--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -198,7 +198,7 @@ DayCareStep::
 	callfar CheckBreedmonCompatibility
 	ld a, [wBreedingCompatibility]
 	cp 230
-	ld b, 32 percent - 1
+	ld b, 31 percent + 1
 	jr nc, .okay
 	ld a, [wBreedingCompatibility]
 	cp 170

--- a/engine/events/pokerus/pokerus.asm
+++ b/engine/events/pokerus/pokerus.asm
@@ -26,8 +26,8 @@ GivePokerusAndConvertBerries:
 	and a
 	ret nz
 	ldh a, [hRandomSub]
-	cp $3
-	ret nc                 ; 3/65536 chance (00 00, 00 01 or 00 02)
+	cp 3
+	ret nc ; 3/65536 chance (00 00, 00 01 or 00 02)
 	ld a, [wPartyCount]
 	ld b, a
 .randomMonSelectLoop
@@ -36,11 +36,11 @@ GivePokerusAndConvertBerries:
 	cp b
 	jr nc, .randomMonSelectLoop
 	ld hl, wPartyMon1PokerusStatus
-	call GetPartyLocation  ; get pokerus byte of random mon
+	call GetPartyLocation ; get pokerus byte of random mon
 	ld a, [hl]
 	and $f0
-	ret nz                 ; if it already has pokerus, do nothing
-.randomPokerusLoop         ; Simultaneously sample the strain and duration
+	ret nz ; if it already has pokerus, do nothing
+.randomPokerusLoop ; Simultaneously sample the strain and duration
 	call Random
 	and a
 	jr z, .randomPokerusLoop
@@ -62,20 +62,20 @@ GivePokerusAndConvertBerries:
 .TrySpreadPokerus:
 	call Random
 	cp 33 percent + 1
-	ret nc              ; 1/3 chance
+	ret nc ; 1/3 chance
 
 	ld a, [wPartyCount]
 	cp 1
-	ret z               ; only one mon, nothing to do
+	ret z ; only one mon, nothing to do
 
 	ld c, [hl]
 	ld a, b
 	cp 2
-	jr c, .checkPreviousMonsLoop    ; no more mons after this one, go backwards
+	jr c, .checkPreviousMonsLoop ; no more mons after this one, go backwards
 
 	call Random
 	cp 50 percent + 1
-	jr c, .checkPreviousMonsLoop    ; 1/2 chance, go backwards
+	jr c, .checkPreviousMonsLoop ; 1/2 chance, go backwards
 .checkFollowingMonsLoop
 	add hl, de
 	ld a, [hl]
@@ -83,8 +83,8 @@ GivePokerusAndConvertBerries:
 	jr z, .infectMon
 	ld c, a
 	and $3
-	ret z               ; if mon has cured pokerus, stop searching
-	dec b               ; go on to next mon
+	ret z ; if mon has cured pokerus, stop searching
+	dec b ; go on to next mon
 	ld a, b
 	cp 1
 	jr nz, .checkFollowingMonsLoop ; no more mons left
@@ -93,7 +93,7 @@ GivePokerusAndConvertBerries:
 .checkPreviousMonsLoop
 	ld a, [wPartyCount]
 	cp b
-	ret z               ; no more mons
+	ret z ; no more mons
 	ld a, l
 	sub e
 	ld l, a
@@ -105,8 +105,8 @@ GivePokerusAndConvertBerries:
 	jr z, .infectMon
 	ld c, a
 	and $3
-	ret z               ; if mon has cured pokerus, stop searching
-	inc b               ; go on to next mon
+	ret z ; if mon has cured pokerus, stop searching
+	inc b ; go on to next mon
 	jr .checkPreviousMonsLoop
 
 .infectMon
@@ -128,7 +128,7 @@ ConvertBerriesToBerryJuice:
 	bit STATUSFLAGS2_REACHED_GOLDENROD_F, [hl]
 	ret z
 	call Random
-	cp 6 percent + 1 ; 1/16 chance
+	cp 1 out_of 16 ; 6.25% chance
 	ret nc
 	ld hl, wPartyMons
 	ld a, [wPartyCount]

--- a/engine/games/slot_machine.asm
+++ b/engine/games/slot_machine.asm
@@ -586,7 +586,7 @@ Slots_StopReel2:
 	call .CheckReel1ForASeven
 	jr nz, .dont_jump
 	call Random
-	cp $50 ; 32%
+	cp 31 percent + 1
 	jr nc, .dont_jump
 	ld a, REEL_ACTION_SET_UP_REEL2_SKIP_TO_7
 	ret
@@ -632,20 +632,20 @@ Slots_StopReel3:
 	and a
 	jr nz, .biased
 	call Random
-	cp 180
+	cp 71 percent - 1
 	jr nc, .stop
-	cp 120
+	cp 47 percent + 1
 	jr nc, .slow_advance
-	cp 60
+	cp 24 percent - 1
 	jr nc, .golem
 	ld a, REEL_ACTION_INIT_CHANSEY
 	ret
 
 .biased
 	call Random
-	cp 160
+	cp 63 percent
 	jr nc, .stop
-	cp 80
+	cp 31 percent + 1
 	jr nc, .slow_advance
 .golem
 	ld a, REEL_ACTION_INIT_GOLEM
@@ -1608,7 +1608,7 @@ Slots_GetNumberOfGolems:
 .not_biased_to_seven
 	call Random
 	and $7
-	cp $4 ; ((50 percent) & 7) + 1
+	cp $8 / 2 ; 50%
 	jr c, .not_biased_to_seven
 	ld e, a
 .loop2
@@ -1649,22 +1649,22 @@ Slots_InitBias:
 	ret
 
 .Normal:
-	db $01, SLOTS_SEVEN    ; 1/256
-	db $03, SLOTS_POKEBALL ; 1/128
-	db $0a, SLOTS_STARYU   ; 7/256
-	db $14, SLOTS_SQUIRTLE ; 5/128
-	db $28, SLOTS_PIKACHU  ; 5/64
-	db $30, SLOTS_CHERRY   ; 1/32
-	db $ff, SLOTS_NO_BIAS   ; everything else
+	db   1 percent - 1, SLOTS_SEVEN
+	db   1 percent + 1, SLOTS_POKEBALL
+	db   4 percent,     SLOTS_STARYU
+	db   8 percent,     SLOTS_SQUIRTLE
+	db  16 percent,     SLOTS_PIKACHU
+	db  19 percent,     SLOTS_CHERRY
+	db 100 percent,     SLOTS_NO_BIAS
 
 .Lucky:
-	db $02, SLOTS_SEVEN    ;  1/128
-	db $03, SLOTS_POKEBALL ;  1/256
-	db $08, SLOTS_STARYU   ;  5/256
-	db $10, SLOTS_SQUIRTLE ;  1/32
-	db $1e, SLOTS_PIKACHU  ;  7/128
-	db $50, SLOTS_CHERRY   ; 25/128
-	db $ff, SLOTS_NO_BIAS   ; everything else
+	db   1 percent,     SLOTS_SEVEN
+	db   1 percent + 1, SLOTS_POKEBALL
+	db   3 percent + 1, SLOTS_STARYU
+	db   6 percent + 1, SLOTS_SQUIRTLE
+	db  12 percent,     SLOTS_PIKACHU
+	db  31 percent + 1, SLOTS_CHERRY
+	db 100 percent,     SLOTS_NO_BIAS
 
 Slots_IlluminateBetLights:
 	ld b, $14 ; turned on

--- a/engine/link/mystery_gift_2.asm
+++ b/engine/link/mystery_gift_2.asm
@@ -80,7 +80,7 @@ PrepMysteryGiftDataToSend:
 
 .tenpercent
 	call Random
-	cp 20 percent - 1
+	cp 20 percent - 1 ; 50
 	jr c, .twopercent
 	call Random
 	and %011

--- a/macros/data.asm
+++ b/macros/data.asm
@@ -1,6 +1,29 @@
 ; Value macros
 
+; Many arbitrary percentages are simple base-10 or base-16 values:
+; -  10 = 4 percent
+; -  15 = 6 percent
+; - $10 = 6 percent + 1 = 7 percent - 1
+; -  20 = 8 percent
+; -  25 = 10 percent
+; -  30 = 12 percent
+; -  40 = 16 percent
+; -  50 = 20 percent - 1
+; -  60 = 24 percent - 1
+; -  70 = 28 percent - 1
+; -  80 = 31 percent + 1 = 32 percent - 1
+; -  85 = 33 percent + 1 = 34 percent - 1
+; - 100 = 39 percent + 1 = 40 percent - 2
+; - 120 = 47 percent + 1
+; - 123 = 49 percent - 1
+; - 160 = 63 percent
+; - 180 = 71 percent - 1 = 70 percent + 2
+; - 200 = 79 percent - 1
+; - 230 = 90 percent + 1
 percent EQUS "* $ff / 100"
+
+; e.g. 1 out_of 2 == 50 percent + 1 == $80
+out_of EQUS "* $100 /"
 
 ; Constant data (db, dw, dl) macros
 


### PR DESCRIPTION
- Use `out_of` for a few chances that are expressed better as fractions than as percentages
- Standardize percentages, e.g. 39 percent + 1, not 40 percent - 2
- Comment on how some arbitrary percentages look neater in base-10