### PR TITLE
Rename ScrollingMenu_UpdateDisplay.string_2485f

### DIFF
--- a/engine/items/tmhm.asm
+++ b/engine/items/tmhm.asm
@@ -417,7 +417,7 @@ TMHM_DisplayPocketItems:
 	inc hl
 	inc hl
 	push de
-	ld de, TMHM_String_Cancel
+	ld de, TMHM_CancelString
 	call PlaceString
 	pop de
 .done
@@ -449,7 +449,7 @@ Unreferenced_Function2ca95:
 	pop hl
 	ret
 
-TMHM_String_Cancel:
+TMHM_CancelString:
 	db "CANCEL@"
 
 TMHM_GetCurrentPocketPosition:
@@ -472,7 +472,7 @@ TMHM_GetCurrentPocketPosition:
 Tutorial_TMHMPocket:
 	hlcoord 9, 3
 	push de
-	ld de, TMHM_String_Cancel
+	ld de, TMHM_CancelString
 	call PlaceString
 	pop de
 	ret

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -1571,10 +1571,10 @@ Unreferenced_Function28b42:
 	ld bc, SCREEN_WIDTH - 2
 	call ByteFill
 	hlcoord 2, 16
-	ld de, .cancel_string
+	ld de, .CancelString
 	jp PlaceString
 
-.cancel_string:
+.CancelString:
 	db "CANCEL@"
 
 Function28b68:

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -1571,10 +1571,10 @@ Unreferenced_Function28b42:
 	ld bc, SCREEN_WIDTH - 2
 	call ByteFill
 	hlcoord 2, 16
-	ld de, .Cancel
+	ld de, .cancel_string
 	jp PlaceString
 
-.Cancel:
+.cancel_string:
 	db "CANCEL@"
 
 Function28b68:

--- a/engine/link/link_trade.asm
+++ b/engine/link/link_trade.asm
@@ -115,11 +115,11 @@ InitTradeSpeciesList:
 	farcall InitMG_Mobile_LinkTradePalMap
 	farcall PlaceTradePartnerNamesAndParty
 	hlcoord 10, 17
-	ld de, .cancel_string
+	ld de, .CancelString
 	call PlaceString
 	ret
 
-.cancel_string:
+.CancelString:
 	db "CANCEL@"
 
 _LoadTradeScreenBorder:

--- a/engine/link/link_trade.asm
+++ b/engine/link/link_trade.asm
@@ -115,11 +115,11 @@ InitTradeSpeciesList:
 	farcall InitMG_Mobile_LinkTradePalMap
 	farcall PlaceTradePartnerNamesAndParty
 	hlcoord 10, 17
-	ld de, .CANCEL
+	ld de, .cancel_string
 	call PlaceString
 	ret
 
-.CANCEL:
+.cancel_string:
 	db "CANCEL@"
 
 _LoadTradeScreenBorder:

--- a/engine/menus/scrolling_menu.asm
+++ b/engine/menus/scrolling_menu.asm
@@ -401,11 +401,11 @@ ScrollingMenu_UpdateDisplay:
 	ld a, [wMenuDataFlags]
 	bit 0, a ; call function on cancel
 	jr nz, .call_function
-	ld de, .string_2485f
+	ld de, .cancel_string
 	call PlaceString
 	ret
 
-.string_2485f
+.cancel_string
 	db "CANCEL@"
 
 .call_function

--- a/engine/menus/scrolling_menu.asm
+++ b/engine/menus/scrolling_menu.asm
@@ -401,11 +401,11 @@ ScrollingMenu_UpdateDisplay:
 	ld a, [wMenuDataFlags]
 	bit 0, a ; call function on cancel
 	jr nz, .call_function
-	ld de, .cancel_string
+	ld de, .CancelString
 	call PlaceString
 	ret
 
-.cancel_string
+.CancelString
 	db "CANCEL@"
 
 .call_function

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -1254,7 +1254,7 @@ BillsPC_RefreshTextboxes:
 	jr nz, .loop
 	ret
 
-.CancelString:
+.cancel_string:
 	db "CANCEL@"
 
 .PlaceNickname:
@@ -1263,7 +1263,7 @@ BillsPC_RefreshTextboxes:
 	ret z
 	cp -1
 	jr nz, .get_nickname
-	ld de, .CancelString
+	ld de, .cancel_string
 	call PlaceString
 	ret
 

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -1254,7 +1254,7 @@ BillsPC_RefreshTextboxes:
 	jr nz, .loop
 	ret
 
-.cancel_string:
+.CancelString:
 	db "CANCEL@"
 
 .PlaceNickname:
@@ -1263,7 +1263,7 @@ BillsPC_RefreshTextboxes:
 	ret z
 	cp -1
 	jr nz, .get_nickname
-	ld de, .cancel_string
+	ld de, .CancelString
 	call PlaceString
 	ret
 

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -105,11 +105,11 @@ PlacePartyNicknames:
 .end
 	dec hl
 	dec hl
-	ld de, .cancel_string
+	ld de, .CancelString
 	call PlaceString
 	ret
 
-.cancel_string:
+.CancelString:
 	db "CANCEL@"
 
 PlacePartyHPBar:

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -105,11 +105,11 @@ PlacePartyNicknames:
 .end
 	dec hl
 	dec hl
-	ld de, .CANCEL
+	ld de, .cancel_string
 	call PlaceString
 	ret
 
-.CANCEL:
+.cancel_string:
 	db "CANCEL@"
 
 PlacePartyHPBar:

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -6487,12 +6487,12 @@ Function102e07:
 	db "Waiting...!@"
 
 Function102e3e:
-	ld de, .cancel_string
+	ld de, .CancelString
 	hlcoord 10, 17
 	call PlaceString
 	ret
 
-.cancel_string:
+.CancelString:
 	db "CANCEL@"
 
 Function102e4f:

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -6487,12 +6487,12 @@ Function102e07:
 	db "Waiting...!@"
 
 Function102e3e:
-	ld de, .CANCEL
+	ld de, .cancel_string
 	hlcoord 10, 17
 	call PlaceString
 	ret
 
-.CANCEL:
+.cancel_string:
 	db "CANCEL@"
 
 Function102e4f:

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -3889,6 +3889,7 @@ Strings_Ll0ToL40:
 	db " L:30 @@"
 	db " L:40 @@"
 	db "CANCEL@@"
+	
 Unreferenced_CancelString:
 	db "CANCEL@"
 

--- a/mobile/mobile_46.asm
+++ b/mobile/mobile_46.asm
@@ -3889,8 +3889,7 @@ Strings_Ll0ToL40:
 	db " L:30 @@"
 	db " L:40 @@"
 	db "CANCEL@@"
-
-String_119d8c:
+Unreferenced_CancelString:
 	db "CANCEL@"
 
 BattleTower_LevelCheck:


### PR DESCRIPTION
Noticed an unnamed string in /engine/menus/scrolling_menu.asm, and a little investigating found that there isn't a consistent name for this sort of thing throughout the project (nor do current labels follow `STYLE.md`).  Are `.CancelString:` and `Prefix_CancelString:` adequate names?
