### PR TITLE
Update used_space.py and mapreader.py tools for rgbds v0.4.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 baserom.txt
 pokecrystal.txt
 
+# used_space.py
+used_space.png
+
 # for vim configuration
 # url: http://www.vim.org/scripts/script.php?script_id=441
 .lvimrc

--- a/tools/mapreader.py
+++ b/tools/mapreader.py
@@ -38,10 +38,11 @@ class MapReader:
     bank_types = {
         'HRAM'     : { 'size': 0x80,   'banked': False, },
         'OAM'      : { 'size': 0xA0,   'banked': False, },
-        'ROM Bank' : { 'size': 0x4000, 'banked': True,  },
-        'SRAM Bank': { 'size': 0x2000, 'banked': True,  },
-        'VRAM Bank': { 'size': 0x1000, 'banked': True,  },
-        'WRAM Bank': { 'size': 0x2000, 'banked': True,  },
+        'ROM0 bank': { 'size': 0x4000, 'banked': True,  },
+        'ROMX bank': { 'size': 0x4000, 'banked': True,  },
+        'SRAM bank': { 'size': 0x2000, 'banked': True,  },
+        'VRAM bank': { 'size': 0x1000, 'banked': True,  },
+        'WRAM bank': { 'size': 0x2000, 'banked': True,  },
     }
 
     # FSM states
@@ -52,7 +53,7 @@ class MapReader:
     # $506D = TypeMatchups
     section_data_regex = re.compile('\$([0-9A-Fa-f]{4}) = (.*)')
     # $3ED2 bytes
-    slack_regex = re.compile('\$([0-9A-Fa-f]{4}) bytes')
+    slack_regex = re.compile('\$([0-9A-Fa-f]{4}) bytes?')
 
     def __init__(self, *args, **kwargs):
         self.__dict__.update(kwargs)

--- a/tools/used_space.py
+++ b/tools/used_space.py
@@ -38,7 +38,8 @@ def main():
 	default_bank_data = {'sections': [], 'used': 0, 'slack': bank_size}
 	for bank in range(num_banks):
 		hits = [0] * pixels_per_bank
-		data = r.bank_data['ROM Bank'].get(bank, default_bank_data)
+		bank_data = r.bank_data['ROM0 bank'] if bank == 0 else r.bank_data['ROMX bank']
+		data = bank_data.get(bank, default_bank_data)
 		for s in data['sections']:
 			beg = s['beg'] & bank_mask
 			end = s['end'] & bank_mask


### PR DESCRIPTION
Guessing these broke some time between their introduction and the rgbds v0.4.0 release. This was the solution I came up with; the fix for ROM0 seems a bit hacky and was mainly done so ROM0 shows up in the png. Feel free to choose another solution in lieu of this one.

(And yes, there are three pic banks in Crystal with exactly 1 byte of slack, so the regex fix matters too now.)