### PR TITLE
WRAM padding

### DIFF
--- a/layout.link
+++ b/layout.link
@@ -311,6 +311,7 @@ WRAM0
 	"Stack"
 	"Audio RAM"
 	"WRAM"
+	align 8
 	"wSpriteAnims"
 	align 8
 	"Sprites"
@@ -318,6 +319,7 @@ WRAM0
 	"Miscellaneous"
 	align 8
 	"Overworld Map"
+	align 4
 	"Video"
 WRAMX 1
 	"WRAM 1"

--- a/wram.asm
+++ b/wram.asm
@@ -211,7 +211,6 @@ wTilePermissions::
 	db
 
 
-
 SECTION "wSpriteAnims", WRAM0
 
 UNION

--- a/wram.asm
+++ b/wram.asm
@@ -210,7 +210,6 @@ wTilePermissions::
 ; bit 0: right
 	db
 
-	ds 1
 
 
 SECTION "wSpriteAnims", WRAM0
@@ -1222,8 +1221,6 @@ ENDU
 endc
 
 ENDU
-
-	ds 12
 
 
 SECTION "Video", WRAM0


### PR DESCRIPTION
Empty space should be left unallocated.