### PR TITLE
"POKé" > "Poké"

### DIFF
--- a/charmap.asm
+++ b/charmap.asm
@@ -23,7 +23,7 @@
 	charmap "<PARA>",    $51
 	charmap "<PLAYER>",  $52 ; wPlayerName
 	charmap "<RIVAL>",   $53 ; wRivalName
-	charmap "#",         $54 ; "POKé"
+	charmap "#",         $54 ; "Poké"
 	charmap "<CONT>",    $55
 	charmap "<……>",      $56 ; "……"
 	charmap "<DONE>",    $57


### PR DESCRIPTION
Lowercasing the # charmap to fit along the rest of the lowercasing.