### PR TITLE
Enable compatibility with upcoming RGBASM version

### DIFF
--- a/home/text.asm
+++ b/home/text.asm
@@ -192,11 +192,13 @@ if ISCONST(\2)
 	jr nz, ._\@
 	ld a, \2
 ._\@:
-elif STRSUB("\2", 1, 1) == "."
-; Locals can use a short jump
-	jr z, \2
 else
+	if STRSUB("\2", 1, 1) == "."
+	; Locals can use a short jump
+	jr z, \2
+	else
 	jp z, \2
+	endc
 endc
 ENDM
 


### PR DESCRIPTION
This is additionally required, because an `elif`'s condition is evaluated even when it's about to be skipped over, and this `"\2"` will become an error.