### PR TITLE
Fix assert off-by-one error

### DIFF
--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -50,7 +50,7 @@ FIRST_MUSIC_CMD EQU const_value
 
 	const octave_cmd ; $d0
 octave: MACRO
-	assert 0 < (\1) && (\1) < 8, "octave must be 1-8"
+	assert 0 < (\1) && (\1) <= 8, "octave must be 1-8"
 	db octave_cmd | 8 - (\1) ; octave
 ENDM
 


### PR DESCRIPTION
This was preventing pokered's Lavender theme from being added to pokecrystal.