### PR TITLE
Document oversight with invalid mail handling + fix

### DIFF
--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -87,7 +87,7 @@ ReadAnyMail:
 	cp b
 	jr z, .got_pointer
 	cp -1
-	jr z, .invalid
+	jr z, .invalid ; BUG: This error handling will not be reached if the Mail type is $FF. Put this check before the pointer check to fix this.
 	inc c
 	inc hl
 	inc hl


### PR DESCRIPTION
Due to the error checking happening after the pointer check, the game will treat $FF as a valid mail type, and will end up grabbing the pointer from the first two bytes of LoadSurfMailGFX. Putting the error check first would fix this.