### PR TITLE
document unused male grunts

### DIFF
--- a/constants/trainer_constants.asm
+++ b/constants/trainer_constants.asm
@@ -287,7 +287,7 @@ KRIS EQU __trainer_class__
 	const GRUNTM_9
 	const GRUNTM_10
 	const GRUNTM_11
-	const GRUNTM_12
+	const GRUNTM_12_UNUSED
 	const GRUNTM_13
 	const GRUNTM_14
 	const GRUNTM_15
@@ -297,15 +297,15 @@ KRIS EQU __trainer_class__
 	const GRUNTM_19
 	const GRUNTM_20
 	const GRUNTM_21
-	const GRUNTM_22
-	const GRUNTM_23
+	const GRUNTM_22_UNUSED
+	const GRUNTM_23_UNUSED
 	const GRUNTM_24
 	const GRUNTM_25
-	const GRUNTM_26
-	const GRUNTM_27
+	const GRUNTM_26_UNUSED
+	const GRUNTM_27_UNUSED
 	const GRUNTM_28
 	const GRUNTM_29
-	const GRUNTM_30
+	const GRUNTM_30_UNUSED
 	const GRUNTM_31
 
 	trainerclass GENTLEMAN ; 20


### PR DESCRIPTION
Looking through the code, these six GruntM trainers appear to be unused.  Checking against `data/trainers/parties.asm`, grunts 12, 22, 23, and 27 are obvious, given the player never faces a Grunt character with the name "Executive".  26 and 30 don't have any used events attached to them, nor are they ever called with `loadtrainer`.

This matches up with https://bulbapedia.bulbagarden.net/wiki/Team_Rocket_Grunt_(Trainer_class)#Pok.C3.A9mon_Gold.2C_Silver.2C_and_Crystal, which has a total of 25 GruntM trainers documented (6 unused out of 31), and these six parties do not appear in the document either.

I marked each as `_UNUSED`, following convention of `NAOKO_UNUSED`