### PR TITLE
move statupmessage above checkfaint in Attack and DefenseUpHit documentation

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -777,10 +777,11 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	criticaltext
  	supereffectivetext
 +	defenseup
++	statupmessage
  	checkfaint
  	buildopponentrage
 -	defenseup
- 	statupmessage
+-	statupmessage
  	endmove
 
  AttackUpHit:
@@ -788,10 +789,11 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	criticaltext
  	supereffectivetext
 +	attackup
++	statupmessage
  	checkfaint
  	buildopponentrage
 -	attackup
- 	statupmessage
+-	statupmessage
  	endmove
 
  AllUpHit:


### PR DESCRIPTION
I missed moving the statupmessage in https://github.com/pret/pokecrystal/pull/792 :facepalm: 

the `AllUpHit` function does not have this (all of the messages are done as part of `allstatsup`)