### PR TITLE
Correctly fix faulty Full Heal of the AI

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1209,10 +1209,9 @@ As Pryce's dialog ("That BADGE will raise the SPECIAL stats of POKéMON.") impli
  EnemyUsedFullHeal:
  	call AIUsedItemSound
  	call AI_HealStatus
- 	ld a, FULL_HEAL
-+	ld [wCurEnemyItem], a
 +	xor a
 +	ld [wEnemyConfuseCount], a
+ 	ld a, FULL_HEAL
  	jp PrintText_UsedItemOn_AND_AIUpdateHUD
 ```
 


### PR DESCRIPTION
The fix for "AI use of Full Heal does not cure confusion status" worked to cure confusion, but it set `a` to 0 when `jp PrintText_UsedItemOn_AND_AIUpdateHUD` needs it to be set to `FULL_HEAL`, as it is just before. 
It also added a useless `ld a, [wCurPartyItem]` since `PrintText_UsedItemOn_AND_AIUpdateHUD` already does it.