### PR TITLE
Use LOAD/ENDL for OAM DMA code in HRAM (requires rgbds 0.4.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 install:
   - |-
     ( cd
-        git clone -b v0.4.0 --depth=1 https://github.com/rednex/rgbds
+        git clone -b v0.4.1 --depth=1 https://github.com/rednex/rgbds
         sudo make -C rgbds install
         rm -rf rgbds
     )

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,15 +41,15 @@ You need to install `gcc`. If you're using Cygwin, re-run its setup, and at "Sel
 
 ### "ERROR: `UNION` already defined"
 
-Download [**rgbds 0.4.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
 
 ### "ERROR: Macro not defined"
 
-Download [**rgbds 0.4.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
 
 ### "Expression must be 8-bit"
 
-Download [**rgbds 0.4.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
 
 ### "Segmentation fault" from `rgbgfx`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ Double click on the text that says "**Skip**" next to each package to select the
 
 Then download [**rgbds**](https://github.com/rednex/rgbds/releases/): the latest **win64.zip** or **win32.zip** release. Extract it and put all the `exe` and `dll` files individually in **C:\cygwin64\usr\local\bin**.
 
-**Note: If you already have an older rgbds, you will need to update to 0.4.0.** Ignore this if you have never installed rgbds before. If a version newer than 0.4.0 does not work, try downloading 0.4.0.
+**Note: If you already have an older rgbds, you will need to update to 0.4.1.** Ignore this if you have never installed rgbds before. If a version newer than 0.4.1 does not work, try downloading 0.4.1.
 
 Now open the **Cygwin terminal** and enter the following commands.
 
@@ -86,7 +86,7 @@ To install **rgbds**:
 
 ```bash
 sudo apt-get install pkg-config flex bison libpng-dev
-git clone -b v0.4.0 --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.4.1 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds install
 ```
 
@@ -102,7 +102,7 @@ To install **rgbds**:
 
 ```bash
 sudo zypper install pkg-config flex bison libpng16-devel
-git clone -b v0.4.0 --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.4.1 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds install
 ```
 
@@ -120,7 +120,7 @@ Alternatively, to install **rgbds** manually:
 
 ```bash
 sudo pacman -S pkg-config flex bison libpng
-git clone -b v0.4.0 --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.4.1 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds install
 ```
 
@@ -157,7 +157,7 @@ If `rgbds` is not available, you'll also need these:
 To install **rgbds**:
 
 ```bash
-git clone -b v0.4.0 --depth=1 https://github.com/rednex/rgbds
+git clone -b v0.4.1 --depth=1 https://github.com/rednex/rgbds
 sudo make -C rgbds install
 ```
 

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -2520,7 +2520,7 @@ EndMoveEffect:
 	ld l, a
 	ld a, [wBattleScriptBufferAddress + 1]
 	ld h, a
-	ld a, $ff
+	ld a, endmove_command
 	ld [hli], a
 	ld [hli], a
 	ld [hl], a

--- a/engine/gfx/load_push_oam.asm
+++ b/engine/gfx/load_push_oam.asm
@@ -1,21 +1,28 @@
 WriteOAMDMACodeToHRAM::
 	ld c, LOW(hTransferVirtualOAM)
-	ld b, .PushOAMEnd - .PushOAM
-	ld hl, .PushOAM
-.loop
+	ld b, OAMDMACodeEnd - OAMDMACode
+	ld hl, OAMDMACode
+.copy
 	ld a, [hli]
 	ldh [c], a
 	inc c
 	dec b
-	jr nz, .loop
+	jr nz, .copy
 	ret
 
-.PushOAM:
+OAMDMACode:
+; This code is defined in ROM, but
+; copied to and called from HRAM.
+LOAD "OAM DMA", HRAM
+hTransferVirtualOAM::
+	; initiate DMA
 	ld a, HIGH(wVirtualOAM)
 	ldh [rDMA], a
+	; wait for DMA to finish
 	ld a, NUM_SPRITE_OAM_STRUCTS
-.pushoam_loop
+.wait
 	dec a
-	jr nz, .pushoam_loop
+	jr nz, .wait
 	ret
-.PushOAMEnd
+ENDL
+OAMDMACodeEnd:

--- a/hram.asm
+++ b/hram.asm
@@ -1,7 +1,5 @@
 SECTION "HRAM", HRAM
 
-hTransferVirtualOAM:: ds 10
-
 hROMBankBackup:: db
 hFarByte::
 hTempBank:: db

--- a/layout.link
+++ b/layout.link
@@ -367,4 +367,5 @@ SRAM $06
 SRAM $07
 	"SRAM Mobile 4"
 HRAM
+	"OAM DMA"
 	"HRAM"


### PR DESCRIPTION
This takes care of one point from #686. Some label and comment changes are copied from pokered.