### PR TITLE
Document fix for StatUpHit effects when opponent is KO'd

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -767,53 +767,44 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
 
 ### Moves that do damage and increase your stats do not increase stats after a KO
 
-The `checkfaint` routine skips the stats increasing effects if the opponent is KO'd, unlike in modern pokemon games.  Note that this can lead to stats being increased at the end of battle, but will not have any negative effects.
+`BattleCommand_CheckFaint` "ends the move effect if the opponent faints", and these moves attempt to raise the user's stats *after* `checkfaint`. Note that fixing this can lead to stats being increased at the end of battle, but will not have any negative effects.
 
-**Fix:** Make the following changes in [data/moves/effects.asm](https://github.com/pret/pokecrystal/blob/master/data/moves/effects.asm)
+**Fix:** Edit [data/moves/effects.asm](https://github.com/pret/pokecrystal/blob/master/data/moves/effects.asm):
 
 ```diff
  DefenseUpHit:
-  checkobedience
-  usedmovetext
-  doturn
-  ...
-  criticaltext
-  supereffectivetext
-+ defenseup
-  checkfaint
-  buildopponentrage
-- defenseup
-  statupmessage
-  endmove
-
+ 	...
+ 	criticaltext
+ 	supereffectivetext
++	defenseup
+ 	checkfaint
+ 	buildopponentrage
+-	defenseup
+ 	statupmessage
+ 	endmove
 
  AttackUpHit:
-  checkobedience
-  usedmovetext
-  doturn
-  ...
-  criticaltext
-  supereffectivetext
-+ attackup
-  checkfaint
-  buildopponentrage
-- attackup
-  statupmessage
-  endmove
+ 	...
+ 	criticaltext
+ 	supereffectivetext
++	attackup
+ 	checkfaint
+ 	buildopponentrage
+-	attackup
+ 	statupmessage
+ 	endmove
 
  AllUpHit:
-  checkobedience
-  usedmovetext
-  doturn
-  ...
-  criticaltext
-  supereffectivetext
-+ allstatsup
-  checkfaint
-  buildopponentrage
-- allstatsup
-  endmove
+ 	...
+ 	criticaltext
+ 	supereffectivetext
++	allstatsup
+ 	checkfaint
+ 	buildopponentrage
+-	allstatsup
+ 	endmove
 ```
+
 
 ## Single-player battle engine
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -37,6 +37,7 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
   - [Dragon Scale, not Dragon Fang, boosts Dragon-type moves](#dragon-scale-not-dragon-fang-boosts-dragon-type-moves)
   - [HP bar animation is slow for high HP](#hp-bar-animation-is-slow-for-high-hp)
   - [HP bar animation off-by-one error for low HP](#hp-bar-animation-off-by-one-error-for-low-hp)
+  - [Moves that do damage and increase your stats do not increase stats after a KO](#moves-that-do-damage-and-increase-your-stats-do-not-increase-stats-after-a-ko)
 - [Single-player battle engine](#single-player-battle-engine)
   - [A Transformed Pokémon can use Sketch and learn otherwise unobtainable moves](#a-transformed-pokémon-can-use-sketch-and-learn-otherwise-unobtainable-moves)
   - [Catching a Transformed Pokémon always catches a Ditto](#catching-a-transformed-pokémon-always-catches-a-ditto)
@@ -764,6 +765,82 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	jr .loop
 ```
 
+### Moves that do damage and increase your stats do not increase stats after a KO
+
+The `checkfaint` routine skips the stats increasing effects if the opponent is KO'd, unlike in modern pokemon games.  Note that this can lead to stats being increased at the end of battle, but will not have any negative effects.
+
+**Fix:** Make the following changes in [data/moves/effects.asm](https://github.com/pret/pokecrystal/blob/master/data/moves/effects.asm)
+
+```diff
+ DefenseUpHit:
+  checkobedience
+  usedmovetext
+  doturn
+  critical
+  damagestats
+  damagecalc
+  stab
+  damagevariation
+  checkhit
+  effectchance
+  moveanim
+  failuretext
+  applydamage
+  criticaltext
+  supereffectivetext
++ defenseup
+  checkfaint
+  buildopponentrage
+- defenseup
+  statupmessage
+  endmove
+
+
+ AttackUpHit:
+  checkobedience
+  usedmovetext
+  doturn
+  critical
+  damagestats
+  damagecalc
+  stab
+  damagevariation
+  checkhit
+  effectchance
+  moveanim
+  failuretext
+  applydamage
+  criticaltext
+  supereffectivetext
++ attackup
+  checkfaint
+  buildopponentrage
+- attackup
+  statupmessage
+  endmove
+
+ AllUpHit:
+  checkobedience
+  usedmovetext
+  doturn
+  critical
+  damagestats
+  damagecalc
+  stab
+  damagevariation
+  checkhit
+  effectchance
+  moveanim
+  failuretext
+  applydamage
+  criticaltext
+  supereffectivetext
++ allstatsup
+  checkfaint
+  buildopponentrage
+- allstatsup
+  endmove
+```
 
 ## Single-player battle engine
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -776,16 +776,7 @@ The `checkfaint` routine skips the stats increasing effects if the opponent is K
   checkobedience
   usedmovetext
   doturn
-  critical
-  damagestats
-  damagecalc
-  stab
-  damagevariation
-  checkhit
-  effectchance
-  moveanim
-  failuretext
-  applydamage
+  ...
   criticaltext
   supereffectivetext
 + defenseup
@@ -800,16 +791,7 @@ The `checkfaint` routine skips the stats increasing effects if the opponent is K
   checkobedience
   usedmovetext
   doturn
-  critical
-  damagestats
-  damagecalc
-  stab
-  damagevariation
-  checkhit
-  effectchance
-  moveanim
-  failuretext
-  applydamage
+  ...
   criticaltext
   supereffectivetext
 + attackup
@@ -823,16 +805,7 @@ The `checkfaint` routine skips the stats increasing effects if the opponent is K
   checkobedience
   usedmovetext
   doturn
-  critical
-  damagestats
-  damagecalc
-  stab
-  damagevariation
-  checkhit
-  effectchance
-  moveanim
-  failuretext
-  applydamage
+  ...
   criticaltext
   supereffectivetext
 + allstatsup


### PR DESCRIPTION
As a kid I always wondered if you could increase stats when you KO'd a pokemon with ancientpower, but I was never sure until I was testing around an attacking move that would increase attack 100% of the time.  This fixed the issue.

I'm not sure if this is considered a bug or is just worth a page here https://github.com/pret/pokecrystal/wiki/Tutorials, but in my opinion it feels like it would've been pasted from the StatDownHit moves, which obviously don't need to decrease stats if the opponent is KO'd.