### PR TITLE
Add label for wd431

### DIFF
--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -1529,7 +1529,7 @@ Function1009f3:
 
 _LinkBattleSendReceiveAction:
 	call .StageForSend
-	ld [wd431], a
+	ld [wLinkBattleSentAction], a
 	farcall PlaceWaitingText
 	ld a, [wLinkMode]
 	cp LINK_MOBILE
@@ -1573,7 +1573,7 @@ _LinkBattleSendReceiveAction:
 	ret
 
 .LinkBattle_SendReceiveAction:
-	ld a, [wd431]
+	ld a, [wLinkBattleSentAction]
 	ld [wPlayerLinkAction], a
 	ld a, $ff
 	ld [wOtherPlayerLinkAction], a
@@ -1642,7 +1642,7 @@ _LinkBattleSendReceiveAction:
 Function100acf:
 	ld de, Unknown_100b0a
 	ld hl, wccb5
-	ld a, [wd431]
+	ld a, [wLinkBattleSentAction]
 	ld [hli], a
 	ld c, $01
 .asm_100adb

--- a/wram.asm
+++ b/wram.asm
@@ -2365,7 +2365,7 @@ ENDU ; d430
 wd430:: ; mobile
 wBattleAction:: db ; d430
 
-wd431:: db ; mobile
+wLinkBattleSentAction:: db ; d431
 wMapStatus:: db ; d432
 wMapEventStatus:: db ; d433
 


### PR DESCRIPTION
Also removes a misleading comment. wd431 is used for battle action communication in general over serial, including regular link battles, not just mobile