### PR TITLE
Require rgbds 0.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 install:
   - |-
     ( cd
-        git clone -b v0.4.1 --depth=1 https://github.com/gbdev/rgbds
+        git clone -b v0.4.2 --depth=1 https://github.com/gbdev/rgbds
         sudo make -C rgbds install
         rm -rf rgbds
     )

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,15 +41,15 @@ You need to install `gcc`. If you're using Cygwin, re-run its setup, and at "Sel
 
 ### "ERROR: `UNION` already defined"
 
-Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.2**][rgbds] or newer. Older versions will not work.
 
 ### "ERROR: Macro not defined"
 
-Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.2**][rgbds] or newer. Older versions will not work.
 
 ### "Expression must be 8-bit"
 
-Download [**rgbds 0.4.1**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.4.2**][rgbds] or newer. Older versions will not work.
 
 ### "Segmentation fault" from `rgbgfx`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,9 +42,9 @@ Run setup and leave the default settings. At the "**Select Packages**" step, cho
 
 Double click on the text that says "**Skip**" next to each package to select the most recent version to install.
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/windows) for Windows with Cygwin to install **rgbds 0.4.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/windows) for Windows with Cygwin to install **rgbds 0.4.2**.
 
-**Note:** If you already have an older rgbds, you will need to update to 0.4.1. Ignore this if you have never installed rgbds before. If a version newer than 0.4.1 does not work, try downloading 0.4.1.
+**Note:** If you already have an older rgbds, you will need to update to 0.4.2. Ignore this if you have never installed rgbds before. If a version newer than 0.4.2 does not work, try downloading 0.4.2.
 
 Now open the **Cygwin terminal** and enter the following commands.
 
@@ -67,7 +67,7 @@ Install [**Homebrew**](https://brew.sh/). Follow the official instructions.
 
 Open **Terminal** and prepare to enter commands.
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/macos) for macOS to install **rgbds 0.4.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/macos) for macOS to install **rgbds 0.4.2**.
 
 Now you're ready to [build **pokecrystal**](#build-pokecrystal).
 
@@ -84,7 +84,7 @@ To install the software required for **pokecrystal**:
 sudo apt-get install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.2** from source.
 
 ### OpenSUSE
 
@@ -94,7 +94,7 @@ To install the software required for **pokecrystal**:
 sudo zypper install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.2** from source.
 
 ### Arch Linux
 
@@ -104,9 +104,9 @@ To install the software required for **pokecrystal**:
 sudo pacman -S make gcc git rgbds
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/arch) for Arch Linux to install **rgbds 0.4.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/arch) for Arch Linux to install **rgbds 0.4.2**.
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.2** from source.
 
 ### Termux
 
@@ -122,7 +122,7 @@ To install **rgbds**:
 sudo apt install rgbds
 ```
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.2** from source.
 
 ### Other distros
 
@@ -133,7 +133,7 @@ If your distro is not listed here, try to find the required software in its repo
 - `git`
 - `rgbds`
 
-If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.1** from source.
+If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install/source) to build **rgbds 0.4.2** from source.
 
 Now you're ready to [build **pokecrystal**](#build-pokecrystal).
 

--- a/macros/code.asm
+++ b/macros/code.asm
@@ -11,11 +11,7 @@ ENDM
 ; Design patterns
 
 jumptable: MACRO
-if !STRCMP("\2", "hl")
-	ld a, [hl]
-else
 	ld a, [\2]
-endc
 	ld e, a
 	ld d, 0
 	ld hl, \1


### PR DESCRIPTION
This allows `[\1]` to work when `\1` is `hl`, `bc`, or `de`

The object file format has changed along with the version number

~~@mid-kid Can you take a look at why `tools/unnamed.py -r . pokecrystal.sym` fails with rgbds 0.4.2?~~ Never mind, I found https://rgbds.gbdev.io/docs/v0.4.2/rgbds.5