### PR TITLE
Group bugs and glitches by category

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -10,84 +10,93 @@ Fixes are written in the `diff` format. If you've used Git before, this should l
 +add green + lines
 ```
 
-Some fixes are mentioned as breaking compatibility with link battles. This can be avoided by writing more complicated fixes that only apply if the value at `[wLinkMode]` is not `LINK_COLOSSEUM`. That's how Crystal itself fixed two bugs in Gold and Silver regarding the moves [Reflect and Light Screen](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024) and [Present](#present-damage-is-incorrect-in-link-battles).
+Fixes in the [multi-player battle engine](#multi-player-battle-engine) category will break compatibility with standard Pokémon Gold/Silver/Crystal for link battles, unless otherwise noted. This can be avoided by writing more complicated fixes that only apply if the value at `[wLinkMode]` is not `LINK_COLOSSEUM`. That's how Crystal itself fixed two bugs in Gold and Silver regarding the moves [Reflect and Light Screen](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024) and [Present](#present-damage-is-incorrect-in-link-battles).
 
 
 ## Contents
 
-- [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
-- [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
-- [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
-- [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
-- [Glacier Badge may not boost Special Defense depending on the value of Special Attack](#glacier-badge-may-not-boost-special-defense-depending-on-the-value-of-special-attack)
-- [Moves with a 100% secondary effect chance will not trigger it in 1/256 uses](#moves-with-a-100-secondary-effect-chance-will-not-trigger-it-in-1256-uses)
-- [Belly Drum sharply boosts Attack even with under 50% HP](#belly-drum-sharply-boosts-attack-even-with-under-50-hp)
-- [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-Pokémons-confusion-count)
-- [Confusion damage is affected by type-boosting items and Explosion/Self-Destruct doubling](#confusion-damage-is-affected-by-type-boosting-items-and-explosionself-destruct-doubling)
-- [Saves corrupted by mid-save shutoff are not handled](#saves-corrupted-by-mid-save-shutoff-are-not-handled)
-- [Moves that lower Defense can do so after breaking a Substitute](#moves-that-lower-defense-can-do-so-after-breaking-a-substitute)
-- [Counter and Mirror Coat still work if the opponent uses an item](#counter-and-mirror-coat-still-work-if-the-opponent-uses-an-item)
-- [A Disabled but PP Up–enhanced move may not trigger Struggle](#a-disabled-but-pp-upenhanced-move-may-not-trigger-struggle)
-- [A Pokémon that fainted from Pursuit will have its old status condition when revived](#a-pokémon-that-fainted-from-pursuit-will-have-its-old-status-condition-when-revived)
-- [Lock-On and Mind Reader don't always bypass Fly and Dig](#lock-on-and-mind-reader-dont-always-bypass-fly-and-dig)
-- [Wild Pokémon can always Teleport regardless of level difference](#wild-pokémon-can-always-teleport-regardless-of-level-difference)
-- [Beat Up can desynchronize link battles](#beat-up-can-desynchronize-link-battles)
-- [Beat Up works incorrectly with only one Pokémon in the party](#beat-up-works-incorrectly-with-only-one-pokémon-in-the-party)
-- [Beat Up may fail to raise Substitute](#beat-up-may-fail-to-raise-substitute)
-- [Beat Up may trigger King's Rock even if it failed](#beat-up-may-trigger-kings-rock-even-if-it-failed)
-- [Present damage is incorrect in link battles](#present-damage-is-incorrect-in-link-battles)
-- [A Transformed Pokémon can use Sketch and learn otherwise unobtainable moves](#a-transformed-pokémon-can-use-sketch-and-learn-otherwise-unobtainable-moves)
-- ["Smart" AI encourages Mean Look if its own Pokémon is badly poisoned](#smart-ai-encourages-mean-look-if-its-own-pokémon-is-badly-poisoned)
-- [AI makes a false assumption about `CheckTypeMatchup`](#ai-makes-a-false-assumption-about-checktypematchup)
-- [NPC use of Full Heal or Full Restore does not cure Nightmare status](#npc-use-of-full-heal-or-full-restore-does-not-cure-nightmare-status)
-- [NPC use of Full Heal does not cure confusion status](#npc-use-of-full-heal-does-not-cure-confusion-status)
-- [HP bar animation is slow for high HP](#hp-bar-animation-is-slow-for-high-hp)
-- [HP bar animation off-by-one error for low HP](#hp-bar-animation-off-by-one-error-for-low-hp)
-- [Experience underflow for level 1 Pokémon with Medium-Slow growth rate](#experience-underflow-for-level-1-pokémon-with-medium-slow-growth-rate)
-- [Five-digit experience gain is printed incorrectly](#five-digit-experience-gain-is-printed-incorrectly)
-- [BRN/PSN/PAR do not affect catch rate](#brnpsnpar-do-not-affect-catch-rate)
-- [Moon Ball does not boost catch rate](#moon-ball-does-not-boost-catch-rate)
-- [Love Ball boosts catch rate for the wrong gender](#love-ball-boosts-catch-rate-for-the-wrong-gender)
-- [Fast Ball only boosts catch rate for three Pokémon](#fast-ball-only-boosts-catch-rate-for-three-pokémon)
-- [Dragon Scale, not Dragon Fang, boosts Dragon-type moves](#dragon-scale-not-dragon-fang-boosts-dragon-type-moves)
-- [Clair can give TM24 Dragonbreath twice](#clair-can-give-tm24-dragonbreath-twice)
-- [Daisy's grooming doesn't always increase happiness](#daisys-grooming-doesnt-always-increase-happiness)
-- [Magikarp in Lake of Rage are shorter, not longer](#magikarp-in-lake-of-rage-are-shorter-not-longer)
-- [Magikarp length limits have a unit conversion error](#magikarp-length-limits-have-a-unit-conversion-error)
-- [Magikarp lengths can be miscalculated](#magikarp-lengths-can-be-miscalculated)
-- [Battle transitions fail to account for the enemy's level](#battle-transitions-fail-to-account-for-the-enemys-level)
-- [A "HOF Master!" title for 200-Time Famers is defined but inaccessible](#a-hof-master-title-for-200-time-famers-is-defined-but-inaccessible)
-- [Slot machine payout sound effects cut each other off](#slot-machine-payout-sound-effects-cut-each-other-off)
-- [Team Rocket battle music is not used for Executives or Scientists](#team-rocket-battle-music-is-not-used-for-executives-or-scientists)
-- [Some trainer NPCs have inconsistent overworld sprites](#some-trainer-npcs-have-inconsistent-overworld-sprites)
-- [No bump noise if standing on tile `$3E`](#no-bump-noise-if-standing-on-tile-3e)
-- [Playing Entei's Pokédex cry can distort Raikou's and Suicune's](#playing-enteis-pokédex-cry-can-distort-raikous-and-suicunes)
-- [In-battle “`…`” ellipsis is too high](#in-battle--ellipsis-is-too-high)
-- [Credits sequence changes move selection menu behavior](#credits-sequence-changes-move-selection-menu-behavior)
-- [Two tiles in the `port` tileset are drawn incorrectly](#two-tiles-in-the-port-tileset-are-drawn-incorrectly)
-- [`LoadMetatiles` wraps around past 128 blocks](#loadmetatiles-wraps-around-past-128-blocks)
-- [Surfing directly across a map connection does not load the new map](#surfing-directly-across-a-map-connection-does-not-load-the-new-map)
-- [Swimming NPCs aren't limited by their movement radius](#swimming-npcs-arent-limited-by-their-movement-radius)
-- [`CheckOwnMon` only checks the first five letters of OT names](#checkownmon-only-checks-the-first-five-letters-of-ot-names)
-- [`CheckOwnMonAnywhere` does not check the Day-Care](#checkownmonanywhere-does-not-check-the-day-care)
-- [Catching a Transformed Pokémon always catches a Ditto](#catching-a-transformed-pokémon-always-catches-a-ditto)
-- [If your party and current PC box are full during the Dude's catching tutorial, his Poké Ball can't be used and may crash the game](#if-your-party-and-current-pc-box-are-full-during-the-dudes-catching-tutorial-his-poké-ball-cant-be-used-and-may-crash-the-game)
-- [Using a Park Ball in normal battles has a corrupt animation](#using-a-park-ball-in-normal-battles-has-a-corrupt-animation)
-- [`HELD_CATCH_CHANCE` has no effect](#held_catch_chance-has-no-effect)
-- [Only the first three evolution entries can have Stone compatibility reported correctly](#only-the-first-three-evolution-entries-can-have-stone-compatibility-reported-correctly)
-- [`EVOLVE_STAT` can break Stone compatibility reporting](#evolve_stat-can-break-stone-compatibility-reporting)
-- [`ScriptCall` can overflow `wScriptStack` and crash](#scriptcall-can-overflow-wscriptstack-and-crash)
-- [`LoadSpriteGFX` does not limit the capacity of `UsedSprites`](#loadspritegfx-does-not-limit-the-capacity-of-usedsprites)
-- [`ChooseWildEncounter` doesn't really validate the wild Pokémon species](#choosewildencounter-doesnt-really-validate-the-wild-pokémon-species)
-- [`TryObjectEvent` arbitrary code execution](#tryobjectevent-arbitrary-code-execution)
-- [`ReadObjectEvents` overflows into `wObjectMasks`](#readobjectevents-overflows-into-wobjectmasks)
-- [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
-- [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
+- [Multi-player battle engine](#multi-player-battle-engine)
+  - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
+  - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
+  - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
+  - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
+  - [Moves with a 100% secondary effect chance will not trigger it in 1/256 uses](#moves-with-a-100-secondary-effect-chance-will-not-trigger-it-in-1256-uses)
+  - [Belly Drum sharply boosts Attack even with under 50% HP](#belly-drum-sharply-boosts-attack-even-with-under-50-hp)
+  - [Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count](#berserk-genes-confusion-lasts-for-256-turns-or-the-previous-pokémons-confusion-count)
+  - [Confusion damage is affected by type-boosting items and Explosion/Self-Destruct doubling](#confusion-damage-is-affected-by-type-boosting-items-and-explosionself-destruct-doubling)
+  - [Moves that lower Defense can do so after breaking a Substitute](#moves-that-lower-defense-can-do-so-after-breaking-a-substitute)
+  - [Counter and Mirror Coat still work if the opponent uses an item](#counter-and-mirror-coat-still-work-if-the-opponent-uses-an-item)
+  - [A Disabled but PP Up–enhanced move may not trigger Struggle](#a-disabled-but-pp-upenhanced-move-may-not-trigger-struggle)
+  - [A Pokémon that fainted from Pursuit will have its old status condition when revived](#a-pokémon-that-fainted-from-pursuit-will-have-its-old-status-condition-when-revived)
+  - [Lock-On and Mind Reader don't always bypass Fly and Dig](#lock-on-and-mind-reader-dont-always-bypass-fly-and-dig)
+  - [Beat Up can desynchronize link battles](#beat-up-can-desynchronize-link-battles)
+  - [Beat Up works incorrectly with only one Pokémon in the party](#beat-up-works-incorrectly-with-only-one-pokémon-in-the-party)
+  - [Beat Up may fail to raise Substitute](#beat-up-may-fail-to-raise-substitute)
+  - [Beat Up may trigger King's Rock even if it failed](#beat-up-may-trigger-kings-rock-even-if-it-failed)
+  - [Present damage is incorrect in link battles](#present-damage-is-incorrect-in-link-battles)
+  - [Dragon Scale, not Dragon Fang, boosts Dragon-type moves](#dragon-scale-not-dragon-fang-boosts-dragon-type-moves)
+  - [HP bar animation is slow for high HP](#hp-bar-animation-is-slow-for-high-hp)
+  - [HP bar animation off-by-one error for low HP](#hp-bar-animation-off-by-one-error-for-low-hp)
+- [Single-player battle engine](#single-player-battle-engine)
+  - [A Transformed Pokémon can use Sketch and learn otherwise unobtainable moves](#a-transformed-pokémon-can-use-sketch-and-learn-otherwise-unobtainable-moves)
+  - [Catching a Transformed Pokémon always catches a Ditto](#catching-a-transformed-pokémon-always-catches-a-ditto)
+  - [Experience underflow for level 1 Pokémon with Medium-Slow growth rate](#experience-underflow-for-level-1-pokémon-with-medium-slow-growth-rate)
+  - [The Dude's catching tutorial may crash if his Poké Ball can't be used](#the-dudes-catching-tutorial-may-crash-if-his-poké-ball-cant-be-used)
+  - [BRN/PSN/PAR do not affect catch rate](#brnpsnpar-do-not-affect-catch-rate)
+  - [Moon Ball does not boost catch rate](#moon-ball-does-not-boost-catch-rate)
+  - [Love Ball boosts catch rate for the wrong gender](#love-ball-boosts-catch-rate-for-the-wrong-gender)
+  - [Fast Ball only boosts catch rate for three Pokémon](#fast-ball-only-boosts-catch-rate-for-three-pokémon)
+  - [Glacier Badge may not boost Special Defense depending on the value of Special Attack](#glacier-badge-may-not-boost-special-defense-depending-on-the-value-of-special-attack)
+  - ["Smart" AI encourages Mean Look if its own Pokémon is badly poisoned](#smart-ai-encourages-mean-look-if-its-own-pokémon-is-badly-poisoned)
+  - [AI makes a false assumption about `CheckTypeMatchup`](#ai-makes-a-false-assumption-about-checktypematchup)
+  - [AI use of Full Heal or Full Restore does not cure Nightmare status](#ai-use-of-full-heal-or-full-restore-does-not-cure-nightmare-status)
+  - [AI use of Full Heal does not cure confusion status](#ai-use-of-full-heal-does-not-cure-confusion-status)
+  - [Wild Pokémon can always Teleport regardless of level difference](#wild-pokémon-can-always-teleport-regardless-of-level-difference)
+  - [`HELD_CATCH_CHANCE` has no effect](#held_catch_chance-has-no-effect)
+  - [Credits sequence changes move selection menu behavior](#credits-sequence-changes-move-selection-menu-behavior)
+- [Overworld engine](#overworld-engine)
+  - [`LoadMetatiles` wraps around past 128 blocks](#loadmetatiles-wraps-around-past-128-blocks)
+  - [Surfing directly across a map connection does not load the new map](#surfing-directly-across-a-map-connection-does-not-load-the-new-map)
+  - [Swimming NPCs aren't limited by their movement radius](#swimming-npcs-arent-limited-by-their-movement-radius)
+- [Graphics](#graphics)
+  - [In-battle “`…`” ellipsis is too high](#in-battle--ellipsis-is-too-high)
+  - [Two tiles in the `port` tileset are drawn incorrectly](#two-tiles-in-the-port-tileset-are-drawn-incorrectly)
+  - [Using a Park Ball in non-Contest battles has a corrupt animation](#using-a-park-ball-in-non-contest-battles-has-a-corrupt-animation)
+  - [Battle transitions fail to account for the enemy's level](#battle-transitions-fail-to-account-for-the-enemys-level)
+  - [Some trainer NPCs have inconsistent overworld sprites](#some-trainer-npcs-have-inconsistent-overworld-sprites)
+- [Audio](#audio)
+  - [Slot machine payout sound effects cut each other off](#slot-machine-payout-sound-effects-cut-each-other-off)
+  - [Team Rocket battle music is not used for Executives or Scientists](#team-rocket-battle-music-is-not-used-for-executives-or-scientists)
+  - [No bump noise if standing on tile `$3E`](#no-bump-noise-if-standing-on-tile-3e)
+  - [Playing Entei's Pokédex cry can distort Raikou's and Suicune's](#playing-enteis-pokédex-cry-can-distort-raikous-and-suicunes)
+- [Text](#text)
+  - [Five-digit experience gain is printed incorrectly](#five-digit-experience-gain-is-printed-incorrectly)
+  - [Only the first three evolution entries can have Stone compatibility reported correctly](#only-the-first-three-evolution-entries-can-have-stone-compatibility-reported-correctly)
+  - [`EVOLVE_STAT` can break Stone compatibility reporting](#evolve_stat-can-break-stone-compatibility-reporting)
+  - [A "HOF Master!" title for 200-Time Famers is defined but inaccessible](#a-hof-master-title-for-200-time-famers-is-defined-but-inaccessible)
+- [Scripted events](#scripted-events)
+  - [Clair can give TM24 Dragonbreath twice](#clair-can-give-tm24-dragonbreath-twice)
+  - [Daisy's grooming doesn't always increase happiness](#daisys-grooming-doesnt-always-increase-happiness)
+  - [Magikarp in Lake of Rage are shorter, not longer](#magikarp-in-lake-of-rage-are-shorter-not-longer)
+  - [Magikarp length limits have a unit conversion error](#magikarp-length-limits-have-a-unit-conversion-error)
+  - [Magikarp lengths can be miscalculated](#magikarp-lengths-can-be-miscalculated)
+  - [`CheckOwnMon` only checks the first five letters of OT names](#checkownmon-only-checks-the-first-five-letters-of-ot-names)
+  - [`CheckOwnMonAnywhere` does not check the Day-Care](#checkownmonanywhere-does-not-check-the-day-care)
+- [Internal engine routines](#internal-engine-routines)
+  - [Saves corrupted by mid-save shutoff are not handled](#saves-corrupted-by-mid-save-shutoff-are-not-handled)
+  - [`ScriptCall` can overflow `wScriptStack` and crash](#scriptcall-can-overflow-wscriptstack-and-crash)
+  - [`LoadSpriteGFX` does not limit the capacity of `UsedSprites`](#loadspritegfx-does-not-limit-the-capacity-of-usedsprites)
+  - [`ChooseWildEncounter` doesn't really validate the wild Pokémon species](#choosewildencounter-doesnt-really-validate-the-wild-pokémon-species)
+  - [`TryObjectEvent` arbitrary code execution](#tryobjectevent-arbitrary-code-execution)
+  - [`ReadObjectEvents` overflows into `wObjectMasks`](#readobjectevents-overflows-into-wobjectmasks)
+  - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
+  - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6⅔-objects)
 
 
-## Perish Song and Spikes can leave a Pokémon with 0 HP and not faint
+## Multi-player battle engine
 
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+
+### Perish Song and Spikes can leave a Pokémon with 0 HP and not faint
 
 ([Video](https://www.youtube.com/watch?v=1IiPWw5fMf8&t=85))
 
@@ -133,9 +142,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ```
 
 
-## Thick Club and Light Ball can make (Special) Attack wrap around above 1024
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Thick Club and Light Ball can make (Special) Attack wrap around above 1024
 
 ([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=450))
 
@@ -160,9 +167,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ```
 
 
-## Metal Powder can increase damage taken with boosted (Special) Defense
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Metal Powder can increase damage taken with boosted (Special) Defense
 
 ([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=450))
 
@@ -198,9 +203,7 @@ Some fixes are mentioned as breaking compatibility with link battles. This can b
 ```
 
 
-## Reflect and Light Screen can make (Special) Defense wrap around above 1024
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Reflect and Light Screen can make (Special) Defense wrap around above 1024
 
 This bug existed for all battles in Gold and Silver, and was only fixed for single-player battles in Crystal to preserve link compatibility.
 
@@ -226,37 +229,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 (This fix also affects Thick Club, Light Ball, and Metal Powder, as described above, but their specific fixes in the above bugs allow more accurate damage calculations.)
 
 
-## Glacier Badge may not boost Special Defense depending on the value of Special Attack
-
-As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") implies, Glacier Badge is intended to boost both Special Attack and Special Defense. However, due to BoostStat overwriting `a` when boosting Special Attack, the Special Defense boost will not happen if the unboosted Special Attack stat is either 0-205 or 433-660.
-
-**Fix:** Edit `BadgeStatBoosts.CheckBadge` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
-
-```diff
- .CheckBadge:
- 	ld a, b
- 	srl b
-+	push af
- 	call c, BoostStat
-+	pop af
- 	inc hl
- 	inc hl
- ; Check every other badge.
- 	srl b
- 	dec c
- 	jr nz, .CheckBadge
- ; Check GlacierBadge again for Special Defense.
--; This check is buggy because it assumes that a is set by the "ld a, b" in the above loop,
--; but it can actually be overwritten by the call to BoostStat.
- 	srl a
- 	call c, BoostStat
- 	ret
-```
-
-
-## Moves with a 100% secondary effect chance will not trigger it in 1/256 uses
-
-*Fixing this bug **may** break compatibility with standard Pokémon Crystal for link battles.*
+### Moves with a 100% secondary effect chance will not trigger it in 1/256 uses
 
 ([Video](https://www.youtube.com/watch?v=mHkyO5T5wZU&t=206))
 
@@ -265,7 +238,7 @@ As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") impli
 ```diff
 -	; BUG: 1/256 chance to fail even for a 100% effect chance,
 -	; since carry is not set if BattleRandom == [hl] == 255
-- 	call BattleRandom
+-	call BattleRandom
 +	ld a, [hl]
 +	sub 100 percent
 +	; If chance was 100%, RNG won't be called (carry not set)
@@ -297,9 +270,7 @@ As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") impli
  	call c, BattleRandom
 ```
 
-## Belly Drum sharply boosts Attack even with under 50% HP
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Belly Drum sharply boosts Attack even with under 50% HP
 
 ([Video](https://www.youtube.com/watch?v=zuCLMikWo4Y))
 
@@ -329,9 +300,7 @@ As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") impli
 ```
 
 
-## Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count
 
 ([Video](https://youtube.com/watch?v=Pru3mohq20A))
 
@@ -359,12 +328,10 @@ As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") impli
  	...
 ```
 
-This makes the Berserk Gene use the regular confusion duration (2-5 turns).
+This makes the Berserk Gene use the regular confusion duration (2–5 turns).
 
 
-## Confusion damage is affected by type-boosting items and Explosion/Self-Destruct doubling
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Confusion damage is affected by type-boosting items and Explosion/Self-Destruct doubling
 
 ([Video](https://twitter.com/crystal_rby/status/874626362287562752))
 
@@ -456,112 +423,7 @@ Then edit four routines in [engine/battle/effect_commands.asm](https://github.co
 ```
 
 
-## Saves corrupted by mid-save shutoff are not handled
-
-([Video 1](https://www.youtube.com/watch?v=ukqtK0l6bu0), [Video 2](https://www.youtube.com/watch?v=c2zHd1BPtvc))
-
-**Fix:** Edit `MoveMonWOMail_InsertMon_SaveGame` and `_SaveGameData` in [engine/menus/save.asm](https://github.com/pret/pokecrystal/blob/master/engine/menus/save.asm):
-
-```diff
- MoveMonWOMail_InsertMon_SaveGame:
- 	...
- 	ld a, TRUE
- 	ld [wSaveFileExists], a
- 	farcall StageRTCTimeForSave
- 	farcall BackupMysteryGift
--	call ValidateSave
-+	call InvalidateSave
- 	call SaveOptions
- 	call SavePlayerData
- 	call SavePokemonData
- 	call SaveChecksum
--	call ValidateBackupSave
-+	call ValidateSave
-+	call InvalidateBackupSave
- 	call SaveBackupOptions
- 	call SaveBackupPlayerData
- 	call SaveBackupPokemonData
- 	call SaveBackupChecksum
-+	call ValidateBackupSave
- 	farcall BackupPartyMonMail
- 	farcall BackupMobileEventIndex
- 	farcall SaveRTC
- 	...
-```
-
-```diff
- _SaveGameData:
- 	...
- 	ld a, TRUE
- 	ld [wSaveFileExists], a
- 	farcall StageRTCTimeForSave
- 	farcall BackupMysteryGift
--	call ValidateSave
-+	call InvalidateSave
- 	call SaveOptions
- 	call SavePlayerData
- 	call SavePokemonData
- 	call SaveBox
- 	call SaveChecksum
--	call ValidateBackupSave
-+	call ValidateSave
-+	call InvalidateBackupSave
- 	call SaveBackupOptions
- 	call SaveBackupPlayerData
- 	call SaveBackupPokemonData
- 	call SaveBackupChecksum
-+	call ValidateBackupSave
- 	call UpdateStackTop
- 	farcall BackupPartyMonMail
- 	farcall BackupMobileEventIndex
- 	farcall SaveRTC
- 	...
-```
-
-Then create two new routines, `InvalidateSave` and `InvalidateBackupSave`:
-
-```diff
- ValidateSave:
- 	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
- 	call OpenSRAM
- 	ld a, SAVE_CHECK_VALUE_1
- 	ld [sCheckValue1], a
- 	ld a, SAVE_CHECK_VALUE_2
- 	ld [sCheckValue2], a
- 	jp CloseSRAM
-
-+InvalidateSave:
-+	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
-+	call OpenSRAM
-+	xor a
-+	ld [sCheckValue1], a
-+	ld [sCheckValue2], a
-+	jp CloseSRAM
-```
-
-```diff
- ValidateBackupSave:
- 	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
- 	call OpenSRAM
- 	ld a, SAVE_CHECK_VALUE_1
- 	ld [sBackupCheckValue1], a
- 	ld a, SAVE_CHECK_VALUE_2
- 	ld [sBackupCheckValue2], a
- 	jp CloseSRAM
-
-+InvalidateBackupSave:
-+	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
-+	call OpenSRAM
-+	xor a
-+	ld [sBackupCheckValue1], a
-+	ld [sBackupCheckValue2], a
-+	jp CloseSRAM
-```
-
-
-## Moves that lower Defense can do so after breaking a Substitute
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Moves that lower Defense can do so after breaking a Substitute
 
 ([Video](https://www.youtube.com/watch?v=OGwKPRJLaaI))
 
@@ -595,9 +457,7 @@ This bug affects Acid, Iron Tail, and Rock Smash.
 ```
 
 
-## Counter and Mirror Coat still work if the opponent uses an item
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Counter and Mirror Coat still work if the opponent uses an item
 
 ([Video](https://www.youtube.com/watch?v=uRYyzKRatFk))
 
@@ -623,9 +483,7 @@ Add this to the end of each file:
 ```
 
 
-## A Disabled but PP Up–enhanced move may not trigger Struggle
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### A Disabled but PP Up–enhanced move may not trigger Struggle
 
 ([Video](https://www.youtube.com/watch?v=1v9x4SgMggs))
 
@@ -648,9 +506,7 @@ Add this to the end of each file:
 ```
 
 
-## A Pokémon that fainted from Pursuit will have its old status condition when revived
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### A Pokémon that fainted from Pursuit will have its old status condition when revived
 
 ([Video](https://www.youtube.com/watch?v=tiRvw-Nb2ME))
 
@@ -678,9 +534,7 @@ Add this to the end of each file:
 ```
 
 
-## Lock-On and Mind Reader don't always bypass Fly and Dig
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Lock-On and Mind Reader don't always bypass Fly and Dig
 
 This bug affects Attract, Curse, Foresight, Mean Look, Mimic, Nightmare, Spider Web, Transform, and stat-lowering effects of moves like String Shot or Bubble during the semi-invulnerable turn of Fly or Dig.
 
@@ -697,28 +551,7 @@ This bug affects Attract, Curse, Foresight, Mean Look, Mimic, Nightmare, Spider 
 ```
 
 
-## Wild Pokémon can always Teleport regardless of level difference
-
-**Fix:** Edit `BattleCommand_Teleport` in [engine/battle/move_effects/teleport.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/move_effects/teleport.asm):
-
-```diff
- .loop_enemy
- 	call BattleRandom
- 	cp c
- 	jr nc, .loop_enemy
- 	srl b
- 	srl b
- 	cp b
--	; This should be jr c, .failed
--	; As written, it makes enemy use of Teleport always succeed if able
--	jr nc, .run_away
-+	jr c, .failed
-```
-
-
-## Beat Up can desynchronize link battles
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Beat Up can desynchronize link battles
 
 ([Video](https://www.youtube.com/watch?v=202-iAsrIa8))
 
@@ -752,9 +585,7 @@ This bug affects Attract, Curse, Foresight, Mean Look, Mimic, Nightmare, Spider 
 ```
 
 
-## Beat Up works incorrectly with only one Pokémon in the party
-
-*Fixing this bug may break compatibility with standard Pokémon Crystal for link battles.*
+### Beat Up works incorrectly with only one Pokémon in the party
 
 This bug prevents the rest of Beat Up's effect from being executed if the player or enemy only has one Pokémon in their party while using it. It prevents Substitute from being raised and King's Rock from working.
 
@@ -783,7 +614,9 @@ This bug prevents the rest of Beat Up's effect from being executed if the player
 ```
 
 
-## Beat Up may fail to raise Substitute
+### Beat Up may fail to raise Substitute
+
+*Fixing this cosmetic bug will* not *break link battle compatibility.*
 
 This bug prevents Substitute from being raised if Beat Up was blocked by Protect or Detect.
 
@@ -806,9 +639,7 @@ This bug prevents Substitute from being raised if Beat Up was blocked by Protect
 ```
 
 
-## Beat Up may trigger King's Rock even if it failed
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Beat Up may trigger King's Rock even if it failed
 
 This bug is caused because Beat Up never sets `wAttackMissed`, even when no Pokémon was able to attack (due to being fainted or having a status condition).
 
@@ -829,9 +660,7 @@ This bug is caused because Beat Up never sets `wAttackMissed`, even when no Pok�
 ```
 
 
-## Present damage is incorrect in link battles
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
+### Present damage is incorrect in link battles
 
 ([Video](https://www.youtube.com/watch?v=XJaQoKtrEuw))
 
@@ -861,7 +690,82 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## A Transformed Pokémon can use Sketch and learn otherwise unobtainable moves
+### Dragon Scale, not Dragon Fang, boosts Dragon-type moves
+
+**Fix:** Edit `ItemAttributes` in [data/items/attributes.asm](https://github.com/pret/pokecrystal/blob/master/data/items/attributes.asm):
+
+```diff
+ ; DRAGON_FANG
+-	item_attribute 100, HELD_NONE, 0, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
++	item_attribute 100, HELD_DRAGON_BOOST, 10, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
+ ...
+ ; DRAGON_SCALE
+-	item_attribute 2100, HELD_DRAGON_BOOST, 10, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
++	item_attribute 2100, HELD_NONE, 0, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
+```
+
+
+### HP bar animation is slow for high HP
+
+*Fixing this cosmetic bug will* not *break link battle compatibility.*
+
+([Video](https://www.youtube.com/watch?v=SE-BfsFgZVM))
+
+**Fix:** Edit `LongAnim_UpdateVariables` in [engine/battle/anim_hp_bar.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/anim_hp_bar.asm):
+
+```diff
+-	; This routine is buggy. The result from ComputeHPBarPixels is stored
+-	; in e. However, the pop de opcode deletes this result before it is even
+-	; used. The game then proceeds as though it never deleted that output.
+-	; To fix, uncomment the line below.
+ 	call ComputeHPBarPixels
+-	; ld a, e
++	ld a, e
+ 	pop bc
+ 	pop de
+ 	pop hl
+-	ld a, e ; Comment or delete this line to fix the above bug.
+ 	ld hl, wCurHPBarPixels
+ 	cp [hl]
+ 	jr z, .loop
+ 	ld [hl], a
+ 	and a
+ 	ret
+```
+
+
+### HP bar animation off-by-one error for low HP
+
+*Fixing this cosmetic bug will* not *break link battle compatibility.*
+
+([Video](https://www.youtube.com/watch?v=9KyNVIZxJvI))
+
+**Fix:** Edit `ShortHPBar_CalcPixelFrame` in [engine/battle/anim_hp_bar.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/anim_hp_bar.asm):
+
+```diff
+ 	ld b, 0
+-; This routine is buggy. If [wCurHPAnimMaxHP] * [wCurHPBarPixels] is
+-; divisible by HP_BAR_LENGTH_PX, the loop runs one extra time.
+-; To fix, uncomment the line below.
+ .loop
+ 	ld a, l
+ 	sub HP_BAR_LENGTH_PX
+ 	ld l, a
+ 	ld a, h
+ 	sbc $0
+ 	ld h, a
+-	; jr z, .done
++	jr z, .done
+ 	jr c, .done
+ 	inc b
+ 	jr .loop
+```
+
+
+## Single-player battle engine
+
+
+### A Transformed Pokémon can use Sketch and learn otherwise unobtainable moves
 
 ([Video](https://www.youtube.com/watch?v=AFiBxAOkCGI))
 
@@ -878,7 +782,228 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## "Smart" AI encourages Mean Look if its own Pokémon is badly poisoned
+### Catching a Transformed Pokémon always catches a Ditto
+
+This bug can affect Mew or Pokémon other than Ditto that used Transform via Mirror Move or Sketch.
+
+**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+ 	ld hl, wEnemySubStatus5
+ 	ld a, [hl]
+ 	push af
+ 	set SUBSTATUS_TRANSFORMED, [hl]
+
+-; This code is buggy. Any wild Pokémon that has Transformed will be
+-; caught as a Ditto, even if it was something else like Mew.
+-; To fix, do not set [wTempEnemyMonSpecies] to DITTO.
+ 	bit SUBSTATUS_TRANSFORMED, a
+-	jr nz, .ditto
+-	jr .not_ditto
++	jr nz, .load_data
+
+-.ditto
+-	ld a, DITTO
+-	ld [wTempEnemyMonSpecies], a
+-	jr .load_data
+-
+-.not_ditto
+-	set SUBSTATUS_TRANSFORMED, [hl]
+ 	ld hl, wEnemyBackupDVs
+ 	ld a, [wEnemyMonDVs]
+ 	ld [hli], a
+ 	ld a, [wEnemyMonDVs + 1]
+ 	ld [hl], a
+
+ .load_data
+ 	ld a, [wTempEnemyMonSpecies]
+ 	ld [wCurPartySpecies], a
+ 	ld a, [wEnemyMonLevel]
+ 	ld [wCurPartyLevel], a
+ 	farcall LoadEnemyMon
+
+ 	pop af
+ 	ld [wEnemySubStatus5], a
+```
+
+
+### Experience underflow for level 1 Pokémon with Medium-Slow growth rate
+
+([Video](https://www.youtube.com/watch?v=SXH8u0plHrE))
+
+This can bring Pokémon straight from level 1 to 100 by gaining just a few experience points.
+
+**Fix:** Edit `CalcExpAtLevel` in [engine/pokemon/experience.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/experience.asm):
+
+```diff
+ CalcExpAtLevel:
+ ; (a/b)*n**3 + c*n**2 + d*n - e
++	ld a, d
++	cp 1
++	jr nz, .UseExpFormula
++; Pokémon have 0 experience at level 1
++	xor a
++	ld hl, hProduct
++	ld [hli], a
++	ld [hli], a
++	ld [hli], a
++	ld [hl], a
++	ret
++
++.UseExpFormula
+ 	ld a, [wBaseGrowthRate]
+ 	add a
+ 	add a
+ 	ld c, a
+ 	ld b, 0
+ 	ld hl, GrowthRates
+ 	add hl, bc
+```
+
+
+### The Dude's catching tutorial may crash if his Poké Ball can't be used
+
+([Video](https://www.youtube.com/watch?v=A8zaTOkjKS4&t=407))
+
+This can occur if your party and current PC box are both full when you start the tutorial.
+
+**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+ 	ld a, [wBattleMode]
+ 	dec a
+ 	jp nz, UseBallInTrainerBattle
+
++	ld a, [wBattleType]
++	cp BATTLETYPE_TUTORIAL
++	jr z, .room_in_party
++
+ 	ld a, [wPartyCount]
+ 	cp PARTY_LENGTH
+ 	jr nz, .room_in_party
+
+ 	ld a, BANK(sBoxCount)
+ 	call OpenSRAM
+ 	ld a, [sBoxCount]
+ 	cp MONS_PER_BOX
+ 	call CloseSRAM
+ 	jp z, Ball_BoxIsFullMessage
+```
+
+
+### BRN/PSN/PAR do not affect catch rate
+
+**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+-; This routine is buggy. It was intended that SLP and FRZ provide a higher
+-; catch rate than BRN/PSN/PAR, which in turn provide a higher catch rate than
+-; no status effect at all. But instead, it makes BRN/PSN/PAR provide no
+-; benefit.
+-; Uncomment the line below to fix this.
+ 	ld b, a
+ 	ld a, [wEnemyMonStatus]
+ 	and 1 << FRZ | SLP
+ 	ld c, 10
+ 	jr nz, .addstatus
+-	; ld a, [wEnemyMonStatus]
++	ld a, [wEnemyMonStatus]
+ 	and a
+ 	ld c, 5
+ 	jr nz, .addstatus
+ 	ld c, 0
+ .addstatus
+ 	ld a, b
+ 	add c
+ 	jr nc, .max_1
+ 	ld a, $ff
+ .max_1
+```
+
+
+### Moon Ball does not boost catch rate
+
+**Fix:** Edit `MoonBallMultiplier` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+-; Moon Stone's constant from Pokémon Red is used.
+-; No Pokémon evolve with Burn Heal,
+-; so Moon Balls always have a catch rate of 1×.
+ 	push bc
+ 	ld a, BANK("Evolutions and Attacks")
+ 	call GetFarByte
+-	cp MOON_STONE_RED ; BURN_HEAL
++	cp MOON_STONE
+ 	pop bc
+ 	ret nz
+```
+
+
+### Love Ball boosts catch rate for the wrong gender
+
+**Fix:** Edit `LoveBallMultiplier` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+ .wildmale
+
+ 	ld a, d
+ 	pop de
+ 	cp d
+ 	pop bc
+-	ret nz ; for the intended effect, this should be "ret z"
++	ret z
+```
+
+
+### Fast Ball only boosts catch rate for three Pokémon
+
+**Fix:** Edit `FastBallMultiplier` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+ .loop
+ 	ld a, BANK(FleeMons)
+ 	call GetFarByte
+
+ 	inc hl
+ 	cp -1
+ 	jr z, .next
+ 	cp c
+-	jr nz, .next ; for the intended effect, this should be "jr nz, .loop"
++	jr nz, .loop
+ 	sla b
+ 	jr c, .max
+```
+
+
+### Glacier Badge may not boost Special Defense depending on the value of Special Attack
+
+As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") implies, Glacier Badge is intended to boost both Special Attack and Special Defense. However, due to BoostStat overwriting `a` when boosting Special Attack, the Special Defense boost will not happen if the unboosted Special Attack stat is either 0–205 or 433–660.
+
+**Fix:** Edit `BadgeStatBoosts.CheckBadge` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
+
+```diff
+ .CheckBadge:
+ 	ld a, b
+ 	srl b
++	push af
+ 	call c, BoostStat
++	pop af
+ 	inc hl
+ 	inc hl
+ ; Check every other badge.
+ 	srl b
+ 	dec c
+ 	jr nz, .CheckBadge
+ ; Check GlacierBadge again for Special Defense.
+-; This check is buggy because it assumes that a is set by the "ld a, b" in the above loop,
+-; but it can actually be overwritten by the call to BoostStat.
+ 	srl a
+ 	call c, BoostStat
+ 	ret
+```
+
+
+### "Smart" AI encourages Mean Look if its own Pokémon is badly poisoned
 
 ([Video](https://www.youtube.com/watch?v=cygMO-zHTls))
 
@@ -895,7 +1020,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## AI makes a false assumption about `CheckTypeMatchup`
+### AI makes a false assumption about `CheckTypeMatchup`
 
 **Fix:** Edit `BattleCheckTypeMatchup` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm):
 
@@ -927,7 +1052,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## NPC use of Full Heal or Full Restore does not cure Nightmare status
+### AI use of Full Heal or Full Restore does not cure Nightmare status
 
 ([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=322))
 
@@ -958,7 +1083,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## NPC use of Full Heal does not cure confusion status
+### AI use of Full Heal does not cure confusion status
 
 **Fix:** Edit `EnemyUsedFullRestore`, `EnemyUsedFullHeal`, and `AI_HealStatus` in [engine/battle/ai/items.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/ai/items.asm):
 
@@ -1009,375 +1134,260 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 ```
 
 
-## HP bar animation is slow for high HP
+### Wild Pokémon can always Teleport regardless of level difference
 
-([Video](https://www.youtube.com/watch?v=SE-BfsFgZVM))
-
-**Fix:** Edit `LongAnim_UpdateVariables` in [engine/battle/anim_hp_bar.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/anim_hp_bar.asm):
+**Fix:** Edit `BattleCommand_Teleport` in [engine/battle/move_effects/teleport.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/move_effects/teleport.asm):
 
 ```diff
--	; This routine is buggy. The result from ComputeHPBarPixels is stored
--	; in e. However, the pop de opcode deletes this result before it is even
--	; used. The game then proceeds as though it never deleted that output.
--	; To fix, uncomment the line below.
- 	call ComputeHPBarPixels
--	; ld a, e
-+	ld a, e
- 	pop bc
- 	pop de
- 	pop hl
--	ld a, e ; Comment or delete this line to fix the above bug.
- 	ld hl, wCurHPBarPixels
- 	cp [hl]
- 	jr z, .loop
- 	ld [hl], a
- 	and a
- 	ret
+ .loop_enemy
+ 	call BattleRandom
+ 	cp c
+ 	jr nc, .loop_enemy
+ 	srl b
+ 	srl b
+ 	cp b
+-	; This should be jr c, .failed
+-	; As written, it makes enemy use of Teleport always succeed if able
+-	jr nc, .run_away
++	jr c, .failed
 ```
 
 
-## HP bar animation off-by-one error for low HP
-
-([Video](https://www.youtube.com/watch?v=9KyNVIZxJvI))
-
-**Fix:** Edit `ShortHPBar_CalcPixelFrame` in [engine/battle/anim_hp_bar.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/anim_hp_bar.asm):
-
-```diff
- 	ld b, 0
--; This routine is buggy. If [wCurHPAnimMaxHP] * [wCurHPBarPixels] is
--; divisible by HP_BAR_LENGTH_PX, the loop runs one extra time.
--; To fix, uncomment the line below.
- .loop
- 	ld a, l
- 	sub HP_BAR_LENGTH_PX
- 	ld l, a
- 	ld a, h
- 	sbc $0
- 	ld h, a
--	; jr z, .done
-+	jr z, .done
- 	jr c, .done
- 	inc b
- 	jr .loop
-```
-
-
-## Experience underflow for level 1 Pokémon with Medium-Slow growth rate
-
-([Video](https://www.youtube.com/watch?v=SXH8u0plHrE))
-
-This can bring Pokémon straight from level 1 to 100 by gaining just a few experience points.
-
-**Fix:** Edit `CalcExpAtLevel` in [engine/pokemon/experience.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/experience.asm):
-
-```diff
- CalcExpAtLevel:
- ; (a/b)*n**3 + c*n**2 + d*n - e
-+	ld a, d
-+	cp 1
-+	jr nz, .UseExpFormula
-+; Pokémon have 0 experience at level 1
-+	xor a
-+	ld hl, hProduct
-+	ld [hli], a
-+	ld [hli], a
-+	ld [hli], a
-+	ld [hl], a
-+	ret
-+
-+.UseExpFormula
- 	ld a, [wBaseGrowthRate]
- 	add a
- 	add a
- 	ld c, a
- 	ld b, 0
- 	ld hl, GrowthRates
- 	add hl, bc
-```
-
-
-## Five-digit experience gain is printed incorrectly
-
-([Video](https://www.youtube.com/watch?v=o54VjpAEoO8))
-
-**Fix:** Edit `_BoostedExpPointsText` and `_ExpPointsText` in [data/text/common_2.asm](https://github.com/pret/pokecrystal/blob/master/data/text/common_2.asm):
-
-```diff
- _BoostedExpPointsText::
- 	text_start
- 	line "a boosted"
- 	cont "@"
--	text_decimal wStringBuffer2, 2, 4
-+	text_decimal wStringBuffer2, 2, 5
- 	text " EXP. Points!"
- 	prompt
-
- _ExpPointsText::
- 	text_start
- 	line "@"
--	text_decimal wStringBuffer2, 2, 4
-+	text_decimal wStringBuffer2, 2, 5
- 	text " EXP. Points!"
- 	prompt
-```
-
-
-## BRN/PSN/PAR do not affect catch rate
+### `HELD_CATCH_CHANCE` has no effect
 
 **Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
 
 ```diff
--; This routine is buggy. It was intended that SLP and FRZ provide a higher
--; catch rate than BRN/PSN/PAR, which in turn provide a higher catch rate than
--; no status effect at all. But instead, it makes BRN/PSN/PAR provide no
--; benefit.
--; Uncomment the line below to fix this.
- 	ld b, a
- 	ld a, [wEnemyMonStatus]
- 	and 1 << FRZ | SLP
- 	ld c, 10
- 	jr nz, .addstatus
--	; ld a, [wEnemyMonStatus]
-+	ld a, [wEnemyMonStatus]
- 	and a
- 	ld c, 5
- 	jr nz, .addstatus
- 	ld c, 0
- .addstatus
+-	; BUG: farcall overwrites a, and GetItemHeldEffect takes b anyway.
+-	; This is probably the reason the HELD_CATCH_CHANCE effect is never used.
+-	; Uncomment the line below to fix.
+ 	ld d, a
+ 	push de
+ 	ld a, [wBattleMonItem]
+-	; ld b, a
++	ld b, a
+ 	farcall GetItemHeldEffect
  	ld a, b
- 	add c
- 	jr nc, .max_1
- 	ld a, $ff
- .max_1
-```
-
-
-## Moon Ball does not boost catch rate
-
-**Fix:** Edit `MoonBallMultiplier` in [items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
-
-```diff
--; Moon Stone's constant from Pokémon Red is used.
--; No Pokémon evolve with Burn Heal,
--; so Moon Balls always have a catch rate of 1×.
- 	push bc
- 	ld a, BANK("Evolutions and Attacks")
- 	call GetFarByte
--	cp MOON_STONE_RED ; BURN_HEAL
-+	cp MOON_STONE
- 	pop bc
- 	ret nz
-```
-
-
-## Love Ball boosts catch rate for the wrong gender
-
-**Fix:** Edit `LoveBallMultiplier` in [items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
-
-```diff
- .wildmale
-
- 	ld a, d
+ 	cp HELD_CATCH_CHANCE
  	pop de
- 	cp d
- 	pop bc
--	ret nz ; for the intended effect, this should be "ret z"
-+	ret z
+ 	ld a, d
+ 	jr nz, .max_2
+ 	add c
+ 	jr nc, .max_2
+ 	ld a, $ff
+ .max_2
 ```
 
 
-## Fast Ball only boosts catch rate for three Pokémon
+### Credits sequence changes move selection menu behavior
 
-**Fix:** Edit `FastBallMultiplier` in [items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+([Video](https://www.youtube.com/watch?v=vjFUo6Jr4po&t=438))
+
+To select a move in battle, you have to press and release the Up or Down buttons. However, after playing the credits sequence, holding down either button will continuously scroll through the moves.
+
+**Fix:** Edit `Credits` in [engine/movie/credits.asm](https://github.com/pret/pokecrystal/blob/master/engine/movie/credits.asm):
 
 ```diff
- .loop
- 	ld a, BANK(FleeMons)
- 	call GetFarByte
+ 	ldh a, [hVBlank]
+ 	push af
+ 	ld a, $5
+ 	ldh [hVBlank], a
++	ldh a, [hInMenu]
++	push af
+ 	ld a, $1
+ 	ldh [hInMenu], a
 
- 	inc hl
- 	cp -1
- 	jr z, .next
- 	cp c
--	jr nz, .next ; for the intended effect, this should be "jr nz, .loop"
-+	jr nz, .loop
- 	sla b
- 	jr c, .max
+ 	...
+
+ 	ldh [hLCDCPointer], a
+ 	ldh [hBGMapAddress], a
++	pop af
++	ldh [hInMenu], a
+ 	pop af
+ 	ldh [hVBlank], a
+ 	pop af
+ 	ldh [rSVBK], a
 ```
 
+The `[hInMenu]` value determines this button behavior. However, the battle moves menu doesn't actually set `[hInMenu]` to anything, so either behavior *may* have been intentional. The default 0 prevents continuous scrolling; a value of 1 allows it. (The Japanese release sets it to 0.)
 
-## Dragon Scale, not Dragon Fang, boosts Dragon-type moves
-
-*Fixing this bug will break compatibility with standard Pokémon Crystal for link battles.*
-
-**Fix:** Edit `ItemAttributes` in [data/items/attributes.asm](https://github.com/pret/pokecrystal/blob/master/data/items/attributes.asm):
+**Optional fix:** To explicitly set a `[hInMenu]` for the moves menu, edit `BattleTurn` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
 
 ```diff
- ; DRAGON_FANG
--	item_attribute 100, HELD_NONE, 0, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
-+	item_attribute 100, HELD_DRAGON_BOOST, 10, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
- ...
- ; DRAGON_SCALE
--	item_attribute 2100, HELD_DRAGON_BOOST, 10, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
-+	item_attribute 2100, HELD_NONE, 0, CANT_SELECT, ITEM, ITEMMENU_NOUSE, ITEMMENU_NOUSE
-```
-
-
-## Clair can give TM24 Dragonbreath twice
-
-([Video](https://www.youtube.com/watch?v=8BvBjqxmyOk))
-
-**Fix:** Edit `DragonsDen1F_MapScripts` in [maps/DragonsDen1F.asm](https://github.com/pret/pokecrystal/blob/master/maps/DragonsDen1F.asm):
-
-```diff
--	db 0 ; callbacks
-+	db 1 ; callbacks
-+	callback MAPCALLBACK_NEWMAP, .UnsetClairScene
+ BattleTurn:
++	ldh a, [hInMenu]
++	push af
++	ld a, 1 ; or "xor a" for the value 0
++	ldh [hInMenu], a
 +
-+.UnsetClairScene:
-+	setmapscene DRAGONS_DEN_B1F, SCENE_DRAGONSDENB1F_NOTHING
-+	return
-```
+ .loop
 
+ 	...
 
-## Daisy's grooming doesn't always increase happiness
+ 	jp .loop
 
-This is a bug with `HaircutOrGrooming` in [engine/events/haircut.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/haircut.asm):
-
-```asm
-; Bug: Subtracting $ff from $ff fails to set c.
-; This can result in overflow into the next data array.
-; In the case of getting a grooming from Daisy, we bleed
-; into CopyPokemonName_Buffer1_Buffer3, which passes
-; $d0 to ChangeHappiness and returns $73 to the script.
-; The end result is that there is a 0.4% chance your
-; Pokemon's happiness will not change at all.
-.loop
-	sub [hl]
-	jr c, .ok
-	inc hl
-	inc hl
-	inc hl
-	jr .loop
-
-.ok
-	inc hl
-	ld a, [hli]
-	ld [wScriptVar], a
-	ld c, [hl]
-	call ChangeHappiness
-	ret
-
-...
-
-INCLUDE "data/events/happiness_probabilities.asm"
-
-CopyPokemonName_Buffer1_Buffer3:
-	ld hl, wStringBuffer1
-	ld de, wStringBuffer3
-	ld bc, MON_NAME_LENGTH
-	jp CopyBytes
-```
-
-**Fix:** Edit  [data/events/happiness_probabilities.asm](https://github.com/pret/pokecrystal/blob/master/data/events/happiness_probabilities.asm):
-
-```diff
- HappinessData_DaisysGrooming:
--	db 100 percent,     2, HAPPINESS_GROOMING ; 99.6% chance
-+	db 50 percent + 1,  2, HAPPINESS_GROOMING ; 50% chance
-+	db 100 percent,     2, HAPPINESS_GROOMING ; 50% chance
-```
-
-
-## Magikarp in Lake of Rage are shorter, not longer
-
-**Fix:** Edit `LoadEnemyMon.CheckMagikarpArea` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
-
-```diff
- .CheckMagikarpArea:
--; The "jr z" checks are supposed to be "jr nz".
--
--; Instead, all maps in GROUP_LAKE_OF_RAGE (Mahogany area)
--; and Routes 20 and 44 are treated as Lake of Rage.
--
--; This also means Lake of Rage Magikarp can be smaller than ones
--; caught elsewhere rather than the other way around.
--
--; Intended behavior enforces a minimum size at Lake of Rage.
--; The real behavior prevents a minimum size in the Lake of Rage area.
--
--; Moreover, due to the check not being translated to feet+inches, all Magikarp
--; smaller than 4'0" may be caught by the filter, a lot more than intended.
- 	ld a, [wMapGroup]
- 	cp GROUP_LAKE_OF_RAGE
--	jr z, .Happiness
-+	jr nz, .Happiness
- 	ld a, [wMapNumber]
- 	cp MAP_LAKE_OF_RAGE
--	jr z, .Happiness
-+	jr nz, .Happiness
-```
-
-
-## Magikarp length limits have a unit conversion error
-
-**Fix:** Edit `LoadEnemyMon.CheckMagikarpArea` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
-
-```diff
- ; Get Magikarp's length
- 	ld de, wEnemyMonDVs
- 	ld bc, wPlayerID
- 	callfar CalcMagikarpLength
-
- ; No reason to keep going if length > 1536 mm (i.e. if HIGH(length) > 6 feet)
- 	ld a, [wMagikarpLength]
--	cp HIGH(1536) ; should be "cp 5", since 1536 mm = 5'0", but HIGH(1536) = 6
-+	cp 5
- 	jr nz, .CheckMagikarpArea
-
- ; 5% chance of skipping both size checks
- 	call Random
- 	cp 5 percent
- 	jr c, .CheckMagikarpArea
- ; Try again if length >= 1616 mm (i.e. if LOW(length) >= 4 inches)
- 	ld a, [wMagikarpLength + 1]
--	cp LOW(1616) ; should be "cp 4", since 1616 mm = 5'4", but LOW(1616) = 80
-+	cp 4
- 	jr nc, .GenerateDVs
-
- ; 20% chance of skipping this check
- 	call Random
- 	cp 20 percent - 1
- 	jr c, .CheckMagikarpArea
- ; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
- 	ld a, [wMagikarpLength + 1]
--	cp LOW(1600) ; should be "cp 3", since 1600 mm = 5'3", but LOW(1600) = 64
-+	cp 3
- 	jr nc, .GenerateDVs
-```
-
-**Better fix:** Rewrite the whole system to use millimeters instead of feet and inches, since they have better precision (1 in = 25.4 mm); and only convert from metric to imperial units for display purposes (or don't, of course).
-
-
-## Magikarp lengths can be miscalculated
-
-**Fix:** Edit `CalcMagikarpLength.BCLessThanDE` in [engine/events/magikarp.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/magikarp.asm):
-
-```diff
- .BCLessThanDE:
--; Intention: Return bc < de.
--; Reality: Return b < d.
- 	ld a, b
- 	cp d
- 	ret c
--	ret nc ; whoops
- 	ld a, c
- 	cp e
+ .quit
++	pop af
++	ldh [hInMenu], a
  	ret
 ```
 
 
-## Battle transitions fail to account for the enemy's level
+## Overworld engine
+
+
+### `LoadMetatiles` wraps around past 128 blocks
+
+This bug prevents you from using blocksets with more than 128 blocks.
+
+**Fix:** Edit `LoadMetatiles` in [home/map.asm](https://github.com/pret/pokecrystal/blob/master/home/map.asm):
+
+```diff
+ 	; Set hl to the address of the current metatile data ([wTilesetBlocksAddress] + (a) tiles).
+-	; This is buggy; it wraps around past 128 blocks.
+-	; To fix, uncomment the line below.
+-	add a ; Comment or delete this line to fix the above bug.
+ 	ld l, a
+ 	ld h, 0
+-	; add hl, hl
++	add hl, hl
+ 	add hl, hl
+ 	add hl, hl
+ 	add hl, hl
+ 	ld a, [wTilesetBlocksAddress]
+ 	add l
+ 	ld l, a
+ 	ld a, [wTilesetBlocksAddress + 1]
+ 	adc h
+ 	ld h, a
+```
+
+
+### Surfing directly across a map connection does not load the new map
+
+([Video](https://www.youtube.com/watch?v=XFOWvMNG-zw))
+
+**Fix:**
+
+First, edit `UsedSurfScript` in [engine/events/overworld.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/overworld.asm):
+
+```diff
+ UsedSurfScript:
+ 	writetext UsedSurfText ; "used SURF!"
+ 	waitbutton
+ 	closetext
+
+ 	callasm .empty_fn ; empty function
+
+ 	readmem wBuffer2
+ 	writevar VAR_MOVEMENT
+
+ 	special UpdatePlayerSprite
+ 	special PlayMapMusic
+-; step into the water (slow_step DIR, step_end)
+ 	special SurfStartStep
+-	applymovement PLAYER, wMovementBuffer
+ 	end
+```
+
+Then edit `SurfStartStep` in [engine/overworld/player_object.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/player_object.asm):
+
+```diff
+ SurfStartStep:
+-	call InitMovementBuffer
+-	call .GetMovementData
+-	call AppendToMovementBuffer
+-	ld a, movement_step_end
+-	call AppendToMovementBuffer
+-	ret
+-
+-.GetMovementData:
+ 	ld a, [wPlayerDirection]
+ 	srl a
+ 	srl a
+ 	maskbits NUM_DIRECTIONS
+ 	ld e, a
+ 	ld d, 0
+ 	ld hl, .movement_data
+ 	add hl, de
+-	ld a, [hl]
+-	ret
++	add hl, de
++	add hl, de
++	ld a, BANK(.movement_data)
++	jp StartAutoInput
+
+ .movement_data
+-	slow_step DOWN
+-	slow_step UP
+-	slow_step LEFT
+-	slow_step RIGHT
++	db D_DOWN,  0, -1
++	db D_UP,    0, -1
++	db D_LEFT,  0, -1
++	db D_RIGHT, 0, -1
+```
+
+
+### Swimming NPCs aren't limited by their movement radius
+
+This bug is why the Lapras in [maps/UnionCaveB2F.asm](https://github.com/pret/pokecrystal/blob/master/maps/UnionCaveB2F.asm), which uses `SPRITEMOVEDATA_SWIM_WANDER`, is not restricted by its `1, 1` movement radius.
+
+**Fix:** Edit `CanObjectMoveInDirection` in [engine/overworld/npc_movement.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/npc_movement.asm):
+
+```diff
+ 	ld hl, OBJECT_FLAGS1
+ 	add hl, bc
+ 	bit NOCLIP_TILES_F, [hl] ; lost, uncomment next line to fix
+-	; jr nz, .noclip_tiles
++	jr nz, .noclip_tiles
+```
+
+
+## Graphics
+
+
+### In-battle “`…`” ellipsis is too high
+
+This is a mistake with the “`…`” tile in [gfx/battle/hp_exp_bar_border.png](https://github.com/pret/pokecrystal/blob/master/gfx/battle/hp_exp_bar_border.png):
+
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/battle/hp_exp_bar_border.png)
+
+**Fix:** Lower the ellipsis by two pixels:
+
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/hp_exp_bar_border.png)
+
+
+### Two tiles in the `port` tileset are drawn incorrectly
+
+This is a mistake with the left-hand warp carpet corner tiles in [gfx/tilesets/port.png](https://github.com/pret/pokecrystal/blob/master/gfx/tilesets/port.png):
+
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/tilesets/port.png)
+
+**Fix:** Adjust them to match the right-hand corner tiles:
+
+![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/port.png)
+
+
+### Using a Park Ball in non-Contest battles has a corrupt animation
+
+([Video](https://www.youtube.com/watch?v=v1ErZdLCIyU))
+
+**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+
+```diff
+ .room_in_party
+ 	xor a
+ 	ld [wWildMon], a
+-	ld a, [wCurItem]
+-	cp PARK_BALL
++	ld a, [wBattleType]
++	cp BATTLETYPE_CONTEST
+ 	call nz, ReturnToBattle_UseBall
+```
+
+
+### Battle transitions fail to account for the enemy's level
 
 ([Video](https://www.youtube.com/watch?v=eij_1060SMc))
 
@@ -1530,66 +1540,7 @@ Finally, edit [engine/battle/read_trainer_party.asm](https://github.com/pret/pok
 ```
 
 
-## A "HOF Master!" title for 200-Time Famers is defined but inaccessible
-
-([Video](https://www.youtube.com/watch?v=iHkWubvxmSg))
-
-**Fix:** Edit `_HallOfFamePC.DisplayMonAndStrings` in [engine/events/halloffame.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/halloffame.asm):
-
-```diff
- 	ld a, [wHallOfFameTempWinCount]
--	cp HOF_MASTER_COUNT + 1 ; should be HOF_MASTER_COUNT
-+	cp HOF_MASTER_COUNT
- 	jr c, .print_num_hof
- 	ld de, .HOFMaster
- 	hlcoord 1, 2
- 	call PlaceString
- 	hlcoord 13, 2
- 	jr .finish
-```
-
-
-## Slot machine payout sound effects cut each other off
-
-([Video](https://www.youtube.com/watch?v=ojq3xqfRF6I))
-
-**Fix:** Edit `SlotsAction_PayoutAnim` in [engine/games/slot_machine.asm](https://github.com/pret/pokecrystal/blob/master/engine/games/slot_machine.asm):
-
-```diff
- .okay
- 	ld [hl], e
- 	dec hl
- 	ld [hl], d
- 	ld a, [wSlotsDelay]
- 	and $7
--	ret z ; ret nz would be more appropriate
-+	ret nz
- 	ld de, SFX_GET_COIN_FROM_SLOTS
- 	call PlaySFX
- 	ret
-```
-
-
-## Team Rocket battle music is not used for Executives or Scientists
-
-**Fix:** Edit `PlayBattleMusic` in [engine/battle/start_battle.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/start_battle.asm):
-
-```diff
- 	ld de, MUSIC_ROCKET_BATTLE
- 	cp GRUNTM
- 	jr z, .done
- 	cp GRUNTF
- 	jr z, .done
-+	cp EXECUTIVEM
-+	jr z, .done
-+	cp EXECUTIVEF
-+	jr z, .done
-+	cp SCIENTIST
-+	jr z, .done
-```
-
-
-## Some trainer NPCs have inconsistent overworld sprites
+### Some trainer NPCs have inconsistent overworld sprites
 
 *Some of these may have been intentional behavior; use your own judgment for whether to fix them.*
 
@@ -1619,7 +1570,50 @@ Most of the NPCs in [maps/NationalParkBugContest.asm](https://github.com/pret/po
 (The use of `SPRITE_ROCKER` instead of `SPRITE_COOLTRAINER_M` for `COOLTRAINERM NICK` may also be an intentional reference to the player's brother from the [Space World '97 beta](https://github.com/pret/pokegold-spaceworld).)
 
 
-## No bump noise if standing on tile `$3E`
+## Audio
+
+
+### Slot machine payout sound effects cut each other off
+
+([Video](https://www.youtube.com/watch?v=ojq3xqfRF6I))
+
+**Fix:** Edit `SlotsAction_PayoutAnim` in [engine/games/slot_machine.asm](https://github.com/pret/pokecrystal/blob/master/engine/games/slot_machine.asm):
+
+```diff
+ .okay
+ 	ld [hl], e
+ 	dec hl
+ 	ld [hl], d
+ 	ld a, [wSlotsDelay]
+ 	and $7
+-	ret z ; ret nz would be more appropriate
++	ret nz
+ 	ld de, SFX_GET_COIN_FROM_SLOTS
+ 	call PlaySFX
+ 	ret
+```
+
+
+### Team Rocket battle music is not used for Executives or Scientists
+
+**Fix:** Edit `PlayBattleMusic` in [engine/battle/start_battle.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/start_battle.asm):
+
+```diff
+ 	ld de, MUSIC_ROCKET_BATTLE
+ 	cp GRUNTM
+ 	jr z, .done
+ 	cp GRUNTF
+ 	jr z, .done
++	cp EXECUTIVEM
++	jr z, .done
++	cp EXECUTIVEF
++	jr z, .done
++	cp SCIENTIST
++	jr z, .done
+```
+
+
+### No bump noise if standing on tile `$3E`
 
 **Fix:** Edit `DoPlayerMovement.CheckWarp` in [engine/overworld/player_movement.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/player_movement.asm):
 
@@ -1652,7 +1646,7 @@ Most of the NPCs in [maps/NationalParkBugContest.asm](https://github.com/pret/po
 ```
 
 
-## Playing Entei's Pokédex cry can distort Raikou's and Suicune's
+### Playing Entei's Pokédex cry can distort Raikou's and Suicune's
 
 ([Video](https://www.youtube.com/watch?v=z305e4sIO24))
 
@@ -1674,191 +1668,256 @@ The exact cause of this bug is unknown.
 ```
 
 
-## In-battle “`…`” ellipsis is too high
-
-This is a mistake with the “`…`” tile in [gfx/battle/hp_exp_bar_border.png](https://github.com/pret/pokecrystal/blob/master/gfx/battle/hp_exp_bar_border.png):
-
-![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/battle/hp_exp_bar_border.png)
-
-**Fix:** Lower the ellipsis by two pixels:
-
-![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/hp_exp_bar_border.png)
+## Text
 
 
-## Credits sequence changes move selection menu behavior
+### Five-digit experience gain is printed incorrectly
 
-([Video](https://www.youtube.com/watch?v=vjFUo6Jr4po&t=438))
+([Video](https://www.youtube.com/watch?v=o54VjpAEoO8))
 
-To select a move in battle, you have to press and release the Up or Down buttons. However, after playing the credits sequence, holding down either button will continuously scroll through the moves.
-
-**Fix:** Edit `Credits` in [engine/movie/credits.asm](https://github.com/pret/pokecrystal/blob/master/engine/movie/credits.asm):
+**Fix:** Edit `_BoostedExpPointsText` and `_ExpPointsText` in [data/text/common_2.asm](https://github.com/pret/pokecrystal/blob/master/data/text/common_2.asm):
 
 ```diff
- 	ldh a, [hVBlank]
- 	push af
- 	ld a, $5
- 	ldh [hVBlank], a
-+	ldh a, [hInMenu]
-+	push af
- 	ld a, $1
- 	ldh [hInMenu], a
+ _BoostedExpPointsText::
+ 	text_start
+ 	line "a boosted"
+ 	cont "@"
+-	text_decimal wStringBuffer2, 2, 4
++	text_decimal wStringBuffer2, 2, 5
+ 	text " EXP. Points!"
+ 	prompt
 
- 	...
-
- 	ldh [hLCDCPointer], a
- 	ldh [hBGMapAddress], a
-+	pop af
-+	ldh [hInMenu], a
- 	pop af
- 	ldh [hVBlank], a
- 	pop af
- 	ldh [rSVBK], a
+ _ExpPointsText::
+ 	text_start
+ 	line "@"
+-	text_decimal wStringBuffer2, 2, 4
++	text_decimal wStringBuffer2, 2, 5
+ 	text " EXP. Points!"
+ 	prompt
 ```
 
-The `[hInMenu]` value determines this button behavior. However, the battle moves menu doesn't actually set `[hInMenu]` to anything, so either behavior *may* have been intentional. The default 0 prevents continuous scrolling; a value of 1 allows it. (The Japanese release sets it to 0.)
 
-**Optional fix:** To explicitly set a `[hInMenu]` for the moves menu, edit `BattleTurn` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
+### Only the first three evolution entries can have Stone compatibility reported correctly
+
+**Workaround:** Edit `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` in [engine/pokemon/party_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/party_menu.asm):
 
 ```diff
- BattleTurn:
-+	ldh a, [hInMenu]
-+	push af
-+	ld a, 1 ; or "xor a" for the value 0
-+	ldh [hInMenu], a
+ .DetermineCompatibility:
+ 	ld de, wStringBuffer1
+ 	ld a, BANK(EvosAttacksPointers)
+ 	ld bc, 2
+ 	call FarCopyBytes
+ 	ld hl, wStringBuffer1
+ 	ld a, [hli]
+ 	ld h, [hl]
+ 	ld l, a
+ 	ld de, wStringBuffer1
+ 	ld a, BANK("Evolutions and Attacks")
+-	ld bc, 10
++	ld bc, wStringBuffer2 - wStringBuffer1
+ 	call FarCopyBytes
+```
+
+This supports up to six entries.
+
+
+### `EVOLVE_STAT` can break Stone compatibility reporting
+
+**Fix:** Edit `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` in [engine/pokemon/party_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/party_menu.asm):
+
+```diff
+ .loop2
+ 	ld a, [hli]
+ 	and a
+ 	jr z, .nope
++	cp EVOLVE_STAT
++	jr nz, .not_four_bytes
++	inc hl
++.not_four_bytes
+ 	inc hl
+ 	inc hl
+ 	cp EVOLVE_ITEM
+ 	jr nz, .loop2
+```
+
+
+### A "HOF Master!" title for 200-Time Famers is defined but inaccessible
+
+([Video](https://www.youtube.com/watch?v=iHkWubvxmSg))
+
+**Fix:** Edit `_HallOfFamePC.DisplayMonAndStrings` in [engine/events/halloffame.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/halloffame.asm):
+
+```diff
+ 	ld a, [wHallOfFameTempWinCount]
+-	cp HOF_MASTER_COUNT + 1 ; should be HOF_MASTER_COUNT
++	cp HOF_MASTER_COUNT
+ 	jr c, .print_num_hof
+ 	ld de, .HOFMaster
+ 	hlcoord 1, 2
+ 	call PlaceString
+ 	hlcoord 13, 2
+ 	jr .finish
+```
+
+
+## Scripted events
+
+
+### Clair can give TM24 Dragonbreath twice
+
+([Video](https://www.youtube.com/watch?v=8BvBjqxmyOk))
+
+**Fix:** Edit `DragonsDen1F_MapScripts` in [maps/DragonsDen1F.asm](https://github.com/pret/pokecrystal/blob/master/maps/DragonsDen1F.asm):
+
+```diff
+-	db 0 ; callbacks
++	db 1 ; callbacks
++	callback MAPCALLBACK_NEWMAP, .UnsetClairScene
 +
- .loop
++.UnsetClairScene:
++	setmapscene DRAGONS_DEN_B1F, SCENE_DRAGONSDENB1F_NOTHING
++	return
+```
 
- 	...
 
- 	jp .loop
+### Daisy's grooming doesn't always increase happiness
 
- .quit
-+	pop af
-+	ldh [hInMenu], a
+This is a bug with `HaircutOrGrooming` in [engine/events/haircut.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/haircut.asm):
+
+```asm
+; Bug: Subtracting $ff from $ff fails to set c.
+; This can result in overflow into the next data array.
+; In the case of getting a grooming from Daisy, we bleed
+; into CopyPokemonName_Buffer1_Buffer3, which passes
+; $d0 to ChangeHappiness and returns $73 to the script.
+; The end result is that there is a 0.4% chance your
+; Pokemon's happiness will not change at all.
+.loop
+	sub [hl]
+	jr c, .ok
+	inc hl
+	inc hl
+	inc hl
+	jr .loop
+
+.ok
+	inc hl
+	ld a, [hli]
+	ld [wScriptVar], a
+	ld c, [hl]
+	call ChangeHappiness
+	ret
+
+...
+
+INCLUDE "data/events/happiness_probabilities.asm"
+
+CopyPokemonName_Buffer1_Buffer3:
+	ld hl, wStringBuffer1
+	ld de, wStringBuffer3
+	ld bc, MON_NAME_LENGTH
+	jp CopyBytes
+```
+
+**Fix:** Edit  [data/events/happiness_probabilities.asm](https://github.com/pret/pokecrystal/blob/master/data/events/happiness_probabilities.asm):
+
+```diff
+ HappinessData_DaisysGrooming:
+-	db 100 percent,     2, HAPPINESS_GROOMING ; 99.6% chance
++	db 50 percent + 1,  2, HAPPINESS_GROOMING ; 50% chance
++	db 100 percent,     2, HAPPINESS_GROOMING ; 50% chance
+```
+
+
+### Magikarp in Lake of Rage are shorter, not longer
+
+**Fix:** Edit `LoadEnemyMon.CheckMagikarpArea` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
+
+```diff
+ .CheckMagikarpArea:
+-; The "jr z" checks are supposed to be "jr nz".
+-
+-; Instead, all maps in GROUP_LAKE_OF_RAGE (Mahogany area)
+-; and Routes 20 and 44 are treated as Lake of Rage.
+-
+-; This also means Lake of Rage Magikarp can be smaller than ones
+-; caught elsewhere rather than the other way around.
+-
+-; Intended behavior enforces a minimum size at Lake of Rage.
+-; The real behavior prevents a minimum size in the Lake of Rage area.
+-
+-; Moreover, due to the check not being translated to feet+inches, all Magikarp
+-; smaller than 4'0" may be caught by the filter, a lot more than intended.
+ 	ld a, [wMapGroup]
+ 	cp GROUP_LAKE_OF_RAGE
+-	jr z, .Happiness
++	jr nz, .Happiness
+ 	ld a, [wMapNumber]
+ 	cp MAP_LAKE_OF_RAGE
+-	jr z, .Happiness
++	jr nz, .Happiness
+```
+
+
+### Magikarp length limits have a unit conversion error
+
+**Fix:** Edit `LoadEnemyMon.CheckMagikarpArea` in [engine/battle/core.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/core.asm):
+
+```diff
+ ; Get Magikarp's length
+ 	ld de, wEnemyMonDVs
+ 	ld bc, wPlayerID
+ 	callfar CalcMagikarpLength
+
+ ; No reason to keep going if length > 1536 mm (i.e. if HIGH(length) > 6 feet)
+ 	ld a, [wMagikarpLength]
+-	cp HIGH(1536) ; should be "cp 5", since 1536 mm = 5'0", but HIGH(1536) = 6
++	cp 5
+ 	jr nz, .CheckMagikarpArea
+
+ ; 5% chance of skipping both size checks
+ 	call Random
+ 	cp 5 percent
+ 	jr c, .CheckMagikarpArea
+ ; Try again if length >= 1616 mm (i.e. if LOW(length) >= 4 inches)
+ 	ld a, [wMagikarpLength + 1]
+-	cp LOW(1616) ; should be "cp 4", since 1616 mm = 5'4", but LOW(1616) = 80
++	cp 4
+ 	jr nc, .GenerateDVs
+
+ ; 20% chance of skipping this check
+ 	call Random
+ 	cp 20 percent - 1
+ 	jr c, .CheckMagikarpArea
+ ; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
+ 	ld a, [wMagikarpLength + 1]
+-	cp LOW(1600) ; should be "cp 3", since 1600 mm = 5'3", but LOW(1600) = 64
++	cp 3
+ 	jr nc, .GenerateDVs
+```
+
+**Better fix:** Rewrite the whole system to use millimeters instead of feet and inches, since they have better precision (1 in = 25.4 mm); and only convert from metric to imperial units for display purposes (or don't, of course).
+
+
+### Magikarp lengths can be miscalculated
+
+**Fix:** Edit `CalcMagikarpLength.BCLessThanDE` in [engine/events/magikarp.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/magikarp.asm):
+
+```diff
+ .BCLessThanDE:
+-; Intention: Return bc < de.
+-; Reality: Return b < d.
+ 	ld a, b
+ 	cp d
+ 	ret c
+-	ret nc ; whoops
+ 	ld a, c
+ 	cp e
  	ret
 ```
 
 
-## Two tiles in the `port` tileset are drawn incorrectly
-
-This is a mistake with the left-hand warp carpet corner tiles in [gfx/tilesets/port.png](https://github.com/pret/pokecrystal/blob/master/gfx/tilesets/port.png):
-
-![image](https://raw.githubusercontent.com/pret/pokecrystal/master/gfx/tilesets/port.png)
-
-**Fix:** Adjust them to match the right-hand corner tiles:
-
-![image](https://raw.githubusercontent.com/pret/pokecrystal/master/docs/images/port.png)
-
-
-## `LoadMetatiles` wraps around past 128 blocks
-
-This bug prevents you from using blocksets with more than 128 blocks.
-
-**Fix:** Edit `LoadMetatiles` in [home/map.asm](https://github.com/pret/pokecrystal/blob/master/home/map.asm):
-
-```diff
- 	; Set hl to the address of the current metatile data ([wTilesetBlocksAddress] + (a) tiles).
--	; This is buggy; it wraps around past 128 blocks.
--	; To fix, uncomment the line below.
--	add a ; Comment or delete this line to fix the above bug.
- 	ld l, a
- 	ld h, 0
--	; add hl, hl
-+	add hl, hl
- 	add hl, hl
- 	add hl, hl
- 	add hl, hl
- 	ld a, [wTilesetBlocksAddress]
- 	add l
- 	ld l, a
- 	ld a, [wTilesetBlocksAddress + 1]
- 	adc h
- 	ld h, a
-```
-
-
-## Surfing directly across a map connection does not load the new map
-
-([Video](https://www.youtube.com/watch?v=XFOWvMNG-zw))
-
-**Fix:**
-
-First, edit `UsedSurfScript` in [engine/events/overworld.asm](https://github.com/pret/pokecrystal/blob/master/engine/events/overworld.asm):
-
-```diff
- UsedSurfScript:
- 	writetext UsedSurfText ; "used SURF!"
- 	waitbutton
- 	closetext
-
- 	callasm .empty_fn ; empty function
-
- 	readmem wBuffer2
- 	writevar VAR_MOVEMENT
-
- 	special UpdatePlayerSprite
- 	special PlayMapMusic
--; step into the water (slow_step DIR, step_end)
- 	special SurfStartStep
--	applymovement PLAYER, wMovementBuffer
- 	end
-```
-
-Then edit `SurfStartStep` in [engine/overworld/player_object.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/player_object.asm):
-
-```diff
- SurfStartStep:
--	call InitMovementBuffer
--	call .GetMovementData
--	call AppendToMovementBuffer
--	ld a, movement_step_end
--	call AppendToMovementBuffer
--	ret
--
--.GetMovementData:
- 	ld a, [wPlayerDirection]
- 	srl a
- 	srl a
- 	maskbits NUM_DIRECTIONS
- 	ld e, a
- 	ld d, 0
- 	ld hl, .movement_data
- 	add hl, de
--	ld a, [hl]
--	ret
-+	add hl, de
-+	add hl, de
-+	ld a, BANK(.movement_data)
-+	jp StartAutoInput
-
- .movement_data
--	slow_step DOWN
--	slow_step UP
--	slow_step LEFT
--	slow_step RIGHT
-+	db D_DOWN,  0, -1
-+	db D_UP,    0, -1
-+	db D_LEFT,  0, -1
-+	db D_RIGHT, 0, -1
-```
-
-
-## Swimming NPCs aren't limited by their movement radius
-
-This bug is why the Lapras in [maps/UnionCaveB2F.asm](https://github.com/pret/pokecrystal/blob/master/maps/UnionCaveB2F.asm), which uses `SPRITEMOVEDATA_SWIM_WANDER`, is not restricted by its `1, 1` movement radius.
-
-**Fix:** Edit `CanObjectMoveInDirection` in [engine/overworld/npc_movement.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/npc_movement.asm):
-
-```diff
- 	ld hl, OBJECT_FLAGS1
- 	add hl, bc
- 	bit NOCLIP_TILES_F, [hl] ; lost, uncomment next line to fix
--	; jr nz, .noclip_tiles
-+	jr nz, .noclip_tiles
-```
-
-
-## `CheckOwnMon` only checks the first five letters of OT names
+### `CheckOwnMon` only checks the first five letters of OT names
 
 ([Video](https://www.youtube.com/watch?v=GVTTmReM4nQ))
 
@@ -1890,7 +1949,7 @@ This bug can allow you to talk to Eusine in Celadon City and encounter Ho-Oh wit
 ```
 
 
-## `CheckOwnMonAnywhere` does not check the Day-Care
+### `CheckOwnMonAnywhere` does not check the Day-Care
 
 *This may have been intentional behavior; use your own judgment for whether to fix it.*
 
@@ -1917,167 +1976,113 @@ This bug can prevent you from talking to Eusine in Celadon City or encountering 
 ```
 
 
-## Catching a Transformed Pokémon always catches a Ditto
+## Internal engine routines
 
-This bug can affect Mew or Pokémon other than Ditto that used Transform via Mirror Move or Sketch.
 
-**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
+### Saves corrupted by mid-save shutoff are not handled
+
+([Video 1](https://www.youtube.com/watch?v=ukqtK0l6bu0), [Video 2](https://www.youtube.com/watch?v=c2zHd1BPtvc))
+
+**Fix:** Edit `MoveMonWOMail_InsertMon_SaveGame` and `_SaveGameData` in [engine/menus/save.asm](https://github.com/pret/pokecrystal/blob/master/engine/menus/save.asm):
 
 ```diff
- 	ld hl, wEnemySubStatus5
- 	ld a, [hl]
- 	push af
- 	set SUBSTATUS_TRANSFORMED, [hl]
+ MoveMonWOMail_InsertMon_SaveGame:
+ 	...
+ 	ld a, TRUE
+ 	ld [wSaveFileExists], a
+ 	farcall StageRTCTimeForSave
+ 	farcall BackupMysteryGift
+-	call ValidateSave
++	call InvalidateSave
+ 	call SaveOptions
+ 	call SavePlayerData
+ 	call SavePokemonData
+ 	call SaveChecksum
+-	call ValidateBackupSave
++	call ValidateSave
++	call InvalidateBackupSave
+ 	call SaveBackupOptions
+ 	call SaveBackupPlayerData
+ 	call SaveBackupPokemonData
+ 	call SaveBackupChecksum
++	call ValidateBackupSave
+ 	farcall BackupPartyMonMail
+ 	farcall BackupMobileEventIndex
+ 	farcall SaveRTC
+ 	...
+```
 
--; This code is buggy. Any wild Pokémon that has Transformed will be
--; caught as a Ditto, even if it was something else like Mew.
--; To fix, do not set [wTempEnemyMonSpecies] to DITTO.
- 	bit SUBSTATUS_TRANSFORMED, a
--	jr nz, .ditto
--	jr .not_ditto
-+	jr nz, .load_data
+```diff
+ _SaveGameData:
+ 	...
+ 	ld a, TRUE
+ 	ld [wSaveFileExists], a
+ 	farcall StageRTCTimeForSave
+ 	farcall BackupMysteryGift
+-	call ValidateSave
++	call InvalidateSave
+ 	call SaveOptions
+ 	call SavePlayerData
+ 	call SavePokemonData
+ 	call SaveBox
+ 	call SaveChecksum
+-	call ValidateBackupSave
++	call ValidateSave
++	call InvalidateBackupSave
+ 	call SaveBackupOptions
+ 	call SaveBackupPlayerData
+ 	call SaveBackupPokemonData
+ 	call SaveBackupChecksum
++	call ValidateBackupSave
+ 	call UpdateStackTop
+ 	farcall BackupPartyMonMail
+ 	farcall BackupMobileEventIndex
+ 	farcall SaveRTC
+ 	...
+```
 
--.ditto
--	ld a, DITTO
--	ld [wTempEnemyMonSpecies], a
--	jr .load_data
--
--.not_ditto
--	set SUBSTATUS_TRANSFORMED, [hl]
- 	ld hl, wEnemyBackupDVs
- 	ld a, [wEnemyMonDVs]
- 	ld [hli], a
- 	ld a, [wEnemyMonDVs + 1]
- 	ld [hl], a
+Then create two new routines, `InvalidateSave` and `InvalidateBackupSave`:
 
- .load_data
- 	ld a, [wTempEnemyMonSpecies]
- 	ld [wCurPartySpecies], a
- 	ld a, [wEnemyMonLevel]
- 	ld [wCurPartyLevel], a
- 	farcall LoadEnemyMon
+```diff
+ ValidateSave:
+ 	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
+ 	call OpenSRAM
+ 	ld a, SAVE_CHECK_VALUE_1
+ 	ld [sCheckValue1], a
+ 	ld a, SAVE_CHECK_VALUE_2
+ 	ld [sCheckValue2], a
+ 	jp CloseSRAM
 
- 	pop af
- 	ld [wEnemySubStatus5], a
++InvalidateSave:
++	ld a, BANK(sCheckValue1) ; aka BANK(sCheckValue2)
++	call OpenSRAM
++	xor a
++	ld [sCheckValue1], a
++	ld [sCheckValue2], a
++	jp CloseSRAM
+```
+
+```diff
+ ValidateBackupSave:
+ 	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
+ 	call OpenSRAM
+ 	ld a, SAVE_CHECK_VALUE_1
+ 	ld [sBackupCheckValue1], a
+ 	ld a, SAVE_CHECK_VALUE_2
+ 	ld [sBackupCheckValue2], a
+ 	jp CloseSRAM
+
++InvalidateBackupSave:
++	ld a, BANK(sBackupCheckValue1) ; aka BANK(sBackupCheckValue2)
++	call OpenSRAM
++	xor a
++	ld [sBackupCheckValue1], a
++	ld [sBackupCheckValue2], a
++	jp CloseSRAM
 ```
 
 
-## If your party and current PC box are full during the Dude's catching tutorial, his Poké Ball can't be used and may crash the game
-([Video](https://www.youtube.com/watch?v=A8zaTOkjKS4&t=407))
-
-**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
-
-```diff
-     ld a, [wBattleMode]
-     dec a
-     jp nz, UseBallInTrainerBattle
- 
-+    ld a, [wBattleType]
-+    cp BATTLETYPE_TUTORIAL
-+    jr z, .room_in_party
-+
-     ld a, [wPartyCount]
-     cp PARTY_LENGTH
-     jr nz, .room_in_party
- 
-     ld a, BANK(sBoxCount)
-     call OpenSRAM
-     ld a, [sBoxCount]
-     cp MONS_PER_BOX
-     call CloseSRAM
-     jp z, Ball_BoxIsFullMessage
-```
-
-
-## Using a Park Ball in normal battles has a corrupt animation
-
-([Video](https://www.youtube.com/watch?v=v1ErZdLCIyU))
-
-**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
-
-```diff
- .room_in_party
- 	xor a
- 	ld [wWildMon], a
--	ld a, [wCurItem]
--	cp PARK_BALL
-+	ld a, [wBattleType]
-+	cp BATTLETYPE_CONTEST
- 	call nz, ReturnToBattle_UseBall
-```
-
-
-## `HELD_CATCH_CHANCE` has no effect
-
-**Fix:** Edit `PokeBallEffect` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
-
-```diff
--	; BUG: farcall overwrites a, and GetItemHeldEffect takes b anyway.
--	; This is probably the reason the HELD_CATCH_CHANCE effect is never used.
--	; Uncomment the line below to fix.
- 	ld d, a
- 	push de
- 	ld a, [wBattleMonItem]
--	; ld b, a
-+	ld b, a
- 	farcall GetItemHeldEffect
- 	ld a, b
- 	cp HELD_CATCH_CHANCE
- 	pop de
- 	ld a, d
- 	jr nz, .max_2
- 	add c
- 	jr nc, .max_2
- 	ld a, $ff
- .max_2
-```
-
-
-## Only the first three evolution entries can have Stone compatibility reported correctly
-
-**Workaround:** Edit `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` in [engine/pokemon/party_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/party_menu.asm):
-
-```diff
- .DetermineCompatibility:
- 	ld de, wStringBuffer1
- 	ld a, BANK(EvosAttacksPointers)
- 	ld bc, 2
- 	call FarCopyBytes
- 	ld hl, wStringBuffer1
- 	ld a, [hli]
- 	ld h, [hl]
- 	ld l, a
- 	ld de, wStringBuffer1
- 	ld a, BANK("Evolutions and Attacks")
--	ld bc, 10
-+	ld bc, wStringBuffer2 - wStringBuffer1
- 	call FarCopyBytes
-```
-
-This supports up to six entries.
-
-
-## `EVOLVE_STAT` can break Stone compatibility reporting
-
-**Fix:** Edit `PlacePartyMonEvoStoneCompatibility.DetermineCompatibility` in [engine/pokemon/party_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/pokemon/party_menu.asm):
-
-```diff
- .loop2
- 	ld a, [hli]
- 	and a
- 	jr z, .nope
-+	cp EVOLVE_STAT
-+	jr nz, .not_four_bytes
-+	inc hl
-+.not_four_bytes
- 	inc hl
- 	inc hl
- 	cp EVOLVE_ITEM
- 	jr nz, .loop2
-```
-
-
-## `ScriptCall` can overflow `wScriptStack` and crash
+### `ScriptCall` can overflow `wScriptStack` and crash
 
 **Fix:** Edit `ScriptCall` in [engine/overworld/scripting.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/scripting.asm):
 
@@ -2120,7 +2125,7 @@ This supports up to six entries.
 ```
 
 
-## `LoadSpriteGFX` does not limit the capacity of `UsedSprites`
+### `LoadSpriteGFX` does not limit the capacity of `UsedSprites`
 
 **Fix:** Edit `LoadSpriteGFX` in [engine/overworld/overworld.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/overworld.asm):
 
@@ -2156,7 +2161,7 @@ This supports up to six entries.
 ```
 
 
-## `ChooseWildEncounter` doesn't really validate the wild Pokémon species
+### `ChooseWildEncounter` doesn't really validate the wild Pokémon species
 
 **Fix:** Edit `ChooseWildEncounter` in [engine/overworld/wildmons.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/wildmons.asm):
 
@@ -2176,7 +2181,7 @@ This supports up to six entries.
 ```
 
 
-## `TryObjectEvent` arbitrary code execution
+### `TryObjectEvent` arbitrary code execution
 
 **Fix:** Edit `TryObjectEvent` in [engine/overworld/events.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/events.asm):
 
@@ -2186,7 +2191,7 @@ This supports up to six entries.
  	ld de, 3
  	ld hl, .pointers
  	call IsInArray
-- 	jr nc, .nope
+-	jr nc, .nope
  	pop bc
 +	jr nc, .nope
 
@@ -2203,7 +2208,7 @@ This supports up to six entries.
 ```
 
 
-## `ReadObjectEvents` overflows into `wObjectMasks`
+### `ReadObjectEvents` overflows into `wObjectMasks`
 
 **Fix:** Edit `ReadObjectEvents` in [home/map.asm](https://github.com/pret/pokecrystal/blob/master/home/map.asm):
 
@@ -2236,7 +2241,7 @@ This supports up to six entries.
 ```
 
 
-## `ClearWRAM` only clears WRAM bank 1
+### `ClearWRAM` only clears WRAM bank 1
 
 **Fix:** Edit `ClearWRAM` in [home/init.asm](https://github.com/pret/pokecrystal/blob/master/home/init.asm):
 
@@ -2262,7 +2267,7 @@ This supports up to six entries.
 ```
 
 
-## `BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects
+### `BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects
 
 **Fix:** Edit `BattleAnimCmd_ClearObjs` in [engine/battle_anims/anim_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle_anims/anim_commands.asm):
 


### PR DESCRIPTION
Categories were inspired by the ones from [GCL for Red/Blue](https://forums.glitchcity.info/index.php?topic=7682.0). (Reminder that pokered has no bug documentation yet.)

Please comment if any categorizations should be changed. In particular, the two cosmetic HP bar animation bugs are grouped in "Link battle engine" since they're visible to both linked players, but should arguably be in "Graphics, audio, and text".