### PR TITLE
Fix typo

### DIFF
--- a/constants/scgb_constants.asm
+++ b/constants/scgb_constants.asm
@@ -144,7 +144,7 @@ SCGB_DEFAULT EQU $ff
 	const SGB_ICON_EN
 	const SGB_DATA_SND
 	const SGB_DATA_TRN
-	const SGB_MLT_REG
+	const SGB_MLT_REQ
 	const SGB_JUMP
 	const SGB_CHR_TRN
 	const SGB_PCT_TRN

--- a/data/sgb_ctrl_packets.asm
+++ b/data/sgb_ctrl_packets.asm
@@ -8,7 +8,7 @@ sgb_pal_trn: MACRO
 ENDM
 
 sgb_mlt_req: MACRO
-	db (SGB_MLT_REG << 3) + 1
+	db (SGB_MLT_REQ << 3) + 1
 	db \1 - 1
 	ds 14
 ENDM


### PR DESCRIPTION
This fixes a typo on the SGB command constant name MLT_REQ.