### PR TITLE
Label wram variables for in home/mobile and lib/mobile

### DIFF
--- a/home/mobile.asm
+++ b/home/mobile.asm
@@ -1,66 +1,66 @@
 Function3e32::
 ; Mobile
 	cp $2
-	ld [$c988], a
+	ld [wc988], a
 	ld a, l
-	ld [$c986], a
+	ld [wc986], a
 	ld a, h
-	ld [$c987], a
+	ld [wc987], a
 	jr nz, .okay
 
-	ld [$c982], a
+	ld [wc982], a
 	ld a, l
-	ld [$c981], a
-	ld hl, $c983
+	ld [wc981], a
+	ld hl, wc983
 	ld a, c
 	ld [hli], a
 	ld a, b
 	ld [hl], a
 
 .okay
-	ld hl, $c822
+	ld hl, wc822
 	set 6, [hl]
 	ldh a, [hROMBank]
 	push af
 	ld a, BANK(Function110030)
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
 	jp Function110030
 
 Function3e60::
 ; Return from Function110030
-	ld [$c986], a
+	ld [wc986], a
 	ld a, l
-	ld [$c987], a
+	ld [wc987], a
 	ld a, h
-	ld [$c988], a
+	ld [wc988], a
 
 	pop bc
 	ld a, b
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
-	ld hl, $c822
+	ld hl, wc822
 	res 6, [hl]
-	ld hl, $c987
+	ld hl, wc987
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$c986]
+	ld a, [wc986]
 	ret
 
 MobileReceive::
 	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_MobileReceive)
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
 	call _MobileReceive
 	pop bc
 	ld a, b
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
 	ret
@@ -83,11 +83,11 @@ MobileTimer::
 	and 1 << VBLANK | 1 << LCD_STAT | 1 << SERIAL | 1 << JOYPAD
 	ldh [rIF], a
 
-	ld a, [$c86a]
+	ld a, [wc86a]
 	or a
 	jr z, .pop_ret
 
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 1, a
 	jr nz, .skip_timer
 
@@ -98,14 +98,14 @@ MobileTimer::
 	ldh a, [hROMBank]
 	push af
 	ld a, BANK(_Timer)
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
 	call _Timer
 
 	pop bc
 	ld a, b
-	ld [$c981], a
+	ld [wc981], a
 	rst Bankswitch
 
 .skip_timer

--- a/lib/mobile/main.asm
+++ b/lib/mobile/main.asm
@@ -89,12 +89,12 @@ ResetReceivePacketBuffer:
 	ret
 
 Function110030::
-; Use the byte at $c988 as a parameter
+; Use the byte at wc988 as a parameter
 ; for a dw.
-; If [$c988] not in {12, 14, 16},
-; clear [$c835].
+; If [wc988] not in {12, 14, 16},
+; clear [wc835].
 	push de
-	ld a, [$c988]
+	ld a, [wc988]
 	cp $0c
 	jr z, .noreset
 	cp $0e
@@ -102,17 +102,17 @@ Function110030::
 	cp $10
 	jr z, .noreset
 	xor a
-	ld [$c835], a
-	ld a, [$c988]
+	ld [wc835], a
+	ld a, [wc988]
 .noreset
 	; Get the pointer
 	ld d, 0
 	ld e, a
 	ld hl, .dw
 	add hl, de
-	; Store the low byte in [$c988]
+	; Store the low byte in [wc988]
 	ld a, [hli]
-	ld [$c988], a
+	ld [wc988], a
 	ld a, [hl]
 	; restore de
 	pop de
@@ -121,7 +121,7 @@ Function110030::
 	; If the destination function is not Function110236,
 	; call Function1100b4.
 	ld h, a
-	ld a, [$c988]
+	ld a, [wc988]
 	ld l, a
 	push hl
 	ld a, LOW(Function110236)
@@ -131,7 +131,7 @@ Function110030::
 	cp h
 .okay
 	call nz, Function1100b4
-	ld hl, $c986
+	ld hl, wc986
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -177,11 +177,11 @@ Function1100b4:
 	push bc
 .loop
 	di
-	ld a, [$c800]
+	ld a, [wc800]
 	ld b, a
-	ld a, [$c80b]
+	ld a, [wc80b]
 	ld c, a
-	ld a, [$c822]
+	ld a, [wc822]
 	ei
 	or a
 	bit 0, a
@@ -193,8 +193,8 @@ Function1100b4:
 	cp $4
 	jr z, .loop
 	xor a
-	ld [$c80f], a
-	ld hl, $c821
+	ld [wc80f], a
+	ld hl, wc821
 	set 1, [hl]
 	scf
 .done
@@ -226,11 +226,11 @@ Function1100dc:
 	ldh [rTMA], a
 	ldh [rTIMA], a
 	ld a, [hli]
-	ld [$c81f], a
-	ld [$c816], a
+	ld [wc81f], a
+	ld [wc816], a
 	ld a, [hl]
-	ld [$c820], a
-	ld [$c815], a
+	ld [wc820], a
+	ld [wc815], a
 	ld c, $7
 	ld a, $2
 	ldh [c], a
@@ -239,7 +239,7 @@ Function1100dc:
 	ret
 
 Function110115:
-	ld hl, $c821
+	ld hl, wc821
 	bit 1, [hl]
 	jr nz, .asm_110120
 	xor a
@@ -249,7 +249,7 @@ Function110115:
 
 .asm_110120
 	res 1, [hl]
-	ld a, [$c80f]
+	ld a, [wc80f]
 	ld e, a
 	cp $22
 	jr z, .asm_11016a
@@ -286,19 +286,19 @@ Function110115:
 	add $15
 	ld e, a
 	xor a
-	ld hl, $c810
+	ld hl, wc810
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 
 .asm_11016a
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld [hl], a
-	ld [$c807], a
+	ld [wc807], a
 	inc a
-	ld [$c86a], a
-	ld hl, $c822
+	ld [wc86a], a
+	ld hl, wc822
 	res 0, [hl]
 	res 5, [hl]
 	ld hl, wMobileSDK_PacketBuffer
@@ -313,31 +313,31 @@ Function110115:
 	jr .asm_1101d7
 
 .asm_11018e
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 4, a
 	ld a, $1
 	jr z, .asm_11016a
 	ld a, $2
-	ld [$c86a], a
-	ld a, [$c805]
-	ld [$c807], a
+	ld [wc86a], a
+	ld a, [wc805]
+	ld [wc807], a
 	jr .asm_110158
 
 .asm_1101a4
 	res 0, [hl]
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	res 7, [hl]
 	res 6, [hl]
 	set 5, [hl]
 	xor a
-	ld [$c86d], a
-	ld [$c9af], a
+	ld [wc86d], a
+	ld [wc9af], a
 	ld a, $2
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, $4
-	ld [$c807], a
+	ld [wc807], a
 	ld a, e
 	cp $32
 	jr z, .asm_1101d7
@@ -349,7 +349,7 @@ Function110115:
 	jp nz, .asm_110158
 
 .asm_1101d7
-	ld hl, $c810
+	ld hl, wc810
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -367,7 +367,7 @@ Function110115:
 	jp nz, .asm_11015b
 
 .asm_1101f2
-	ld bc, $c880
+	ld bc, wc880
 	jp .asm_11015b
 
 .asm_1101f8
@@ -375,22 +375,22 @@ Function110115:
 	cp $a4
 	jr z, .asm_1101a4
 	ld a, $3
-	ld [$c86a], a
-	ld hl, $c810
+	ld [wc86a], a
+	ld hl, wc810
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	jp .asm_11015b
 
 .asm_11020d
-	ld a, [$c810]
+	ld a, [wc810]
 	cp $2
 	jr z, .asm_1101a4
 	cp $3
 	jr z, .asm_1101a4
 	ld a, $4
-	ld [$c86a], a
-	ld hl, $c810
+	ld [wc86a], a
+	ld hl, wc810
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -400,8 +400,8 @@ Function110226:
 	ld a, $21
 
 Function110228:
-	ld [$c80f], a
-	ld hl, $c821
+	ld [wc80f], a
+	ld hl, wc821
 	set 1, [hl]
 	ret
 
@@ -413,7 +413,7 @@ Function110235:
 	nop
 
 Function110236:
-	ld a, [$c988]
+	ld a, [wc988]
 	push af
 	push bc
 	push hl
@@ -424,7 +424,7 @@ Function110236:
 	ldh [rIF], a
 	call ResetReceivePacketBuffer
 	ld bc, $0452
-	ld hl, $c800
+	ld hl, wc800
 .asm_11024e
 	xor a
 	ld [hli], a
@@ -432,26 +432,26 @@ Function110236:
 	ld a, c
 	or b
 	jr nz, .asm_11024e
-	ld a, [$c822]
+	ld a, [wc822]
 	set 6, a
-	ld [$c822], a
+	ld [wc822], a
 	pop hl
 	ld a, l
-	ld [$c981], a
+	ld [wc981], a
 	ld a, h
-	ld [$c982], a
+	ld [wc982], a
 	pop bc
-	ld hl, $c983
+	ld hl, wc983
 	ld a, c
 	ld [hli], a
 	ld a, b
 	ld [hl], a
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, e
 	ld [hli], a
 	ld [hl], d
 	xor a
-	ld [$c819], a
+	ld [wc819], a
 	ld c, $c
 	call Function1100dc
 	call Function1104b0
@@ -465,24 +465,24 @@ Function110236:
 	ld a, $a
 
 .asm_11028b
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110291:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 1, a
 	jr z, .asm_1102a6
-	ld a, [$c80f]
+	ld a, [wc80f]
 	cp $14
 	jr z, .asm_1102b3
 	cp $25
 	jr z, .asm_1102b3
-	ld a, [$c821]
+	ld a, [wc821]
 
 .asm_1102a6
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 
@@ -490,10 +490,10 @@ Function110291:
 	xor a
 	ldh [rTAC], a
 	xor a
-	ld [$c819], a
+	ld [wc819], a
 	ld a, l
 	ld b, h
-	ld hl, $c880
+	ld hl, wc880
 	ld [hli], a
 	ld a, b
 	ld [hli], a
@@ -503,10 +503,10 @@ Function110291:
 	ld [hli], a
 	ld a, d
 	ld [hl], a
-	ld a, [$c870]
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $72
 	ld [hli], a
 	ld a, $c8
@@ -515,7 +515,7 @@ Function110291:
 	ld b, MobilePacket_WriteConfigurationData.End - MobilePacket_WriteConfigurationData
 	ld hl, MobilePacket_WriteConfigurationData
 	call MobileSDK_CopyBytes
-	ld a, [$c882]
+	ld a, [wc882]
 	ld c, a
 	or a
 	jr z, .asm_1102f2
@@ -534,47 +534,47 @@ Function110291:
 	inc de
 	ld a, $80
 	add c
-	ld hl, $c882
+	ld hl, wc882
 	ld [hli], a
 	ld a, [hl]
 	ld [de], a
 	inc de
 	add $80
 	ld [hl], a
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	ld c, b
 	call MobileSDK_CopyBytes
 	ld a, l
-	ld [$c880], a
+	ld [wc880], a
 	ld a, h
-	ld [$c881], a
+	ld [wc881], a
 	ld b, c
 	inc b
 	call Function111f63
 	call Function1104b0
 	ld a, $2e
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 1, [hl]
 	set 0, [hl]
 	ret
 
 Function11032c:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 1, a
 	jp nz, Function110226
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 	xor a
 	ldh [rTAC], a
-	ld [$c819], a
-	ld hl, $c880
+	ld [wc819], a
+	ld hl, wc880
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -583,22 +583,22 @@ Function11032c:
 	ld [hli], a
 	ld a, b
 	ld [hli], a
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hl], a
-	ld a, [$c870]
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
 	ld de, wMobileSDK_PacketBuffer
 	ld b, 6 ; header size
 	ld hl, MobilePacket_ReadConfigurationDataPart1
 	call MobileSDK_CopyBytes
-	ld a, [$c883]
+	ld a, [wc883]
 	ld [de], a
 	inc de
-	ld a, [$c882]
+	ld a, [wc882]
 	ld c, a
 	or a
 	jr z, .asm_11037f
@@ -617,7 +617,7 @@ Function11032c:
 	call Function111f63
 	call Function1104b0
 	ld a, $2d
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110393:
@@ -648,10 +648,10 @@ Function11039a:
 	ret
 
 Function1103ac:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 	push hl
@@ -672,12 +672,12 @@ Function1103ac:
 .asm_1103d6
 	xor a
 	ldh [rTAC], a
-	ld [$c86d], a
-	ld [$c97a], a
-	ld a, [$c870]
+	ld [wc86d], a
+	ld [wc97a], a
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $80
 	ld [hli], a
 	ld a, $c8
@@ -688,7 +688,7 @@ Function1103ac:
 	call Function111f63
 	ld b, MobilePacket_ISPLogin.End - MobilePacket_ISPLogin
 	ld hl, MobilePacket_ISPLogin
-	ld de, $cb74
+	ld de, wMobileSDK_PacketBuffer + 45
 	call MobileSDK_CopyBytes
 	inc de
 	inc de
@@ -696,8 +696,8 @@ Function1103ac:
 	ld bc, 0
 	call MobileSDK_CopyString
 	ld a, c
-	ld [$cb7a], a
-	ld [$c86b], a
+	ld [wMobileSDK_PacketBuffer + 51], a
+	ld [wc86b], a
 	push de
 	inc de
 	ld bc, 0
@@ -708,24 +708,24 @@ Function1103ac:
 	pop de
 	ld a, c
 	ld [de], a
-	ld a, [$c86b]
+	ld a, [wc86b]
 	add c
 	add $a
-	ld [$cb79], a
+	ld [wMobileSDK_PacketBuffer + 50], a
 	call Function1104b0
 	ld a, $b
-	ld [$c86a], a
+	ld [wc86a], a
 
 Function110432:
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	ret
 
 Function110438:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 	push hl
@@ -738,11 +738,11 @@ Function110438:
 .asm_110454
 	xor a
 	ldh [rTAC], a
-	ld [$c97a], a
-	ld a, [$c870]
+	ld [wc97a], a
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
-	ld hl, $c98f
+	ld hl, wc98f
 	ld a, $81
 	ld [hli], a
 	ld a, $c8
@@ -753,13 +753,13 @@ Function110438:
 	ld [hli], a
 	ld [hl], a
 	ld a, $ff
-	ld [$c86e], a
+	ld [wc86e], a
 	call Function110485
 	ld b, a
 	call Function111f63
 	call Function1104b0
 	ld a, $c
-	ld [$c86a], a
+	ld [wc86a], a
 	jr Function110432
 
 Function110485:
@@ -777,7 +777,7 @@ Function110485:
 	jr .asm_1104a1
 
 .asm_11049e
-	ld a, [$c871]
+	ld a, [wc871]
 
 .asm_1104a1
 	ld [de], a
@@ -794,28 +794,28 @@ Function1104b0:
 	ld [wMobileSDK_SendCommandID], a
 	call Function110393
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, MobilePacket_Idle.End - MobilePacket_Idle
 	ld hl, MobilePacket_Idle
 	ld b, 1
 	jp PacketSendBytes
 
 Function1104c6:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jr z, .asm_110526
 	cp $3
 	jr z, .asm_110526
 	cp $2
 	jp nz, Function110226
-	ld hl, $c822
+	ld hl, wc822
 	bit 4, [hl]
 	jr nz, .asm_110507
 	ld a, $2
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, MOBILE_COMMAND_ISP_LOGOUT | $80
 	ld [wMobileSDK_SendCommandID], a
 	ld de, MobilePacket_ISPLogout.End - MobilePacket_ISPLogout
@@ -824,21 +824,21 @@ Function1104c6:
 	call PacketSendBytes
 .asm_1104fa
 	ld a, $e
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	set 0, [hl]
 	res 3, [hl]
 	ret
 
 .asm_110507
-	ld a, [$c807]
+	ld a, [wc807]
 	or a
 	jr nz, .asm_11051f
 	ld a, $1
-	ld [$c86a], a
-	ld hl, $c822
+	ld [wc86a], a
+	ld hl, wc822
 	res 4, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	and $17
 	ld [hl], a
@@ -846,18 +846,18 @@ Function1104c6:
 
 .asm_11051f
 	ld a, $2
-	ld [$c86b], a
+	ld [wc86b], a
 	jr .asm_1104fa
 
 .asm_110526
 	call Function112724
 	xor a
-	ld [$c86b], a
-	ld de, $cb67
+	ld [wc86b], a
+	ld de, wMobileSDK_PacketBuffer + 32
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
@@ -869,7 +869,7 @@ Function1104c6:
 	ld a, $7
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
@@ -883,7 +883,7 @@ Function1104c6:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $e
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110578:
@@ -908,36 +908,36 @@ Function11058c:
 	ret
 
 Function110596:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jr nz, .asm_1105d9
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jr nz, .asm_1105d9
-	ld a, [$c835]
+	ld a, [wc835]
 	or a
 	ret nz
 	ld a, b
-	ld [$cb36], a
+	ld [wcb36], a
 	xor a
 	ldh [rTAC], a
 	ld a, e
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, d
-	ld [$c86f], a
+	ld [wc86f], a
 	xor a
-	ld [$c819], a
-	ld a, [$c870]
+	ld [wc819], a
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $80
 	ld [hli], a
 	ld a, $c8
 	ld [hl], a
 	call Function1104b0
-	ld a, [$cb36]
-	ld [$c86a], a
+	ld a, [wcb36]
+	ld [wc86a], a
 	xor a
 	jp Function110432
 
@@ -946,18 +946,18 @@ Function110596:
 	jp Function110226
 
 Function1105dd:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 	xor a
 	ldh [rTAC], a
-	ld a, [$c870]
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
-	ld hl, $c98f
+	ld hl, wc98f
 	ld a, $81
 	ld [hli], a
 	ld a, $c8
@@ -968,15 +968,15 @@ Function1105dd:
 	ld [hli], a
 	ld [hl], a
 	ld a, $ff
-	ld [$c86e], a
+	ld [wc86e], a
 	call Function1104b0
 	ld a, $d
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110615:
 	ld b, $15
-	ld [$c86e], a
+	ld [wc86e], a
 	or a
 	jr z, .asm_110625
 	dec a
@@ -987,27 +987,27 @@ Function110615:
 
 .asm_110625
 	ld a, $19
-	ld hl, $c83e
+	ld hl, wc83e
 	jr .asm_110631
 
 .asm_11062c
 	ld a, $6e
-	ld hl, $c852
+	ld hl, wc852
 
 .asm_110631
 	push hl
 	push bc
-	ld [$cba2], a
-	ld hl, $c829
+	ld [wMobileSDK_PacketBuffer + 91], a
+	ld hl, wc829
 	ld a, $9d
 	ld [hli], a
 	ld a, $cb
 	ld [hl], a
 	xor a
-	ld [$cba1], a
-	ld [$c86b], a
-	ld [$c9af], a
-	ld de, $cb97
+	ld [wMobileSDK_PacketBuffer + 90], a
+	ld [wc86b], a
+	ld [wc9af], a
+	ld de, wMobileSDK_PacketBuffer + 80
 	ld hl, MobilePacket_OpenTCPConnection
 	ld b, MobilePacket_OpenTCPConnection.End - MobilePacket_OpenTCPConnection
 	call MobileSDK_CopyBytes
@@ -1027,13 +1027,13 @@ Function110615:
 	ld [hl], a
 	ld b, c
 	call Function111f63
-	ld a, [$c86e]
+	ld a, [wc86e]
 	cp $2
 	jr nz, .asm_1106ac
-	ld a, [$cabc]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 128]
 	or a
 	jr z, .asm_1106ac
-	ld hl, $c995
+	ld hl, wc995
 	ld a, [hli]
 	cp $99
 	jr nz, .asm_1106ac
@@ -1044,15 +1044,15 @@ Function110615:
 	cp $23
 	jr nz, .asm_1106ac
 	ld a, $2
-	ld [$c86e], a
+	ld [wc86e], a
 	dec a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, $a3
 	ld de, $0010
-	ld hl, $c995
+	ld hl, wc995
 	call Function111f02
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 .asm_1106ac
@@ -1062,18 +1062,18 @@ Function110615:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 .asm_1106c1
 	ld b, $50
-	ld hl, $c876
+	ld hl, wc876
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	ld de, $0007
 	add hl, de
-	ld de, $c8ff
+	ld de, wc8ff
 .asm_1106d0
 	ld a, [hli]
 	ld [de], a
@@ -1088,22 +1088,22 @@ Function110615:
 	ld [de], a
 	dec hl
 	ld a, l
-	ld [$c876], a
+	ld [wc876], a
 	ld a, h
-	ld [$c877], a
-	ld hl, $c8ff
+	ld [wc877], a
+	ld hl, wc8ff
 	ld a, $50
 	ld b, $40
 	jp .asm_110631
 
 Function1106ef:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $2
 	jp nz, Function110226
-	ld a, [$c86d]
+	ld a, [wc86d]
 	or a
 	jp nz, Function110226
 	push hl
@@ -1115,12 +1115,12 @@ Function1106ef:
 
 .asm_110712
 	xor a
-	ld [$c86b], a
-	ld de, $cba7
+	ld [wc86b], a
+	ld de, wMobileSDK_PacketBuffer + 96
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld de, $cbb7
+	ld de, wMobileSDK_PacketBuffer + 112
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
@@ -1144,7 +1144,7 @@ Function1106ef:
 	ld a, c
 	add b
 	add $2
-	ld [$cbbc], a
+	ld [wMobileSDK_PacketBuffer + 117], a
 	pop hl
 	call MobileSDK_CopyBytes
 	call Function11295e
@@ -1152,13 +1152,13 @@ Function1106ef:
 	jp Function110615
 
 Function110757:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $3
 	jp nz, Function110226
-	ld a, [$c98a]
+	ld a, [wc98a]
 	or a
 	jp nz, Function110226
 	push hl
@@ -1183,26 +1183,26 @@ Function110757:
 	jr nz, .asm_110781
 	call Function112724
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
-	ld de, $cb53
+	ld de, wMobileSDK_PacketBuffer + 12
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
-	ld de, $cb59
-	ld a, [$c86c]
+	ld de, wMobileSDK_PacketBuffer + 18
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
-	ld de, $cb5a
+	ld de, wMobileSDK_PacketBuffer + 19
 	ld hl, Unknown_1120a4
 	call MobileSDK_CopyString
 	pop hl
@@ -1212,23 +1212,23 @@ Function110757:
 	inc de
 	inc c
 	ld a, l
-	ld [$c87c], a
+	ld [wc87c], a
 	ld a, h
-	ld [$c87d], a
+	ld [wc87d], a
 	call Function11295e
 	ld a, c
-	ld [$cb58], a
+	ld [wMobileSDK_PacketBuffer + 17], a
 	ld b, c
 	call Function111f63
 	ld a, MOBILE_COMMAND_TRANSFER_DATA | $80
 	ld [wMobileSDK_SendCommandID], a
-	ld hl, $cb53
+	ld hl, wMobileSDK_PacketBuffer + 12
 	ld d, $0
 	ld e, c
 	ld b, $5
 	call PacketSendBytes
 	ld a, $15
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 .asm_1107fb
@@ -1236,99 +1236,99 @@ Function110757:
 	jp Function110231
 
 Function1107ff:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $3
 	jp nz, Function110226
-	ld a, [$c98a]
+	ld a, [wc98a]
 	or a
 	jp z, Function110226
 	ld a, c
 	or b
 	jp z, Function110231
 	ld a, l
-	ld [$c87c], a
+	ld [wc87c], a
 	ld a, h
-	ld [$c87d], a
-	ld hl, $c87e
+	ld [wc87d], a
+	ld hl, wc87e
 	ld a, c
 	ld [hli], a
 	ld a, b
 	ld [hli], a
 	ld a, d
-	ld [$c86f], a
+	ld [wc86f], a
 	call Function112724
-	ld hl, $c98a
+	ld hl, wc98a
 	ld a, [hl]
 	and $1
 	xor $1
-	ld [$c86b], a
+	ld [wc86b], a
 	inc [hl]
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld de, $cb4d
-	ld a, [$c86c]
+	ld de, wMobileSDK_PacketBuffer + 6
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
-	ld de, $cbdd
+	ld de, wMobileSDK_PacketBuffer + 150
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
-	ld de, $cbe3
-	ld a, [$c86c]
+	ld de, wMobileSDK_PacketBuffer + 156
+	ld a, [wc86c]
 	ld [de], a
-	ld a, [$c86b]
+	ld a, [wc86b]
 	or a
 	jr nz, .asm_110891
 	ld bc, $0001
-	ld de, $cbe4
+	ld de, wMobileSDK_PacketBuffer + 157
 	ld hl, Unknown_1120ba
 	call MobileSDK_CopyString
 	ld a, c
-	ld [$cbe2], a
+	ld [wMobileSDK_PacketBuffer + 155], a
 	ld b, c
 	call Function111f63
 	ld a, MOBILE_COMMAND_TRANSFER_DATA | $80
 	ld [wMobileSDK_SendCommandID], a
 	ld de, $0011
-	ld hl, $cbdd
+	ld hl, wMobileSDK_PacketBuffer + 150
 	ld b, $5
 	call PacketSendBytes
 
 .asm_110891
 	ld a, $16
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110899:
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $3
 	jp nz, Function110226
 	jr Function1108ab
 
 Function1108a3:
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 
 Function1108ab:
-	ld hl, $c821
+	ld hl, wc821
 	bit 0, [hl]
 	jp nz, Function110226
 	call Function112724
 	xor a
-	ld [$c86b], a
-	ld de, $cb67
+	ld [wc86b], a
+	ld de, wMobileSDK_PacketBuffer + 32
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
@@ -1340,7 +1340,7 @@ Function1108ab:
 	ld a, $7
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
@@ -1354,21 +1354,21 @@ Function1108ab:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $17
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110905:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $2
 	jp nz, Function110226
-	ld a, [$c86d]
+	ld a, [wc86d]
 	or a
 	jp nz, Function110226
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	push hl
 	ld c, $20
 	call Function11039a
@@ -1382,7 +1382,7 @@ Function110905:
 	jp Function110231
 
 .asm_110933
-	ld de, $cba7
+	ld de, wMobileSDK_PacketBuffer + 96
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
@@ -1405,9 +1405,9 @@ Function110905:
 	ld a, b
 	add $6
 	ld c, a
-	ld [$cbac], a
+	ld [wMobileSDK_PacketBuffer + 101], a
 	pop hl
-	ld de, $cbb3
+	ld de, wMobileSDK_PacketBuffer + 108
 	call MobileSDK_CopyBytes
 .asm_110961
 	ld a, [hli]
@@ -1415,23 +1415,23 @@ Function110905:
 	jr nz, .asm_110961
 	call Function11295e
 	ld a, c
-	ld [$cbac], a
+	ld [wMobileSDK_PacketBuffer + 101], a
 	ld bc, $0006
-	ld de, $cbf3
+	ld de, wMobileSDK_PacketBuffer + 172
 	ld a, $20
 	call MobileSDK_CopyStringLen
 	call Function11295e
 	ld a, c
-	ld [$cbec], a
-	ld de, $cbe7
+	ld [wMobileSDK_PacketBuffer + 165], a
+	ld de, wMobileSDK_PacketBuffer + 160
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
-	ld de, $cbee
+	ld de, wMobileSDK_PacketBuffer + 167
 	ld hl, Unknown_1120ce
 	ld b, $5
 	call MobileSDK_CopyBytes
-	ld de, $cbc7
+	ld de, wMobileSDK_PacketBuffer + 128
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
@@ -1439,18 +1439,18 @@ Function110905:
 	jp Function110615
 
 Function1109a4:
-	ld hl, $c821
+	ld hl, wc821
 	bit 0, [hl]
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 	ld a, e
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, d
-	ld [$c86f], a
+	ld [wc86f], a
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	call Function112729
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
@@ -1459,7 +1459,7 @@ Function1109a4:
 	ld a, $7
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
@@ -1473,22 +1473,22 @@ Function1109a4:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $18
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function1109f9:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, e
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, d
-	ld [$c86f], a
+	ld [wc86f], a
 	ld a, l
 	or h
 	jp z, Function110231
@@ -1501,13 +1501,13 @@ Function1109f9:
 	ld a, $d
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	ld hl, Unknown_1120db
 	call MobileSDK_CopyString
-	ld de, $cb53
+	ld de, wMobileSDK_PacketBuffer + 12
 	pop hl
 	call Function110d37
 	ld b, c
@@ -1518,14 +1518,14 @@ Function1109f9:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $1d
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110a5b:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
 	jr z, .asm_110a6d
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1a
 	jp nz, Function110226
 	jp Function110af4
@@ -1533,17 +1533,17 @@ Function110a5b:
 .asm_110a6d
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 	ld a, l
 	or h
 	jp z, Function110231
 	ld a, l
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, h
-	ld [$c86f], a
-	ld hl, $c827
+	ld [wc86f], a
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1552,7 +1552,7 @@ Function110a5b:
 	inc de
 	dec bc
 	dec bc
-	ld hl, $c98f
+	ld hl, wc98f
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1561,7 +1561,7 @@ Function110a5b:
 	ld [hli], a
 	ld a, b
 	ld [hl], a
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $80
 	ld [hli], a
 	ld a, $c8
@@ -1574,7 +1574,7 @@ Function110a5b:
 	ld [hli], a
 	ld [hli], a
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
 	ld b, $5
@@ -1582,14 +1582,14 @@ Function110a5b:
 	ld a, $d
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	ld hl, Unknown_1120e8
 	call MobileSDK_CopyString
-	ld de, $cb53
-	ld hl, $c86e
+	ld de, wMobileSDK_PacketBuffer + 12
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -1602,11 +1602,11 @@ Function110a5b:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $1a
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110af4:
-	ld hl, $c827
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1620,22 +1620,22 @@ Function110af4:
 	ld e, [hl]
 	ld a, b
 	or c
-	ld [$c86e], a
-	ld [$c86f], a
+	ld [wc86e], a
+	ld [wc86f], a
 	jr z, .asm_110b5c
 	dec bc
 	dec bc
-	ld a, [$c993]
+	ld a, [wc993]
 	or a
 	jp nz, .asm_110bd5
-	ld a, [$c994]
+	ld a, [wc994]
 	or a
 	jr z, .asm_110b1c
 	ld e, a
 
 .asm_110b1c
 	xor a
-	ld [$c994], a
+	ld [wc994], a
 	cp b
 	jr nz, .asm_110b5c
 	ld a, e
@@ -1645,16 +1645,16 @@ Function110af4:
 	sub c
 	ld [hl], a
 	ld b, c
-	ld hl, $c82d
-	ld a, [$c993]
+	ld hl, wc82d
+	ld a, [wc993]
 	add c
 	ld [hli], a
 	ld a, b
 	adc 0
 	ld [hl], a
 	xor a
-	ld [$c993], a
-	ld hl, $ca3f
+	ld [wc993], a
+	ld hl, wMobileSDK_ReceivePacketBuffer + 3
 	ld a, [hli]
 	inc hl
 	sub e
@@ -1662,13 +1662,13 @@ Function110af4:
 	ld e, a
 	ld d, 0
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
 	pop bc
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -1687,20 +1687,20 @@ Function110af4:
 	ld a, c
 	ld [hli], a
 	ld [hl], b
-	ld hl, $c82d
-	ld a, [$c993]
+	ld hl, wc82d
+	ld a, [wc993]
 	add e
 	ld [hli], a
 	ld a, 0
 	adc 0
 	ld [hl], a
 	xor a
-	ld [$c993], a
-	ld a, [$c86e]
+	ld [wc993], a
+	ld a, [wc86e]
 	or a
 	jr z, .asm_110b9b
 	ld b, e
-	ld hl, $ca3f
+	ld hl, wMobileSDK_ReceivePacketBuffer + 3
 	ld a, [hli]
 	inc hl
 	sub e
@@ -1708,12 +1708,12 @@ Function110af4:
 	ld e, a
 	ld d, 0
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1723,28 +1723,28 @@ Function110af4:
 	call Function1127f3
 	jr z, .asm_110bbb
 	di
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, $000b
 	ld a, MOBILE_COMMAND_TRANSFER_DATA | $80
 	ld [wMobileSDK_SendCommandID], a
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	ld b, $5
 	jp PacketSendBytes
 
 .asm_110bbb
 	ld a, $4
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	res 2, [hl]
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
-	ld hl, $c82d
+	ld hl, wc82d
 	ld b, $2
 	jp MobileSDK_CopyBytes
 
@@ -1757,7 +1757,7 @@ Function110af4:
 	cp c
 	jr c, .asm_110c05
 	ld b, c
-	ld hl, $c993
+	ld hl, wc993
 	ld a, [hl]
 	sub c
 	ld [hl], a
@@ -1765,14 +1765,14 @@ Function110af4:
 	sub e
 	ld e, a
 	ld d, 0
-	ld hl, $c880
+	ld hl, wc880
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -1785,25 +1785,25 @@ Function110af4:
 .asm_110c05
 	push hl
 	push bc
-	ld a, [$c993]
+	ld a, [wc993]
 	ld b, a
 	ld a, $80
 	sub e
 	ld e, a
 	ld d, 0
-	ld hl, $c880
+	ld hl, wc880
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
 	ld a, e
-	ld [$c829], a
+	ld [wc829], a
 	ld a, d
-	ld [$c82a], a
+	ld [wc82a], a
 	pop bc
-	ld a, [$c993]
+	ld a, [wc993]
 	ld e, a
 	ld a, c
 	sub e
@@ -1811,25 +1811,25 @@ Function110af4:
 	ld a, b
 	sbc $0
 	ld b, a
-	ld a, [$c994]
+	ld a, [wc994]
 	ld e, a
 	pop hl
 	jp .asm_110b1c
 
 Function110c3c:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 	ld a, l
 	or h
 	jp z, Function110231
 	ld a, l
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, h
-	ld [$c86f], a
+	ld [wc86f], a
 	call Function112729
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
@@ -1838,14 +1838,14 @@ Function110c3c:
 	ld a, $d
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	ld hl, Unknown_1120f5
 	call MobileSDK_CopyString
-	ld de, $cb53
-	ld hl, $c86e
+	ld de, wMobileSDK_PacketBuffer + 12
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -1858,14 +1858,14 @@ Function110c3c:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $1b
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110c9e:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
 	jr z, .asm_110cb0
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1c
 	jp nz, Function110226
 	jp Function110af4
@@ -1873,17 +1873,17 @@ Function110c9e:
 .asm_110cb0
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $4
 	jp nz, Function110226
 	ld a, l
 	or h
 	jp z, Function110231
 	ld a, l
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, h
-	ld [$c86f], a
-	ld hl, $c827
+	ld [wc86f], a
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1892,7 +1892,7 @@ Function110c9e:
 	inc de
 	dec bc
 	dec bc
-	ld hl, $c98f
+	ld hl, wc98f
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -1901,7 +1901,7 @@ Function110c9e:
 	ld [hli], a
 	ld a, b
 	ld [hl], a
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $80
 	ld [hli], a
 	ld a, $c8
@@ -1914,7 +1914,7 @@ Function110c9e:
 	ld [hli], a
 	ld [hli], a
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
 	ld b, $5
@@ -1922,14 +1922,14 @@ Function110c9e:
 	ld a, $e
 	ld [de], a
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	ld hl, Unknown_112102
 	call MobileSDK_CopyString
-	ld de, $cb52
-	ld hl, $c86e
+	ld de, wMobileSDK_PacketBuffer + 11
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -1942,7 +1942,7 @@ Function110c9e:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $1c
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 Function110d37:
@@ -2056,10 +2056,10 @@ Function110d37:
 	jr z, .done
 	sub b
 	ld c, a
-	ld a, [$cb4c]
+	ld a, [wMobileSDK_PacketBuffer + 5]
 	sub c
 	ld c, a
-	ld [$cb4c], a
+	ld [wMobileSDK_PacketBuffer + 5], a
 	push hl
 	ld b, $1
 .penultimate_loop
@@ -2082,9 +2082,9 @@ Function110d37:
 	ret
 
 Function110ddd:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
-	ld a, [$c86a]
+	ld a, [wc86a]
 	jr z, .asm_110e00
 	cp $13
 	jp z, Function111044
@@ -2106,31 +2106,31 @@ Function110ddd:
 .asm_110e00
 	cp $2
 	jp nz, Function110226
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86d]
+	ld a, [wc86d]
 	or a
 	jp nz, Function110226
 	ld a, l
-	ld [$c9b5], a
+	ld [wc9b5], a
 	ld a, h
-	ld [$c9b6], a
+	ld [wc9b6], a
 	xor a
-	ld [$c989], a
-	ld [$c9a5], a
-	ld [$c98a], a
-	ld [$c993], a
+	ld [wc989], a
+	ld [wc9a5], a
+	ld [wc98a], a
+	ld [wc993], a
 	ld a, [hli]
-	ld [$c833], a
+	ld [wc833], a
 	ld a, [hli]
-	ld [$c834], a
+	ld [wc834], a
 	inc hl
 	inc hl
 	ld a, l
-	ld [$c97f], a
+	ld [wc97f], a
 	ld a, h
-	ld [$c980], a
+	ld [wc980], a
 	dec hl
 	dec hl
 	ld a, [hli]
@@ -2206,7 +2206,7 @@ Function110ddd:
 	jr nz, .asm_110e8f
 	pop hl
 	ld a, $1
-	ld [$c98a], a
+	ld [wc98a], a
 	ld c, $1
 	jr .asm_110eb3
 
@@ -2225,7 +2225,7 @@ Function110ddd:
 	jr nz, .asm_110eaa
 
 .asm_110eb3
-	ld hl, $c97f
+	ld hl, wc97f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2239,8 +2239,8 @@ Function110ddd:
 
 .asm_110ecb
 	ld a, c
-	ld [$c98f], a
-	ld [$cabc], a
+	ld [wc98f], a
+	ld [wMobileSDK_ReceivePacketBuffer + 128], a
 	pop hl
 	call Function1111d7
 	ld a, b
@@ -2252,7 +2252,7 @@ Function110ddd:
 	jp nz, .asm_110dfa
 
 .asm_110ee3
-	ld hl, $c98b
+	ld hl, wc98b
 	xor a
 	ld [hli], a
 	ld [hli], a
@@ -2262,10 +2262,10 @@ Function110ddd:
 	pop de
 	pop hl
 	ld a, l
-	ld [$c876], a
+	ld [wc876], a
 	ld a, h
-	ld [$c877], a
-	ld hl, $c872
+	ld [wc877], a
+	ld hl, wc872
 	ld a, c
 	ld [hli], a
 	ld a, b
@@ -2277,10 +2277,10 @@ Function110ddd:
 	inc hl
 	inc hl
 	xor a
-	ld [$c994], a
+	ld [wc994], a
 
 Function110f07:
-	ld hl, $c833
+	ld hl, wc833
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2290,11 +2290,11 @@ Function110f07:
 	ld [hl], a
 
 .asm_110f12
-	ld hl, $c991
+	ld hl, wc991
 	xor a
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c866
+	ld hl, wc866
 	ld a, [hli]
 	or [hl]
 	inc hl
@@ -2307,28 +2307,28 @@ Function110f07:
 
 .asm_110f28
 	ld a, $2
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, $1f
-	ld [$cb51], a
+	ld [wMobileSDK_PacketBuffer + 10], a
 	ld a, $90
-	ld [$cb52], a
+	ld [wMobileSDK_PacketBuffer + 11], a
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_OpenTCPConnection
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld hl, $c866
+	ld hl, wc866
 	ld b, $4
 	call MobileSDK_CopyBytes
 	inc de
 	inc de
 	ld b, $6
 	call Function111f63
-	ld a, [$cabc]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 128]
 	or a
 	jr z, .asm_110f95
-	ld hl, $c995
+	ld hl, wc995
 	ld a, [hli]
 	cp $99
 	jr nz, .asm_110f8a
@@ -2339,20 +2339,20 @@ Function110f07:
 	cp $23
 	jr nz, .asm_110f8a
 	ld a, $2
-	ld [$c86e], a
+	ld [wc86e], a
 	dec a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, $a3
 	ld de, $0010
-	ld hl, $c995
+	ld hl, wc995
 	call Function111f02
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 .asm_110f8a
 	ld hl, wMobileSDK_PacketBuffer
-	ld de, $c995
+	ld de, wc995
 	ld b, $10
 	call MobileSDK_CopyBytes
 
@@ -2364,7 +2364,7 @@ Function110f07:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 URIPrefix:
@@ -2388,7 +2388,7 @@ HTTPRankingURL:
 .End
 
 Function111044:
-	ld hl, $c827
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -2402,12 +2402,12 @@ Function111044:
 	ld e, [hl]
 	ld a, b
 	or c
-	ld [$c86e], a
-	ld [$c86f], a
+	ld [wc86e], a
+	ld [wc86f], a
 	dec bc
 	dec bc
 	jp z, Function1111ca
-	ld a, [$c991]
+	ld a, [wc991]
 	or a
 	call nz, Function11115f
 	xor a
@@ -2423,12 +2423,12 @@ Function111044:
 	sub c
 	ld [hl], a
 	ld b, c
-	ld hl, $c82d
+	ld hl, wc82d
 	ld a, c
 	ld [hli], a
 	xor a
 	ld [hl], a
-	ld hl, $ca3f
+	ld hl, wMobileSDK_ReceivePacketBuffer + 3
 	ld a, [hli]
 	inc hl
 	sub e
@@ -2436,21 +2436,21 @@ Function111044:
 	ld e, a
 	ld d, 0
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
 	pop bc
-	ld a, [$c991]
+	ld a, [wc991]
 	ld l, a
 	ld h, 0
 	add hl, bc
 	ld c, l
 	ld b, h
 	xor a
-	ld [$c991], a
-	ld hl, $c827
+	ld [wc991], a
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2469,20 +2469,20 @@ Function111044:
 	ld a, c
 	ld [hli], a
 	ld [hl], b
-	ld hl, $c82d
-	ld a, [$c991]
+	ld hl, wc82d
+	ld a, [wc991]
 	add e
 	ld [hli], a
 	ld a, 0
 	adc 0
 	ld [hl], a
 	xor a
-	ld [$c991], a
-	ld a, [$c86e]
+	ld [wc991], a
+	ld a, [wc86e]
 	or a
 	jr z, .asm_1110eb
 	ld b, e
-	ld hl, $ca3f
+	ld hl, wMobileSDK_ReceivePacketBuffer + 3
 	ld a, [hli]
 	inc hl
 	sub e
@@ -2490,12 +2490,12 @@ Function111044:
 	ld e, a
 	ld d, 0
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -2504,8 +2504,8 @@ Function111044:
 .asm_1110eb
 	di
 	ld a, $2
-	ld [$c989], a
-	ld hl, $c821
+	ld [wc989], a
+	ld hl, wc821
 	res 2, [hl]
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
@@ -2517,46 +2517,46 @@ Function111044:
 	ld b, $5
 	call PacketSendBytes
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	ret
 
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$c82d]
+	ld a, [wc82d]
 	ld [hli], a
-	ld a, [$c82e]
+	ld a, [wc82e]
 	ld [hl], a
-	ld hl, $c98f
+	ld hl, wc98f
 	inc [hl]
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, $1
-	ld [$c86b], a
-	ld a, [$c86d]
-	ld [$c86e], a
+	ld [wc86b], a
+	ld a, [wc86d]
+	ld [wc86e], a
 	xor a
-	ld [$c989], a
+	ld [wc989], a
 	ld a, $a3
 	ld de, $0010
-	ld hl, $c995
+	ld hl, wc995
 	jp Function111f02
 
 .asm_111144
 	res 0, [hl]
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$c82d]
+	ld a, [wc82d]
 	ld [hli], a
-	ld a, [$c82e]
+	ld a, [wc82e]
 	ld [hl], a
 	ld a, $2
-	ld [$c86a], a
+	ld [wc86a], a
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ei
 	ret
 
@@ -2574,25 +2574,25 @@ Function11115f:
 	push bc
 	ld b, e
 	ld c, e
-	ld a, [$c993]
+	ld a, [wc993]
 	sub e
 	ld e, a
 	ld d, 0
-	ld hl, $c880
+	ld hl, wc880
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	call MobileSDK_CopyBytes
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hl], a
 	ld e, c
 	ld a, c
-	ld hl, $c82d
+	ld hl, wc82d
 	ld [hli], a
 	xor a
 	ld [hl], a
@@ -2603,8 +2603,8 @@ Function11115f:
 	ld a, b
 	sbc $0
 	ld b, a
-	ld a, [$c992]
-	ld [$c82b], a
+	ld a, [wc992]
+	ld [wc82b], a
 	ld e, a
 	pop hl
 	ret
@@ -2612,20 +2612,20 @@ Function11115f:
 .asm_1111a2
 	ld a, e
 	sub c
-	ld [$c991], a
-	ld a, [$c993]
+	ld [wc991], a
+	ld a, [wc993]
 	sub e
 	ld e, a
 	ld d, 0
-	ld hl, $c880
+	ld hl, wc880
 	add hl, de
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
 	ld b, c
 	call MobileSDK_CopyBytes
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2637,15 +2637,15 @@ Function11115f:
 	ret
 
 Function1111ca:
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
 	ld a, $6
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112430
 
 Function1111d7:
 	push hl
-	ld hl, $c866
+	ld hl, wc866
 	ld a, [hli]
 	or [hl]
 	inc hl
@@ -2669,7 +2669,7 @@ Function1111d7:
 	inc bc
 	or a
 	jr nz, .asm_1111f1
-	ld hl, $c87a
+	ld hl, wc87a
 	ld a, c
 	ld [hli], a
 	ld a, b
@@ -2677,22 +2677,22 @@ Function1111d7:
 	ret
 
 Function1111fe:
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
-	ld a, [$c86a]
+	ld a, [wc86a]
 	jp nz, Function1113ea
 	cp $2
 	jp nz, Function110226
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
-	ld a, [$c86d]
+	ld a, [wc86d]
 	or a
 	jp nz, Function110226
 	xor a
-	ld [$c989], a
-	ld [$c98a], a
-	ld [$c993], a
+	ld [wc989], a
+	ld [wc98a], a
+	ld [wc993], a
 	push hl
 	push de
 	push bc
@@ -2701,15 +2701,15 @@ rept 4
 	inc hl
 endr
 	ld a, [hli]
-	ld [$c833], a
+	ld [wc833], a
 	ld a, [hli]
-	ld [$c834], a
+	ld [wc834], a
 	inc hl
 	inc hl
 	ld a, l
-	ld [$c97f], a
+	ld [wc97f], a
 	ld a, h
-	ld [$c980], a
+	ld [wc980], a
 	dec hl
 	dec hl
 	ld a, [hli]
@@ -2763,7 +2763,7 @@ endr
 	dec b
 	jr nz, .asm_11127e
 	ld a, $2
-	ld [$c98a], a
+	ld [wc98a], a
 	pop hl
 	jr .asm_1112a0
 
@@ -2796,7 +2796,7 @@ endr
 	jr c, .asm_1112cc
 	cp $3a
 	jr nc, .asm_1112cc
-	ld hl, $c97f
+	ld hl, wc97f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2810,8 +2810,8 @@ endr
 
 .asm_1112cc
 	ld a, c
-	ld [$c98f], a
-	ld [$cabc], a
+	ld [wc98f], a
+	ld [wMobileSDK_ReceivePacketBuffer + 128], a
 	pop hl
 	ld de, $0006
 	add hl, de
@@ -2832,10 +2832,10 @@ endr
 	pop de
 	pop hl
 	ld a, l
-	ld [$c876], a
+	ld [wc876], a
 	ld a, h
-	ld [$c877], a
-	ld hl, $c872
+	ld [wc877], a
+	ld hl, wc872
 	ld a, c
 	ld [hli], a
 	ld a, b
@@ -2851,31 +2851,31 @@ endr
 	ld a, d
 	ld [hl], a
 	call Function111335
-	ld hl, $c876
+	ld hl, wc876
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	ld a, [hli]
-	ld [$c9aa], a
+	ld [wc9aa], a
 	ld a, [hli]
-	ld [$c9ab], a
+	ld [wc9ab], a
 	ld a, [hli]
-	ld [$c9ac], a
+	ld [wc9ac], a
 	ld a, [hli]
-	ld [$c9ad], a
+	ld [wc9ad], a
 	inc hl
 	inc hl
 	ld a, [hli]
-	ld [$c876], a
+	ld [wc876], a
 	ld a, [hl]
-	ld [$c877], a
-	ld a, [$c98f]
+	ld [wc877], a
+	ld a, [wc98f]
 	xor $1
-	ld [$c994], a
+	ld [wc994], a
 	jp Function110f07
 
 Function111335:
-	ld hl, $c876
+	ld hl, wc876
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -2885,7 +2885,7 @@ Function111335:
 	ld h, [hl]
 	ld l, a
 	xor a
-	ld [$c8c9], a
+	ld [wc8c9], a
 .asm_111344
 	ld de, $8ad0
 	add hl, de
@@ -2906,7 +2906,7 @@ Function111335:
 .asm_11135b
 	ld de, $2710
 	add hl, de
-	ld [$c8c6], a
+	ld [wc8c6], a
 	xor a
 .asm_111363
 	ld de, $f448
@@ -2948,7 +2948,7 @@ Function111335:
 .asm_111396
 	ld de, $0064
 	add hl, de
-	ld [$c8c7], a
+	ld [wc8c7], a
 	xor a
 .asm_11139e
 	ld de, $ffe2
@@ -2971,9 +2971,9 @@ Function111335:
 	ld de, $000a
 	add hl, de
 	add l
-	ld [$c8c8], a
-	ld de, $c9a5
-	ld hl, $c8c6
+	ld [wc8c8], a
+	ld de, wc9a5
+	ld hl, wc8c6
 	ld a, [hli]
 	or $30
 	ld [de], a
@@ -3019,38 +3019,38 @@ Function1113f8:
 	jp Function110231
 
 Function1113fe:
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jp z, .asm_11147f
 	bit 7, a
 	jp nz, .asm_11147f
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, .asm_11147f
 .asm_111413
-	ld a, [$c800]
+	ld a, [wc800]
 	or a
 	jr nz, .asm_111413
 	di
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 3, a
 	jp nz, .asm_11147b
-	ld a, [$c807]
+	ld a, [wc807]
 	or a
 	jr nz, .asm_111436
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	ld a, $23
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $ff
 	ei
 	ret
 
 .asm_111436
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	push hl
-	ld hl, $c829
+	ld hl, wc829
 	xor a
 	ld [hli], a
 	ld [hli], a
@@ -3083,9 +3083,9 @@ Function1113fe:
 	inc b
 	inc b
 	call Function111f63
-	ld hl, $c822
+	ld hl, wc822
 	set 7, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	ld a, $0
 	ei
@@ -3108,23 +3108,23 @@ Function1113fe:
 	ret
 
 Function11148c:
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jp z, Function110226
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 0, a
 	jp nz, Function110226
 	bit 3, a
 	jp z, Function110226
 	ld e, l
 	ld d, h
-	ld a, [$c992]
+	ld a, [wc992]
 	or a
 	jr nz, .asm_111507
-	ld a, [$c993]
+	ld a, [wc993]
 	ld c, a
 	ld b, 0
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	add hl, bc
 	ld a, [hli]
 	or a
@@ -3139,12 +3139,12 @@ Function11148c:
 	ld b, a
 	inc c
 	add c
-	ld [$c993], a
-	ld a, [$c994]
+	ld [wc993], a
+	ld a, [wc994]
 	dec a
 	sub b
 	ld c, a
-	ld [$c994], a
+	ld [wc994], a
 	ld a, b
 	ld [de], a
 	inc de
@@ -3153,7 +3153,7 @@ Function11148c:
 	xor a
 	or c
 	jr nz, .asm_1114dc
-	ld hl, $c821
+	ld hl, wc821
 	res 3, [hl]
 	ret
 
@@ -3170,23 +3170,23 @@ Function11148c:
 .asm_1114e6
 	cp c
 	ret c
-	ld [$c991], a
+	ld [wc991], a
 	dec c
 	ld a, c
 	or a
 	jr z, .asm_111500
-	ld [$c992], a
+	ld [wc992], a
 	ld b, a
-	ld de, $c880
+	ld de, wc880
 	call MobileSDK_CopyBytes
 .asm_1114fa
-	ld hl, $c821
+	ld hl, wc821
 	res 3, [hl]
 	ret
 
 .asm_111500
 	ld a, $ff
-	ld [$c992], a
+	ld [wc992], a
 	jr .asm_1114fa
 
 .asm_111507
@@ -3196,11 +3196,11 @@ Function11148c:
 
 .asm_11150c
 	ld b, a
-	ld a, [$c991]
+	ld a, [wc991]
 	sub b
 	ld c, a
-	ld hl, $c880
-	ld a, [$c991]
+	ld hl, wc880
+	ld a, [wc991]
 	ld [de], a
 	inc de
 	ld a, b
@@ -3209,20 +3209,20 @@ Function11148c:
 	call MobileSDK_CopyBytes
 
 .asm_111521
-	ld hl, $ca41
+	ld hl, wMobileSDK_ReceivePacketBuffer + 5
 	ld b, c
 	call MobileSDK_CopyBytes
 	push hl
 	ld a, c
 	inc a
-	ld [$c993], a
+	ld [wc993], a
 	ld b, a
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	sub b
-	ld [$c994], a
+	ld [wc994], a
 	ld c, a
 	xor a
-	ld hl, $c991
+	ld hl, wc991
 	ld [hli], a
 	ld [hl], a
 	pop hl
@@ -3232,27 +3232,27 @@ Function111540:
 	nop
 
 Function111541:
-	ld hl, $c821
+	ld hl, wc821
 	bit 0, [hl]
 	jp nz, Function110226
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $5
 	jp nc, Function110226
-	ld [$c985], a
+	ld [wc985], a
 	ld a, e
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, d
-	ld [$c86f], a
-	ld a, [$c807]
+	ld [wc86f], a
+	ld a, [wc807]
 	cp $2
 	jr c, .asm_111582
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, MOBILE_COMMAND_TELEPHONE_STATUS | $80
 	ld hl, MobilePacket_TelephoneStatus
 	call PacketSendEmptyBody
 .asm_11156f
-	ld a, [$c988]
+	ld a, [wc988]
 	cp $40
 	jr nz, .asm_11157a
 	ld a, $2c
@@ -3262,28 +3262,28 @@ Function111541:
 	ld a, $1e
 
 .asm_11157c
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function110432
 
 .asm_111582
 	xor a
 	ldh [rTAC], a
-	ld a, [$c870]
+	ld a, [wc870]
 	ld c, a
 	call Function1100dc
 	call Function1104b0
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	jr .asm_11156f
 
 Function111596:
-	ld hl, $c86a
+	ld hl, wc86a
 	ld a, [hl]
 	cp $1
 	jp z, Function110226
 	cp $2a
 	jp z, Function110226
-	ld a, [$c800]
+	ld a, [wc800]
 	bit 1, a
 	jr nz, .asm_1115af
 	ld a, $2a
@@ -3298,17 +3298,17 @@ Function111596:
 	di
 	ld [hli], a
 	ld [hl], b
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
 	res 0, [hl]
 	xor a
-	ld [$c80b], a
-	ld [$c800], a
+	ld [wc80b], a
+	ld [wc800], a
 	ld a, $8
-	ld [$c807], a
+	ld [wc807], a
 	call ResetReceivePacketBuffer
 	call Function11164f
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	ei
 	ret
@@ -3323,11 +3323,11 @@ Function111596:
 Function1115e4:
 	di
 	push af
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	ld a, $1
-	ld [$c86b], a
-	ld a, [$c86d]
+	ld [wc86b], a
+	ld a, [wc86d]
 	or a
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	jr z, .asm_111609
@@ -3339,7 +3339,7 @@ Function1115e4:
 	call Function112430
 .asm_111604
 	pop af
-	ld [$c86a], a
+	ld [wc86a], a
 	ret
 
 .asm_111609
@@ -3351,13 +3351,13 @@ Function1115e4:
 	jr .asm_111604
 
 Function111610:
-	ld hl, $c86a
+	ld hl, wc86a
 	ld a, [hl]
 	dec a
 	jp z, Function110226
 	dec a
 	jp z, Function110226
-	ld a, [$c800]
+	ld a, [wc800]
 	or a
 	jr nz, .asm_111626
 	ld a, $28
@@ -3371,7 +3371,7 @@ Function111610:
 	ret
 
 Function11162d:
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1
 	jp nz, Function110226
 	xor a
@@ -3381,7 +3381,7 @@ Function11162d:
 	call Function111686
 	call ResetReceivePacketBuffer
 	ld bc, $0452
-	ld hl, $c800
+	ld hl, wc800
 .asm_111647
 	xor a
 	ld [hli], a
@@ -3392,10 +3392,10 @@ Function11162d:
 	ret
 
 Function11164f:
-	ld hl, $c815
+	ld hl, wc815
 	xor a
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	ld b, a
 	ld a, [wMobileSDK_AdapterType]
 	ld a, b
@@ -3438,10 +3438,10 @@ Function111686:
 	and $f3
 	ldh [c], a
 	ld a, [wMobileSDK_PacketBuffer + 1]
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, [wMobileSDK_PacketBuffer]
 	ld c, a
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	or c
 	ld [hl], a
@@ -3453,17 +3453,17 @@ Function1116a0:
 
 Function1116a4:
 	set 1, [hl]
-	ld a, [$c86a]
+	ld a, [wc86a]
 
 Function1116a9:
-	ld [$cb48], a
-	ld hl, $c815
+	ld [wMobileSDK_PacketBuffer + 1], a
+	ld hl, wc815
 	xor a
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	rla
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	ld b, a
 	and $d
@@ -3474,12 +3474,12 @@ Function1116a9:
 	ret
 
 _MobileReceive::
-	ld a, [$c800]
+	ld a, [wc800]
 	rrca
 	jp nc, Function1118bc
 	rrca
 	jp c, Function1117e7
-	ld hl, $c801
+	ld hl, wc801
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -3493,7 +3493,7 @@ _MobileReceive::
 	ld a, d
 	or a
 	jp nz, Function1118bc
-	ld hl, $c808
+	ld hl, wc808
 	add hl, de
 	ldh a, [rSB]
 	ld [hl], a
@@ -3512,10 +3512,10 @@ _MobileReceive::
 	dec a
 	cp [hl]
 	jp z, Function1117a0
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $1
 	jr nz, .asm_111716
-	ld a, [$c806]
+	ld a, [wc806]
 	or a
 	jr z, .asm_111778
 .asm_111716
@@ -3535,23 +3535,23 @@ _MobileReceive::
 	jr z, .asm_111730
 .asm_111730
 	xor a
-	ld [$c819], a
+	ld [wc819], a
 	ld a, $3
-	ld [$c800], a
+	ld [wc800], a
 	xor a
-	ld hl, $c80a
+	ld hl, wc80a
 	ld [hli], a
 	ld [hli], a
 	ld [hli], a
-	ld hl, $c81f
+	ld hl, wc81f
 	ld a, [hli]
 	ld b, a
 	ld a, [hl]
-	ld hl, $c815
+	ld hl, wc815
 	ld [hli], a
 	ld a, b
 	ld [hli], a
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 0, a
 	jr z, .asm_111757
 	ld a, $b
@@ -3578,9 +3578,9 @@ _MobileReceive::
 	jp Function1118bc
 .asm_111778
 	xor a
-	ld [$c800], a
+	ld [wc800], a
 Function11177c:
-	ld hl, $c820
+	ld hl, wc820
 	ld a, [hld]
 	ld e, a
 	ld a, [hl]
@@ -3594,7 +3594,7 @@ Function11177c:
 	jr nz, .asm_111785
 	or a
 	inc a
-	ld hl, $c816
+	ld hl, wc816
 	ld [hld], a
 	ld [hl], e
 	jp Function1118bc
@@ -3611,32 +3611,32 @@ asm_11179a:
 Function1117a0:
 	ld b, $3
 asm_1117a2:
-	ld hl, $c822
+	ld hl, wc822
 	set 3, [hl]
-	ld hl, $c815
-	ld a, [$c820]
+	ld hl, wc815
+	ld a, [wc820]
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	ld [hl], a
 	xor a
-	ld [$c800], a
-	ld hl, $c819
+	ld [wc800], a
+	ld hl, wc819
 	inc [hl]
 	ld a, b
 	cp [hl]
 	jp nc, Function1118bc
 	xor a
-	ld hl, $c806
+	ld hl, wc806
 	ld [hli], a
-	ld [$c800], a
+	ld [wc800], a
 	ld a, $6
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	ld a, $15
-	ld [$c80f], a
-	ld hl, $c810
-	ld a, [$c808]
+	ld [wc80f], a
+	ld hl, wc810
+	ld a, [wc808]
 	and $f
 	cp $2
 	jr nz, .asm_1117e1
@@ -3648,7 +3648,7 @@ asm_1117a2:
 	jp Function1118bc
 
 Function1117e7:
-	ld a, [$c80b]
+	ld a, [wc80b]
 	or a
 	jr z, .asm_1117f8
 	dec a
@@ -3657,7 +3657,7 @@ Function1117e7:
 	jp z, Function111884
 	jp Function111892
 .asm_1117f8
-	ld hl, $c80a
+	ld hl, wc80a
 	ld a, [hl]
 	or a
 	jr nz, .asm_111803
@@ -3672,26 +3672,26 @@ Function1117e7:
 	cp $d2
 	jr nz, .asm_111817
 	xor a
-	ld [$c9ae], a
+	ld [wc9ae], a
 .asm_111812
 	xor a
 	ld [hl], a
 	jp Function1118bc
 .asm_111817
-	ld a, [$c9ae]
+	ld a, [wc9ae]
 	inc a
-	ld [$c9ae], a
+	ld [wc9ae], a
 	cp $14
 	jr c, .asm_111812
 	ld a, $6
-	ld [$c807], a
+	ld [wc807], a
 	ld a, $10
-	ld [$c80f], a
+	ld [wc80f], a
 	xor a
-	ld [$c800], a
-	ld hl, $c822
+	ld [wc800], a
+	ld hl, wc822
 	res 0, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	set 1, a
 	and $f
@@ -3711,18 +3711,18 @@ Function1117e7:
 	ld [hli], a
 	dec b
 	jr nz, .asm_11184e
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jr z, .asm_111864
 	ld b, a
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 3, a
 	jr nz, .asm_111864
 	jp Function11177c
 .asm_111864
-	ld a, [$c820]
+	ld a, [wc820]
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	ld [hl], a
 	jr Function1118bc
 
@@ -3734,7 +3734,7 @@ Function11186e:
 	xor a
 	ld [hli], a
 	ldh a, [rSB]
-	ld [$c80c], a
+	ld [wc80c], a
 	inc [hl]
 	or a
 	jr nz, Function1118bc
@@ -3743,7 +3743,7 @@ Function11186e:
 
 Function111884:
 	call Function1118c2
-	ld a, [$c80c]
+	ld a, [wc80c]
 	cp [hl]
 	jr nz, Function1118bc
 	xor a
@@ -3755,12 +3755,12 @@ Function111892:
 	ldh a, [rSB]
 	ld c, a
 	call Function111664
-	ld hl, $c80a
+	ld hl, wc80a
 	inc [hl]
 	ld a, $2
 	cp [hl]
 	jr c, .asm_1118b4
-	ld a, [$c80a]
+	ld a, [wc80a]
 	add $11
 	ld e, a
 	ld d, $c8
@@ -3768,7 +3768,7 @@ Function111892:
 	cp c
 	jr z, Function1118bc
 	ld a, $1
-	ld [$c814], a
+	ld [wc814], a
 	jr Function1118bc
 .asm_1118b4
 	ld a, $4
@@ -3778,7 +3778,7 @@ Function111892:
 	ld [hli], a
 	inc [hl]
 Function1118bc:
-	ld hl, $c822
+	ld hl, wc822
 	res 1, [hl]
 	ret
 
@@ -3796,16 +3796,16 @@ Function1118c2:
 	ld a, l
 	ld [wMobileSDK_PacketChecksum + 1], a
 	call Function111664
-	ld hl, $c80a
+	ld hl, wc80a
 	inc [hl]
 	ret
 
 _Timer::
-	ld a, [$c80b]
+	ld a, [wc80b]
 	cp $4
 	call z, Function111b3c
 	call Function11214e
-	ld hl, $c807
+	ld hl, wc807
 	ld a, [hli]
 	cp $2
 	jr c, .asm_111927
@@ -3820,42 +3820,42 @@ _Timer::
 	or b
 	jr nz, .asm_111927
 .asm_1118fe
-	ld hl, $c807
+	ld hl, wc807
 	ld a, $6
 	cp [hl]
 	jp z, Function111b3b
 	ld [hl], a
 	ld a, $10
-	ld [$c80f], a
+	ld [wc80f], a
 	xor a
-	ld [$c800], a
-	ld hl, $c822
+	ld [wc800], a
+	ld hl, wc822
 	res 0, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	and $f
 	or $2
 	ld [hl], a
 	ld a, $10
-	ld [$c80f], a
+	ld [wc80f], a
 	jp Function111b3b
 .asm_111927
-	ld a, [$c800]
+	ld a, [wc800]
 	cp $1
 	jp z, Function111b21
 	cp $3
 	jp z, Function111a2a
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $1
 	jp c, Function111b3b
-	ld hl, $c815
+	ld hl, wc815
 	dec [hl]
 	jp nz, Function111b3b
 	inc hl
 	dec [hl]
 	jp nz, Function111b3b
-	ld hl, $c807
-	ld a, [$c822]
+	ld hl, wc807
+	ld a, [wc822]
 	bit 3, a
 	jp nz, Function111a0b
 	bit 4, a
@@ -3867,32 +3867,32 @@ _Timer::
 	jr z, .asm_111984
 	cp $8
 	jr z, .asm_11197d
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $2a
 	jr z, .asm_111991
 	cp $d
 	jr nz, .asm_111977
-	ld a, [$c86b]
+	ld a, [wc86b]
 	cp $4
 	jr nc, .asm_11199c
 .asm_111977
 	call Function111f97
 	jp Function111b3b
 .asm_11197d
-	ld a, [$c805]
+	ld a, [wc805]
 	ld [hl], a
 	jp Function111b3b
 .asm_111984
 	xor a
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	res 0, [hl]
 	call Function111686
 	jp Function111b3b
 .asm_111991
 	xor a
 	ld [hl], a
-	ld [$c821], a
+	ld [wc821], a
 	call Function111686
 	jp Function111b3b
 .asm_11199c
@@ -3900,11 +3900,11 @@ _Timer::
 	ld [hl], a
 	or a
 	jp z, Function111b3b
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 7, a
 	jr nz, .asm_1119be
 .asm_1119a9
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 3, a
 	jr nz, .asm_111977
 	ld de, MobilePacket_TransferData.End - MobilePacket_TransferData
@@ -3913,10 +3913,10 @@ _Timer::
 	call Function111f02
 	jp Function111b3b
 .asm_1119be
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 3, a
 	jr nz, .asm_1119dd
-	ld a, [$cb4c]
+	ld a, [wMobileSDK_PacketBuffer + 5]
 	add $a
 	ld e, a
 	ld d, 0
@@ -3927,35 +3927,35 @@ _Timer::
 	call PacketSendBytes
 	jp Function111b3b
 .asm_1119dd
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	res 0, [hl]
-	ld hl, $c822
+	ld hl, wc822
 	res 7, [hl]
 	ld a, $21
-	ld [$c80f], a
+	ld [wc80f], a
 	jr .asm_1119a9
 
 Function1119f0:
 	ld a, MOBILE_COMMAND_BEGIN_SESSION | $80
 	ld [wMobileSDK_SendCommandID], a
-	ld [$c808], a
+	ld [wc808], a
 	ld b, $5
 	ld de, MobilePacket_BeginSession.End - MobilePacket_BeginSession
 	ld hl, MobilePacket_BeginSession
 	call PacketSendBytes
 	ld a, $1
-	ld [$c806], a
+	ld [wc806], a
 	jp Function111b3b
 
 Function111a0b:
 	ld a, [hl]
 	cp $6
 	jp z, Function111b3b
-	ld hl, $c822
+	ld hl, wc822
 	res 3, [hl]
 	res 0, [hl]
-	ld hl, $c81a
+	ld hl, wc81a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -3968,7 +3968,7 @@ Function111a0b:
 	jp Function111b3b
 
 Function111a2a:
-	ld hl, $c80b
+	ld hl, wc80b
 	ld a, [hld]
 	or a
 	jr z, asm_111a47
@@ -3987,7 +3987,7 @@ Function111a42:
 	jp Function111b2e
 
 asm_111a47:
-	ld hl, $c815
+	ld hl, wc815
 	dec [hl]
 	jr nz, asm_111a40
 	inc hl
@@ -3996,51 +3996,51 @@ asm_111a47:
 	inc hl
 	dec [hl]
 	jr z, .asm_111a63
-	ld hl, $c81f
+	ld hl, wc81f
 	ld a, [hli]
 	ld d, a
 	ld a, [hl]
-	ld hl, $c815
+	ld hl, wc815
 	ld [hli], a
 	ld a, d
 	ld [hli], a
 	jr asm_111a40
 .asm_111a63
 	di
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $2a
 	jr z, .asm_111aa8
-	ld hl, $c9b2
+	ld hl, wc9b2
 	inc [hl]
 	ld a, [hl]
 	cp $1
 	jr z, .asm_111a91
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
 	res 0, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	res 4, [hl]
 	ld a, $0
-	ld [$c805], a
+	ld [wc805], a
 	ld a, $29
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, $1
-	ld [$c806], a
+	ld [wc806], a
 	jr .asm_111aa8
 .asm_111a91
 	ld a, $29
-	ld [$c86a], a
+	ld [wc86a], a
 	xor a
-	ld [$c806], a
-	ld [$c86b], a
-	ld [$c80b], a
-	ld [$c800], a
+	ld [wc806], a
+	ld [wc86b], a
+	ld [wc80b], a
+	ld [wc800], a
 	ld a, $8
-	ld [$c807], a
+	ld [wc807], a
 .asm_111aa8
 	call ResetReceivePacketBuffer
 	call Function11164f
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
 	res 0, [hl]
 	ei
@@ -4051,32 +4051,32 @@ Function111ab9:
 	jr Function111a42
 
 Function111abd:
-	ld a, [$c814]
+	ld a, [wc814]
 	or a
 	jr nz, .asm_111acb
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	xor $80
 	jp Function111a42
 .asm_111acb
-	ld hl, $c819
+	ld hl, wc819
 	inc [hl]
 	ld a, $3
 	cp [hl]
 	jr z, .asm_111afe
 	call ResetReceivePacketBuffer
 	ld a, $3
-	ld [$c800], a
+	ld [wc800], a
 	xor a
-	ld hl, $c80a
+	ld hl, wc80a
 	ld [hli], a
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c815
-	ld a, [$c820]
+	ld hl, wc815
+	ld a, [wc820]
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	ld [hli], a
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 0, a
 	jr z, .asm_111af9
 	ld a, $b
@@ -4087,26 +4087,26 @@ Function111abd:
 	ld [hli], a
 	jr .asm_111b1c
 .asm_111afe
-	ld hl, $c806
+	ld hl, wc806
 	xor a
 	ld [hli], a
-	ld [$c800], a
+	ld [wc800], a
 	ld a, $6
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	ld a, $15
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $2
-	ld [$c810], a
+	ld [wc810], a
 	xor a
-	ld [$c811], a
+	ld [wc811], a
 .asm_111b1c
 	ld a, $f1
 	jp Function111a42
 
 Function111b21:
-	ld hl, $c803
+	ld hl, wc803
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
@@ -4118,7 +4118,7 @@ Function111b21:
 	ld [hl], e
 
 Function111b2e:
-	ld hl, $c822
+	ld hl, wc822
 	set 1, [hl]
 	ld a, (0 << rSC_ON) | (1 << rSC_CGB) | (1 << rSC_CLOCK)
 	ldh [rSC], a
@@ -4130,13 +4130,13 @@ Function111b3b:
 
 Function111b3c:
 	xor a
-	ld [$c819], a
-	ld [$c80b], a
-	ld hl, $c9b1
+	ld [wc819], a
+	ld [wc80b], a
+	ld hl, wc9b1
 	ld [hli], a
 	ld [hl], a
-	ld [$c800], a
-	ld hl, $c822
+	ld [wc800], a
+	ld hl, wc822
 	res 5, [hl]
 	bit 0, [hl]
 	jr z, .asm_111b59
@@ -4185,45 +4185,45 @@ Function111b3c:
 	jp z, Function111d65
 	cp MOBILE_COMMAND_DIAL_TELEPHONE | $80
 	jp z, Function111d65
-	ld hl, $c822
+	ld hl, wc822
 	res 0, [hl]
 	ld a, $a
-	ld [$c807], a
+	ld [wc807], a
 	xor a
-	ld [$c800], a
+	ld [wc800], a
 	ret
 
 .asm_111bbe
-	ld a, [$ca40]
-	ld [$c86c], a
+	ld a, [wMobileSDK_ReceivePacketBuffer + 4]
+	ld [wc86c], a
 	ld a, $4
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 .asm_111bca
 	ld a, $3
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 .asm_111bd0
 	ld a, $4
-	ld [$c807], a
-	ld de, $c823
-	ld hl, $ca40
+	ld [wc807], a
+	ld de, wc823
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	ld b, $4
 	jp MobileSDK_CopyBytes
 
 .asm_111be0
 	ld a, $2
-	ld [$c807], a
-	ld hl, $c822
+	ld [wc807], a
+	ld hl, wc822
 	res 4, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	res 4, [hl]
 	ret
 
 .asm_111bf0
-	ld hl, $c829
+	ld hl, wc829
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
@@ -4234,42 +4234,42 @@ Function111b3c:
 	inc hl
 	call MobileSDK_CopyBytes
 	ld a, $2
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 Function111c06:
-	ld de, $c872
-	ld hl, $ca40
+	ld de, wc872
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	ld b, $2
 	call MobileSDK_CopyBytes
 	ld a, $2
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 Function111c17:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp MOBILE_COMMAND_TRANSFER_DATA_END | $80
 	jp z, Function111d07
-	ld a, [$c86f]
+	ld a, [wc86f]
 	ld b, a
-	ld a, [$c86e]
+	ld a, [wc86e]
 	or b
 	jp z, Function111d07
-	ld hl, $c82b
+	ld hl, wc82b
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	dec a
 	jp z, Function111d07
 	ld c, a
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jp z, Function111cc2
-	ld a, [$c992]
+	ld a, [wc992]
 	or a
 	jr nz, .asm_111c89
-	ld a, [$ca41]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 5]
 	or a
 	jr z, .asm_111c50
 	cp $81
@@ -4278,30 +4278,30 @@ Function111c17:
 	ld a, $80
 .asm_111c52
 	ld b, a
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	dec a
 	dec a
 	cp b
 	jr c, .asm_111c6e
 .asm_111c5b
-	ld hl, $c821
+	ld hl, wc821
 	set 3, [hl]
-	ld hl, $c993
+	ld hl, wc993
 	ld a, $1
 	ld [hli], a
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	dec a
 	ld [hl], a
 	jp Function111d07
 .asm_111c6e
-	ld hl, $c992
+	ld hl, wc992
 	or a
 	jr z, .asm_111c83
 	ld [hld], a
 	ld [hl], b
 	ld b, a
-	ld hl, $ca42
-	ld de, $c880
+	ld hl, wMobileSDK_ReceivePacketBuffer + 6
+	ld de, wc880
 	call MobileSDK_CopyBytes
 	jp Function111d07
 .asm_111c83
@@ -4312,10 +4312,10 @@ Function111c17:
 .asm_111c89
 	cp $ff
 	jr nz, .asm_111c9d
-	ld hl, $c991
+	ld hl, wc991
 	ld a, [hli]
 	ld b, a
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	dec a
 	cp b
 	jr nc, .asm_111c5b
@@ -4323,11 +4323,11 @@ Function111c17:
 	xor a
 	ld [hl], a
 .asm_111c9d
-	ld hl, $c991
+	ld hl, wc991
 	ld a, [hli]
 	sub [hl]
 	ld b, a
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	dec a
 	cp b
 	jr nc, .asm_111c5b
@@ -4336,12 +4336,12 @@ Function111c17:
 	ld l, [hl]
 	ld h, $0
 	add l
-	ld [$c992], a
-	ld de, $c880
+	ld [wc992], a
+	ld de, wc880
 	add hl, de
 	ld e, l
 	ld d, h
-	ld hl, $ca41
+	ld hl, wMobileSDK_ReceivePacketBuffer + 5
 	call MobileSDK_CopyBytes
 	jr Function111d07
 
@@ -4353,9 +4353,9 @@ Function111cc2:
 	cp e
 	jr c, .asm_111cda
 	jr z, .asm_111cda
-	ld a, [$c821]
+	ld a, [wc821]
 	set 2, a
-	ld [$c821], a
+	ld [wc821], a
 	ld a, c
 	sub e
 	ld c, e
@@ -4372,17 +4372,17 @@ Function111cc2:
 	ld a, d
 	ld [hld], a
 	ld [hl], e
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
-	ld hl, $ca41
+	ld hl, wMobileSDK_ReceivePacketBuffer + 5
 	ld a, c
 	or a
 	jr z, Function111d07
 	ld b, a
 	call MobileSDK_CopyBytes
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld [hl], d
@@ -4395,30 +4395,30 @@ Function111cc2:
 	inc [hl]
 
 Function111d07:
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jr z, .asm_111d1c
 	bit 7, a
 	jr z, .asm_111d1c
-	ld hl, $c822
+	ld hl, wc822
 	res 7, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	res 0, [hl]
 .asm_111d1c
-	ld a, [$c805]
-	ld [$c807], a
+	ld a, [wc805]
+	ld [wc807], a
 	ret
 
 Function111d23:
-	ld a, [$c829]
+	ld a, [wc829]
 	ld e, a
-	ld a, [$c82a]
+	ld a, [wc82a]
 	ld d, a
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	ld b, $4
 	call MobileSDK_CopyBytes
 	ld a, $4
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 ParseResponse_BeginSession:
@@ -4446,7 +4446,7 @@ ParseResponse_BeginSession:
 .done
 	ld [wMobileSDK_AdapterType], a
 	ld a, $2
-	ld [$c807], a
+	ld [wc807], a
 	ret
 .fail
 	xor a
@@ -4454,18 +4454,18 @@ ParseResponse_BeginSession:
 
 Function111d65:
 	ld a, $3
-	ld [$c807], a
-	ld hl, $c821
+	ld [wc807], a
+	ld hl, wc821
 	set 4, [hl]
 	ret
 
 Function111d70:
-	ld hl, $c822
+	ld hl, wc822
 	bit 0, [hl]
 	jr z, .asm_111dc0
-	ld a, [$c805]
-	ld [$c807], a
-	ld a, [$ca33]
+	ld a, [wc805]
+	ld [wc807], a
+	ld a, [wMobileSDK_ReceivePacketBufferAlt + 4]
 	ld b, a
 	call Function111dd9
 	call Function111e15
@@ -4475,43 +4475,43 @@ Function111d70:
 	jr z, .asm_111da9
 	or a
 	ret nz
-	ld hl, $c821
+	ld hl, wc821
 	res 4, [hl]
 	set 1, [hl]
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jr nz, .asm_111dbb
 	ld a, $23
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $6
-	ld [$c807], a
+	ld [wc807], a
 	ret
 .asm_111da9
-	ld hl, $c821
+	ld hl, wc821
 	res 4, [hl]
 	set 1, [hl]
 	ld a, $11
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $6
-	ld [$c807], a
+	ld [wc807], a
 	ret
 .asm_111dbb
 	xor a
-	ld [$c807], a
+	ld [wc807], a
 	ret
 .asm_111dc0
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$ca40]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 4]
 	ld b, a
 	call Function111dd9
 	call Function111e15
 	ld a, b
 	ld [hl], a
-	ld a, [$c805]
-	ld [$c807], a
+	ld a, [wc805]
+	ld [wc807], a
 	ret
 
 Function111dd9:
@@ -4528,13 +4528,13 @@ Function111dd9:
 	ret
 .asm_111dea
 	ld b, $5
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 0, a
 	jr z, .asm_111df8
-	ld a, [$c86a]
+	ld a, [wc86a]
 	jr .asm_111dfb
 .asm_111df8
-	ld a, [$c985]
+	ld a, [wc985]
 .asm_111dfb
 	cp $4
 	ret z
@@ -4546,7 +4546,7 @@ Function111dd9:
 	cp $3
 	ret z
 	ld b, $1
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	ret z
 	inc b
@@ -4563,10 +4563,10 @@ Function111e15:
 	rrca
 	push hl
 	ld l, a
-	ld a, [$c821]
+	ld a, [wc821]
 	and $1f
 	or l
-	ld [$c821], a
+	ld [wc821], a
 	pop hl
 	ret
 
@@ -4578,26 +4578,26 @@ GetErrorCode:
 	ld a, [wMobileSDK_SendCommandID]
 	cp -1
 	jp z, Function111ef8
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $d
 	jr z, .asm_111e48
 	cp $2a
 	jr z, .asm_111e48
 	ld a, $6
-	ld [$c807], a
-	ld hl, $c821
+	ld [wc807], a
+	ld hl, wc821
 	set 1, [hl]
 .asm_111e48
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 0, a
 	jr z, .asm_111e54
-	ld hl, $ca33
+	ld hl, wMobileSDK_ReceivePacketBufferAlt + 4
 	jr .asm_111e57
 .asm_111e54
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 .asm_111e57
 	ld a, [hli]
-	ld [$c80e], a
+	ld [wc80e], a
 	cp MOBILE_COMMAND_BEGIN_SESSION
 	jr z, .adapter_not_plugged_in
 	cp MOBILE_COMMAND_DIAL_TELEPHONE
@@ -4621,7 +4621,7 @@ GetErrorCode:
 	ld a, [hl]
 
 .store_error_code
-	ld [$c80f], a
+	ld [wc80f], a
 	ret
 
 .adapter_not_plugged_in
@@ -4644,34 +4644,34 @@ GetErrorCode:
 	jr .store_error_code
 
 .hang_up_logout
-	ld hl, $c821
+	ld hl, wc821
 	res 1, [hl]
 	res 4, [hl]
 	ld a, $2
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 .transfer_data
 	ld a, [hl]
 	cp $1
 	jr nz, .asm_111ed3
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 4, a
 	jr z, .asm_111ed3
 	res 4, a
-	ld [$c822], a
-	ld hl, $c821
+	ld [wc822], a
+	ld hl, wc821
 	ld a, [hl]
 	and $f
 	or $2
 	ld [hl], a
 	ld a, $23
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $6
-	ld [$c807], a
+	ld [wc807], a
 	ret
 .asm_111ed3
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
 	ld a, $24
 	jr .store_error_code
@@ -4685,7 +4685,7 @@ GetErrorCode:
 	jr .store_error_code
 
 .open_tcp_connection
-	ld hl, $c821
+	ld hl, wc821
 	res 1, [hl]
 
 .dns_query
@@ -4693,15 +4693,15 @@ GetErrorCode:
 	jr .store_error_code
 
 .close_tcp_connection
-	ld hl, $c821
+	ld hl, wc821
 	res 1, [hl]
 	ld a, $3
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 Function111ef8:
-	ld a, [$c805]
-	ld [$c807], a
+	ld a, [wc805]
+	ld [wc807], a
 	ret
 
 PacketSendEmptyBody:
@@ -4717,7 +4717,7 @@ PacketSendBytes:
 ; b = ?
 	call Function1100b4
 	ret c
-	ld a, [$c800]
+	ld a, [wc800]
 	cp $0
 	jr z, .asm_111f17
 	call Function110226
@@ -4732,35 +4732,35 @@ PacketSendBytes:
 	cp $ff
 	jr z, .asm_111f35
 	ld a, l
-	ld [$c81c], a
+	ld [wc81c], a
 	ld a, h
-	ld [$c81d], a
+	ld [wc81d], a
 	ld a, e
-	ld [$c81a], a
+	ld [wc81a], a
 	ld a, d
-	ld [$c81b], a
+	ld [wc81b], a
 .asm_111f35
 	ld a, e
-	ld [$c801], a
+	ld [wc801], a
 	ld a, d
-	ld [$c802], a
+	ld [wc802], a
 	ld a, l
-	ld [$c803], a
+	ld [wc803], a
 	ld a, h
-	ld [$c804], a
-	ld hl, $c807
+	ld [wc804], a
+	ld hl, wc807
 	ld a, [hl]
 	cp b
 	jr z, .asm_111f4f
-	ld [$c805], a
+	ld [wc805], a
 .asm_111f4f
 	ld a, b
-	ld [$c807], a
+	ld [wc807], a
 	xor a
-	ld [$c806], a
+	ld [wc806], a
 	ld a, $1
-	ld [$c800], a
-	ld hl, $c822
+	ld [wc800], a
+	ld hl, wc822
 	set 5, [hl]
 	ei
 	ret
@@ -4812,17 +4812,17 @@ Function111f8d:
 	ret
 
 Function111f97:
-	ld hl, $c822
+	ld hl, wc822
 	bit 0, [hl]
 	ret nz
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $2
 	jr c, .asm_111fcb
 	cp $5
 	jr z, .asm_111fcb
 	cp $6
 	jr nz, .asm_111fcd
-	ld a, [$c80f]
+	ld a, [wc80f]
 	cp $22
 	jr z, .asm_111fcb
 	cp $23
@@ -4851,7 +4851,7 @@ Function111f97:
 	ld hl, MobilePacket_TelephoneStatus
 	ld de, MobilePacket_TelephoneStatus.End - MobilePacket_TelephoneStatus
 	call PacketSendBytes
-	ld hl, $c822
+	ld hl, wc822
 	set 0, [hl]
 	ret
 .asm_111fe9
@@ -4972,10 +4972,10 @@ Unknown_11213d:
 	db "Content-Length: ", 0
 
 Function11214e:
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 5, a
 	ret nz
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $a
 	ret c
 	ld c, a
@@ -4990,7 +4990,7 @@ Function11214e:
 	cp $28
 	jr z, .asm_112175
 .asm_11216f
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $6
 	ret z
 .asm_112175
@@ -5002,27 +5002,27 @@ Function11214e:
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld hl, $c86b
+	ld hl, wc86b
 	inc [hl]
 	ld a, [hl]
 	ret
 .asm_112187
 	ld c, a
-	ld a, [$c86b]
+	ld a, [wc86b]
 	cp $1
 	jr nz, .asm_11216f
-	ld hl, $c821
+	ld hl, wc821
 	res 1, [hl]
 	jr .asm_112175
 .asm_112196
 	ld c, a
-	ld a, [$c80f]
+	ld a, [wc80f]
 	cp $24
 	jr nz, .asm_11216f
-	ld a, [$c86b]
+	ld a, [wc86b]
 	cp $1
 	jr nz, .asm_11216f
-	ld hl, $c821
+	ld hl, wc821
 	res 1, [hl]
 	jr .asm_112175
 
@@ -5087,7 +5087,7 @@ Function1121f6:
 	ret
 
 .asm_112210
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -5123,10 +5123,10 @@ Function1121f6:
 	xor b
 
 .asm_11223a
-	ld hl, $c871
+	ld hl, wc871
 	ld [hld], a
 	ld [hl], c
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $a
 	jr nz, Function112251
 	jp Function1116a0
@@ -5138,17 +5138,17 @@ Function1121f6:
 
 Function112251:
 	xor a
-	ld [$c821], a
-	ld [$c807], a
+	ld [wc821], a
+	ld [wc807], a
 	inc a
-	ld [$c86a], a
+	ld [wc86a], a
 	ret
 
 Function11225d:
-	ld [$c80f], a
+	ld [wc80f], a
 	ld a, $5
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	ret
 
 Function112269:
@@ -5179,7 +5179,7 @@ Function112271:
 	jp Function11236b
 
 .asm_112292
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $e0
 	ld [hli], a
 	ld a, $c8
@@ -5188,7 +5188,7 @@ Function112271:
 	jp Function11236b
 
 .asm_1122a1
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $4d
 	jr nz, .asm_1122f5
@@ -5212,23 +5212,23 @@ Function112271:
 	ld a, [hl]
 	cp e
 	jr nz, .asm_1122fc
-	ld hl, $c884
-	ld de, $c836
+	ld hl, wc884
+	ld de, wc836
 	ld b, $8
 	call MobileSDK_CopyBytes
-	ld hl, $c8ca
+	ld hl, wc8ca
 	ld b, $2c
 	call MobileSDK_CopyBytes
-	ld a, [$cb79]
+	ld a, [wMobileSDK_PacketBuffer + 50]
 	ld c, a
 	sub $8
 	ld e, a
 	ld d, 0
-	ld hl, $cb7a
+	ld hl, wMobileSDK_PacketBuffer + 51
 	add hl, de
 	ld e, l
 	ld d, h
-	ld hl, $c836
+	ld hl, wc836
 	ld b, $8
 	call MobileSDK_CopyBytes
 	ld b, c
@@ -5237,20 +5237,20 @@ Function112271:
 
 .asm_1122f5
 	ld a, $25
-	ld [$c872], a
+	ld [wc872], a
 	jr .asm_112301
 
 .asm_1122fc
 	ld a, $14
-	ld [$c872], a
+	ld [wc872], a
 
 .asm_112301
 	ld a, $6
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112269
 
 .asm_112309
-	ld a, [$c821]
+	ld a, [wc821]
 	and $e0
 	jr nz, .asm_112314
 	ld b, $92
@@ -5263,35 +5263,35 @@ Function112271:
 	inc a
 
 .asm_11231b
-	ld [$c872], a
+	ld [wc872], a
 	ld a, $6
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112269
 
 .asm_112326
 	ld d, a
-	ld a, [$cb79]
+	ld a, [wMobileSDK_PacketBuffer + 50]
 	add $a
 	ld e, a
-	ld hl, $cb74
+	ld hl, wMobileSDK_PacketBuffer + 45
 	ld a, $a1
 	jp Function111f02
 
 .asm_112335
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	set 5, [hl]
 	ret
 
 .asm_112342
-	ld a, [$c872]
+	ld a, [wc872]
 	call Function11225d
 	jp Function1116a4
 
 Function11234b:
-	ld a, [$cb4c]
+	ld a, [wMobileSDK_PacketBuffer + 5]
 	add $a
 	ld e, a
 	ld d, 0
@@ -5300,7 +5300,7 @@ Function11234b:
 	jp Function111f02
 
 Function11235a:
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, $80
 	ld [hli], a
 	ld a, $c8
@@ -5327,7 +5327,7 @@ Function112373:
 	ret
 
 .asm_112381
-	ld a, [$c821]
+	ld a, [wc821]
 	and $e0
 	jr nz, .asm_11238c
 	ld b, $92
@@ -5341,21 +5341,21 @@ Function112373:
 
 .asm_112393
 	ld a, $3
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112269
 
 .asm_11239b
-	ld hl, $c822
+	ld hl, wc822
 	set 4, [hl]
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	set 6, [hl]
 	ret
 
 .asm_1123ad
-	ld a, [$c872]
+	ld a, [wc872]
 	call Function11225d
 	jp Function1116a4
 
@@ -5378,11 +5378,11 @@ Function1123b6:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $ee
 	jr z, .asm_1123bd
-	ld hl, $c822
+	ld hl, wc822
 	set 4, [hl]
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	set 6, [hl]
 	set 5, [hl]
@@ -5408,9 +5408,9 @@ Function1123e1:
 	jr z, .asm_112408
 	call Function1127e1
 	jr z, .asm_112408
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cb67
+	ld hl, wMobileSDK_PacketBuffer + 32
 	jp Function1127c5
 
 .asm_112408
@@ -5418,7 +5418,7 @@ Function1123e1:
 
 .asm_11240a
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, MOBILE_COMMAND_ISP_LOGOUT | $80
 	ld hl, MobilePacket_ISPLogout
 	jp PacketSendEmptyBody
@@ -5432,9 +5432,9 @@ Function1123e1:
 	jp Function112269
 
 .asm_112421
-	ld hl, $c822
+	ld hl, wc822
 	res 4, [hl]
-	ld hl, $c821
+	ld hl, wc821
 	ld a, [hl]
 	and $f
 	ld [hl], a
@@ -5442,12 +5442,12 @@ Function1123e1:
 
 Function112430:
 	ld a, $3
-	ld [$c807], a
+	ld [wc807], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_CloseTCPConnection
 	ld b, MobilePacket_CloseTCPConnection.End - MobilePacket_CloseTCPConnection
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	inc b
@@ -5465,16 +5465,16 @@ Function112451:
 
 .asm_112458
 	ld b, $6
-	ld de, $cba3
+	ld de, wMobileSDK_PacketBuffer + 92
 	call Function111f63
-	ld a, [$c86e]
+	ld a, [wc86e]
 	inc a
 	cp $3
 	jr nz, .asm_11248b
-	ld a, [$cabc]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 128]
 	or a
 	jr z, .asm_11248b
-	ld hl, $c995
+	ld hl, wc995
 	ld a, [hli]
 	cp $99
 	jr nz, .asm_112480
@@ -5486,56 +5486,56 @@ Function112451:
 	jr z, .asm_11248b
 
 .asm_112480
-	ld hl, $cb97
-	ld de, $c995
+	ld hl, wMobileSDK_PacketBuffer + 80
+	ld de, wc995
 	ld b, $10
 	call MobileSDK_CopyBytes
 
 .asm_11248b
 	ld a, $a3
 	ld de, $0010
-	ld hl, $cb97
+	ld hl, wMobileSDK_PacketBuffer + 80
 	jp Function111f02
 
 .asm_112496
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $a3
 	jr z, .asm_1124ce
-	ld a, [$c822]
+	ld a, [wc822]
 	bit 3, a
 	jr z, .asm_1124ab
 	dec [hl]
 	ld a, $3
-	ld [$c807], a
+	ld [wc807], a
 	ret
 
 .asm_1124ab
-	ld a, [$c9af]
+	ld a, [wc9af]
 	cp $5
 	jr c, .asm_1124b8
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	ret
 
 .asm_1124b8
 	dec [hl]
-	ld hl, $c9af
+	ld hl, wc9af
 	inc [hl]
-	ld hl, $c822
+	ld hl, wc822
 	set 3, [hl]
-	ld hl, $c815
-	ld a, [$c820]
+	ld hl, wc815
+	ld a, [wc820]
 	ld [hli], a
-	ld a, [$c81f]
+	ld a, [wc81f]
 	ld [hl], a
 	ret
 
 .asm_1124ce
 	xor a
-	ld [$c9af], a
-	ld a, [$c86e]
+	ld [wc9af], a
+	ld a, [wc86e]
 	inc a
-	ld [$c86d], a
+	ld [wc86d], a
 	dec a
 	jp z, Function11261c
 	dec a
@@ -5546,8 +5546,8 @@ Function112451:
 	jp z, Function112566
 	call Function1125c7
 	push de
-	ld de, $c880
-	ld hl, $c827
+	ld de, wc880
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -5557,7 +5557,7 @@ Function112451:
 	ld a, d
 	ld [hli], a
 	ld a, $1
-	ld [$c86e], a
+	ld [wc86e], a
 	ld a, $fa
 	ld [hli], a
 	xor a
@@ -5567,88 +5567,88 @@ Function112451:
 	ld [hli], a
 	pop de
 	ld a, $1
-	ld [$c994], a
+	ld [wc994], a
 	call Function11269b
 	ld a, $5
-	ld [$c86b], a
+	ld [wc86b], a
 	call Function112534
-	ld a, [$c9a5]
+	ld a, [wc9a5]
 	or a
 	jr z, .asm_112521
 	ld a, $1
 
 .asm_112521
 	add $23
-	ld [$c86a], a
-	ld a, [$c98a]
+	ld [wc86a], a
+	ld a, [wc98a]
 	cp $2
 	jr nz, .asm_112531
 	xor a
-	ld [$c9a5], a
+	ld [wc9a5], a
 
 .asm_112531
 	jp Function1125bf
 
 Function112534:
 	ld b, $fa
-	ld hl, $c880
+	ld hl, wc880
 	xor a
 .asm_11253a
 	ld [hli], a
 	dec b
 	jr nz, .asm_11253a
-	ld a, [$c876]
-	ld [$c87c], a
-	ld a, [$c877]
-	ld [$c87d], a
-	ld a, [$c87a]
-	ld [$c87e], a
-	ld a, [$c87b]
-	ld [$c87f], a
+	ld a, [wc876]
+	ld [wc87c], a
+	ld a, [wc877]
+	ld [wc87d], a
+	ld a, [wc87a]
+	ld [wc87e], a
+	ld a, [wc87b]
+	ld [wc87f], a
 	ld a, c
-	ld [$cb58], a
+	ld [wMobileSDK_PacketBuffer + 17], a
 	ld b, c
 	call Function111f63
 	ld a, $95
-	ld hl, $cb53
+	ld hl, wMobileSDK_PacketBuffer + 12
 	jp Function111f02
 
 Function112566:
 	call Function1125c7
-	ld a, [$cb5a]
+	ld a, [wMobileSDK_PacketBuffer + 19]
 	and $1
 	or a
 	jr nz, .asm_11257d
-	ld a, [$c98a]
+	ld a, [wc98a]
 	cp $2
 	jr nz, .asm_11257d
 	ld a, $1
-	ld [$c994], a
+	ld [wc994], a
 
 .asm_11257d
 	call Function11269b
 	ld a, $5
-	ld [$c86b], a
+	ld [wc86b], a
 	call Function112534
-	ld a, [$c9a5]
+	ld a, [wc9a5]
 	or a
 	jr z, .asm_112590
 	ld a, $1
 
 .asm_112590
 	add $21
-	ld [$c86a], a
+	ld [wc86a], a
 	jr Function1125bf
 
 Function112597:
 	call Function1125c7
 	call Function11269b
 	ld a, $5
-	ld [$c86b], a
+	ld [wc86b], a
 	call Function112534
-	ld a, [$c98f]
+	ld a, [wc98f]
 	ld b, a
-	ld a, [$c994]
+	ld a, [wc994]
 	and $1
 	add $13
 	bit 0, b
@@ -5660,16 +5660,16 @@ Function112597:
 	add b
 
 .asm_1125bc
-	ld [$c86a], a
+	ld [wc86a], a
 
 Function1125bf:
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	res 2, [hl]
 	ret
 
 Function1125c7:
-	ld hl, $c872
+	ld hl, wc872
 	ld a, [hli]
 	ld c, a
 	ld a, [hli]
@@ -5677,11 +5677,11 @@ Function1125c7:
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
-	ld a, [$c994]
+	ld a, [wc994]
 	and $1
 	xor $1
-	ld [$c86b], a
-	ld hl, $c827
+	ld [wc86b], a
+	ld hl, wc827
 	ld a, e
 	ld [hli], a
 	ld a, d
@@ -5705,91 +5705,91 @@ Function1125c7:
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
-	ld de, $cb53
+	ld de, wMobileSDK_PacketBuffer + 12
 	ld hl, MobilePacket_TransferData
 	ld b, $5
 	call MobileSDK_CopyBytes
 	inc de
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ret
 
 Function11261c:
 	xor a
-	ld [$c86b], a
-	ld a, [$c86c]
-	ld [$cbbd], a
-	ld de, $cbad
+	ld [wc86b], a
+	ld a, [wc86c]
+	ld [wMobileSDK_PacketBuffer + 118], a
+	ld de, wMobileSDK_PacketBuffer + 102
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
 	call Function112724
-	ld a, [$cbbc]
+	ld a, [wMobileSDK_PacketBuffer + 117]
 	ld b, a
-	ld de, $cbbd
+	ld de, wMobileSDK_PacketBuffer + 118
 	add e
 	ld e, a
 	ld a, $0
 	adc d
 	ld d, a
 	call Function111f63
-	ld hl, $cba7
+	ld hl, wMobileSDK_PacketBuffer + 96
 	call Function1127c5
 	ld a, $11
-	ld [$c86a], a
+	ld [wc86a], a
 
 Function11264e:
-	ld hl, $c821
+	ld hl, wc821
 	set 0, [hl]
 	ret
 
 Function112654:
 	xor a
-	ld [$c86b], a
-	ld a, [$c86c]
-	ld [$cbad], a
-	ld [$cbed], a
-	ld de, $cbcd
+	ld [wc86b], a
+	ld a, [wc86c]
+	ld [wMobileSDK_PacketBuffer + 102], a
+	ld [wMobileSDK_PacketBuffer + 166], a
+	ld de, wMobileSDK_PacketBuffer + 134
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
 	call Function112724
-	ld a, [$cbec]
+	ld a, [wMobileSDK_PacketBuffer + 165]
 	ld b, a
-	ld de, $cbed
+	ld de, wMobileSDK_PacketBuffer + 166
 	add e
 	ld e, a
 	ld a, $0
 	adc d
 	ld d, a
 	call Function111f63
-	ld a, [$cbac]
+	ld a, [wMobileSDK_PacketBuffer + 101]
 	ld b, a
-	ld de, $cbad
+	ld de, wMobileSDK_PacketBuffer + 102
 	add e
 	ld e, a
 	ld a, $0
 	adc d
 	ld d, a
 	call Function111f63
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	call Function1127c5
 	ld a, $12
-	ld [$c86a], a
+	ld [wc86a], a
 	jr Function11264e
 
 Function11269b:
 	ld bc, $0001
 	ld hl, Unknown_112110
-	ld a, [$c994]
+	ld a, [wc994]
 	or a
 	call nz, Function1126ac
 	call MobileSDK_CopyString
@@ -5831,10 +5831,10 @@ Function1126b6:
 
 Function1126e6:
 	xor a
-	ld [$c86b], a
+	ld [wc86b], a
 	ld hl, Unknown_11213d
 	call MobileSDK_CopyString
-	ld hl, $c9a5
+	ld hl, wc9a5
 	ld b, $5
 .asm_1126f5
 	ld a, [hl]
@@ -5865,20 +5865,20 @@ Function1126e6:
 
 Function112715:
 	xor a
-	ld [$c86c], a
+	ld [wc86c], a
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	ret
 
 Function112724:
 	ld a, $ff
-	ld [$c86e], a
+	ld [wc86e], a
 
 Function112729:
 	push hl
-	ld hl, $c82c
+	ld hl, wc82c
 	xor a
 	ld [hld], a
 	ld a, $ff
@@ -5901,7 +5901,7 @@ Function11273a:
 
 .asm_112744
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, $30
 	call Function11225d
 	set 1, [hl]
@@ -5911,7 +5911,7 @@ Function11273a:
 .asm_112752
 	call Function1127e1
 	jr nz, .asm_11277a
-	ld hl, $c880
+	ld hl, wc880
 	call Function112b11
 	ld a, $2
 	cp d
@@ -5920,29 +5920,29 @@ Function11273a:
 	cp e
 	jr nz, .asm_1127b7
 	call Function112724
-	ld a, [$cbbc]
+	ld a, [wMobileSDK_PacketBuffer + 117]
 	add $a
 	ld e, a
 	ld d, 0
 	ld a, $95
-	ld hl, $cbb7
+	ld hl, wMobileSDK_PacketBuffer + 112
 	jp Function111f02
 
 .asm_11277a
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jr z, Function1127cd
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	xor a
-	ld [$ca3f], a
-	ld hl, $cba7
+	ld [wMobileSDK_ReceivePacketBuffer + 3], a
+	ld hl, wMobileSDK_PacketBuffer + 96
 	jp Function1127c5
 
 .asm_11278f
 	call Function1127e1
 	jr nz, .asm_11277a
-	ld hl, $c880
+	ld hl, wc880
 	call Function112b11
 	ld a, $2
 	cp d
@@ -5951,23 +5951,23 @@ Function11273a:
 	cp e
 	jr nz, .asm_1127b7
 	ld a, $3
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	ld a, [hl]
 	and $d6
 	or $80
 	ld [hl], a
 	xor a
-	ld [$c98a], a
+	ld [wc98a], a
 	ret
 
 .asm_1127b7
-	ld hl, $c810
+	ld hl, wc810
 	ld a, e
 	ld [hli], a
 	ld [hl], d
 	ld a, $2
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112430
 
 Function1127c5:
@@ -5976,12 +5976,12 @@ Function1127c5:
 	jp Function111f02
 
 Function1127cd:
-	ld hl, $c810
+	ld hl, wc810
 	xor a
 	ld [hli], a
 	ld [hl], a
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, $30
 	call Function11225d
 	set 1, [hl]
@@ -5990,7 +5990,7 @@ Function1127cd:
 
 Function1127e1:
 	call Function112807
-	ld hl, $c832
+	ld hl, wc832
 
 Function1127e7:
 	ld a, [hli]
@@ -6005,7 +6005,7 @@ Function1127e7:
 
 Function1127f3:
 	call Function112807
-	ld hl, $c82f
+	ld hl, wc82f
 	ld a, [hli]
 	cp $d
 	ret nz
@@ -6020,7 +6020,7 @@ Function1127f3:
 Function112807:
 	push bc
 	push de
-	ld hl, $ca3f
+	ld hl, wMobileSDK_ReceivePacketBuffer + 3
 	ld a, [hl]
 	dec a
 	jr z, .asm_11282d
@@ -6032,11 +6032,11 @@ Function112807:
 	ld b, a
 	ld e, c
 	ld d, $0
-	ld hl, $c82f
+	ld hl, wc82f
 	add hl, de
-	ld de, $c82f
+	ld de, wc82f
 	call MobileSDK_CopyBytes
-	ld hl, $ca41
+	ld hl, wMobileSDK_ReceivePacketBuffer + 5
 	ld b, c
 .asm_11282a
 	call MobileSDK_CopyBytes
@@ -6050,10 +6050,10 @@ Function112807:
 	sub $5
 	ld c, a
 	ld b, 0
-	ld hl, $ca41
+	ld hl, wMobileSDK_ReceivePacketBuffer + 5
 	add hl, bc
 	ld b, $5
-	ld de, $c82f
+	ld de, wc82f
 	jr .asm_11282a
 
 Function112840:
@@ -6064,7 +6064,7 @@ Function112840:
 .asm_112844
 	call Function1127e1
 	jr nz, .asm_1128ab
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $32
 	jr nz, Function1128bd
@@ -6072,7 +6072,7 @@ Function112840:
 	cp $35
 	jr nz, Function1128bd
 	call Function112724
-	ld hl, $c87c
+	ld hl, wc87c
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -6080,10 +6080,10 @@ Function112840:
 	or a
 	jr z, .asm_11289d
 	push hl
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	ld bc, $0001
-	ld de, $cb5a
+	ld de, wMobileSDK_PacketBuffer + 19
 	ld hl, Unknown_1120b0
 	call MobileSDK_CopyString
 	pop hl
@@ -6094,15 +6094,15 @@ Function112840:
 	inc de
 	inc c
 	ld a, l
-	ld [$c87c], a
+	ld [wc87c], a
 	ld a, h
-	ld [$c87d], a
+	ld [wc87d], a
 	call Function11295e
 	ld a, c
-	ld [$cb58], a
+	ld [wMobileSDK_PacketBuffer + 17], a
 	ld b, c
 	call Function111f63
-	ld hl, $cb53
+	ld hl, wMobileSDK_PacketBuffer + 12
 	ld d, $0
 	ld e, c
 	ld a, $95
@@ -6110,25 +6110,25 @@ Function112840:
 
 .asm_11289d
 	ld a, $3
-	ld [$c86a], a
+	ld [wc86a], a
 	call Function1128d3
 	ld a, $1
-	ld [$c98a], a
+	ld [wc98a], a
 	ret
 
 .asm_1128ab
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jp z, Function1127cd
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	ld hl, wMobileSDK_PacketBuffer
 	jp Function1127c5
 
 Function1128bd:
-	ld hl, $c880
+	ld hl, wc880
 	call Function112b11
-	ld hl, $c810
+	ld hl, wc810
 	ld a, e
 	ld [hli], a
 	ld [hl], d
@@ -6139,7 +6139,7 @@ Function1128bd:
 	ret
 
 Function1128d3:
-	ld hl, $c821
+	ld hl, wc821
 	res 0, [hl]
 	res 2, [hl]
 	ret
@@ -6158,18 +6158,18 @@ Function1128db:
 	cp $9f
 	jp z, Function1127cd
 	call Function113482
-	ld a, [$c86f]
+	ld a, [wc86f]
 	or a
 	jr nz, .asm_112901
 	ld a, $3
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	ret
 
 .asm_112901
 	call Function112724
-	ld de, $cb4c
+	ld de, wMobileSDK_PacketBuffer + 5
 	ld a, $1
 	ld [de], a
 	inc de
@@ -6184,7 +6184,7 @@ Function1128db:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jp z, Function1127cd
-	ld hl, $c880
+	ld hl, wc880
 	call Function112b11
 	ld a, d
 	cp $2
@@ -6193,14 +6193,14 @@ Function1128db:
 	cp $50
 	jr nz, .asm_11295b
 	ld a, $3
-	ld [$c86a], a
+	ld [wc86a], a
 	call Function1128d3
 	xor a
-	ld [$c98a], a
+	ld [wc98a], a
 	ret
 
 .asm_11293d
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 
 .asm_112941
@@ -6210,7 +6210,7 @@ Function1128db:
 .asm_112947
 	call Function1127e1
 	jr nz, .asm_11293d
-	ld hl, $c880
+	ld hl, wc880
 	call Function112b11
 	ld a, d
 	cp $3
@@ -6246,9 +6246,9 @@ Function112969:
 	jr z, .asm_112986
 	call Function1127e1
 	jr z, .asm_112986
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cb67
+	ld hl, wMobileSDK_PacketBuffer + 32
 	jp Function1127c5
 
 .asm_112986
@@ -6256,10 +6256,10 @@ Function112969:
 
 .asm_112989
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	res 7, [hl]
 	set 5, [hl]
@@ -6279,41 +6279,41 @@ Function11299c:
 .asm_1129aa
 	call Function1127e1
 	jr nz, .asm_1129fe
-	ld a, [$c880]
+	ld a, [wc880]
 	cp $2b
 	jr nz, .asm_112a0f
 	call Function112724
-	ld a, [$cbac]
+	ld a, [wMobileSDK_PacketBuffer + 101]
 	add $a
 	ld e, a
 	ld d, 0
 	ld a, $95
-	ld hl, $cba7
+	ld hl, wMobileSDK_PacketBuffer + 96
 	jp Function111f02
 
 .asm_1129c9
 	ld d, a
 	call Function1127e1
 	jr nz, .asm_1129fe
-	ld a, [$c880]
+	ld a, [wc880]
 	cp $2b
 	jr nz, .asm_112a0f
 	call Function112724
-	ld a, [$cbec]
+	ld a, [wMobileSDK_PacketBuffer + 165]
 	add $a
 	ld e, a
 	ld a, $95
-	ld hl, $cbe7
+	ld hl, wMobileSDK_PacketBuffer + 160
 	jp Function111f02
 
 .asm_1129e7
 	call Function1127e1
 	jr nz, .asm_1129fe
-	ld a, [$c880]
+	ld a, [wc880]
 	cp $2b
 	jr nz, .asm_112a0f
 	ld a, $4
-	ld [$c86a], a
+	ld [wc86a], a
 	call Function1128d3
 	set 7, [hl]
 	ret
@@ -6322,49 +6322,49 @@ Function11299c:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jr z, Function112a42
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	jp Function1127c5
 
 .asm_112a0f
-	ld a, [$c86b]
-	ld [$cb67], a
+	ld a, [wc86b]
+	ld [wMobileSDK_PacketBuffer + 32], a
 	ld a, $3
-	ld [$c86b], a
+	ld [wc86b], a
 	jp Function112430
 
 .asm_112a1d
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld de, $0002
-	ld a, [$cb67]
+	ld a, [wMobileSDK_PacketBuffer + 32]
 	cp $1
 	jr z, .asm_112a2c
 	inc de
 .asm_112a2c
 
 Function112a2c:
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	res 0, [hl]
-	ld hl, $c80f
+	ld hl, wc80f
 	ld a, $31
 	ld [hli], a
 	ld a, e
 	ld [hli], a
 	ld [hl], d
 	ld a, $5
-	ld [$c86a], a
+	ld [wc86a], a
 	ret
 
 Function112a42:
-	ld hl, $c810
+	ld hl, wc810
 	xor a
 	ld [hli], a
 	ld [hl], a
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, $31
 	call Function11225d
 	set 1, [hl]
@@ -6379,7 +6379,7 @@ Function112a56:
 .asm_112a5a
 	call Function1127e1
 	jr nz, .asm_112a95
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $2b
 	jr nz, .asm_112aa6
@@ -6388,9 +6388,9 @@ Function112a56:
 	cp $20
 	jr nz, .asm_112a67
 	call Function112aac
-	ld a, [$c86e]
+	ld a, [wc86e]
 	ld c, a
-	ld a, [$c86f]
+	ld a, [wc86f]
 	ld b, a
 	ld a, e
 	ld [bc], a
@@ -6398,7 +6398,7 @@ Function112a56:
 	ld a, d
 	ld [bc], a
 	call Function112aac
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -6411,16 +6411,16 @@ Function112a56:
 	ld a, c
 	ld [hli], a
 	ld a, $4
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function1128d3
 
 .asm_112a95
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jr z, Function112a42
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	jp Function1127c5
 
 .asm_112aa6
@@ -6428,11 +6428,11 @@ Function112a56:
 	jp Function112a2c
 
 Function112aac:
-	ld a, [$c872]
+	ld a, [wc872]
 	push af
-	ld a, [$c873]
+	ld a, [wc873]
 	push af
-	ld a, [$c874]
+	ld a, [wc874]
 	push af
 	ld bc, 0
 	ld de, 0
@@ -6448,24 +6448,24 @@ Function112aac:
 	rl d
 	rl c
 	ld a, e
-	ld [$c872], a
+	ld [wc872], a
 	ld a, d
-	ld [$c873], a
+	ld [wc873], a
 	ld a, c
-	ld [$c874], a
+	ld [wc874], a
 	sla e
 	rl d
 	rl c
 	sla e
 	rl d
 	rl c
-	ld a, [$c872]
+	ld a, [wc872]
 	add e
 	ld e, a
-	ld a, [$c873]
+	ld a, [wc873]
 	adc d
 	ld d, a
-	ld a, [$c874]
+	ld a, [wc874]
 	adc c
 	ld c, a
 	ld a, b
@@ -6481,22 +6481,22 @@ Function112aac:
 
 .asm_112b04
 	pop af
-	ld [$c874], a
+	ld [wc874], a
 	pop af
-	ld [$c873], a
+	ld [wc873], a
 	pop af
-	ld [$c872], a
+	ld [wc872], a
 	ret
 
 Function112b11:
-	ld a, [$c872]
+	ld a, [wc872]
 	push af
-	ld a, [$c873]
+	ld a, [wc873]
 	push af
-	ld a, [$c874]
+	ld a, [wc874]
 	push af
 	ld bc, $0300
-	ld de, $c872
+	ld de, wc872
 	call Function112b60
 	call nc, Function112b60
 	call nc, Function112b60
@@ -6510,7 +6510,7 @@ Function112b11:
 
 .asm_112b36
 	push hl
-	ld hl, $c872
+	ld hl, wc872
 	ld de, 0
 	ld a, b
 	or a
@@ -6538,11 +6538,11 @@ Function112b11:
 .asm_112b52
 	pop hl
 	pop af
-	ld [$c874], a
+	ld [wc874], a
 	pop af
-	ld [$c873], a
+	ld [wc873], a
 	pop af
-	ld [$c872], a
+	ld [wc872], a
 	ret
 
 Function112b60:
@@ -6569,7 +6569,7 @@ Function112b71:
 .asm_112b75
 	call Function1127e1
 	jr nz, .asm_112ba3
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $2b
 	jr nz, .asm_112bb5
@@ -6582,7 +6582,7 @@ Function112b71:
 	cp $20
 	jr nz, .asm_112b87
 	call Function112aac
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -6593,16 +6593,16 @@ Function112b71:
 	ld a, c
 	ld [hli], a
 	ld a, $4
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function1128d3
 
 .asm_112ba3
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jp z, Function112a42
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	jp Function1127c5
 
 .asm_112bb5
@@ -6617,21 +6617,21 @@ Function112bbb:
 .asm_112bbf
 	call Function1127e1
 	jr nz, .asm_112bd4
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $2b
 	jr nz, .asm_112be6
 	ld a, $4
-	ld [$c86a], a
+	ld [wc86a], a
 	jp Function1128d3
 
 .asm_112bd4
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jp z, Function112a42
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	jp Function1127c5
 
 .asm_112be6
@@ -6649,21 +6649,21 @@ Function112bec:
 	ret
 
 .asm_112bf7
-	ld a, [$c880]
+	ld a, [wc880]
 	cp $2d
 	jr nz, .asm_112c03
 	call Function1127e1
 	jr z, .asm_112c0b
 
 .asm_112c03
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
 	jp z, .asm_112cef
 
 .asm_112c0b
-	ld hl, $c86b
+	ld hl, wc86b
 	inc [hl]
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $2b
 	jp nz, Function112d20
@@ -6674,13 +6674,13 @@ Function112bec:
 	cp $a
 	jr nz, .asm_112c1a
 	push hl
-	ld hl, $c98f
+	ld hl, wc98f
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
 	ld d, a
 	ld a, b
-	ld [$c82d], a
+	ld [wc82d], a
 	ld a, [hli]
 	ld h, [hl]
 	sub b
@@ -6691,16 +6691,16 @@ Function112bec:
 	jr nc, .asm_112c56
 	cp $ff
 	jr nz, .asm_112c56
-	ld hl, $c991
+	ld hl, wc991
 	ld a, [hli]
 	ld c, a
 	inc hl
 	ld a, b
 	sub c
 	ld [hli], a
-	ld a, [$c82b]
+	ld a, [wc82b]
 	ld [hl], a
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -6713,10 +6713,10 @@ Function112bec:
 	jp MobileSDK_CopyBytes
 
 .asm_112c56
-	ld [$c993], a
-	ld a, [$c82b]
+	ld [wc993], a
+	ld a, [wc82b]
 	ld c, a
-	ld [$c994], a
+	ld [wc994], a
 	push hl
 	ld a, l
 	sub c
@@ -6728,8 +6728,8 @@ Function112bec:
 	cp $ff
 	jr nz, .asm_112c9f
 	ld a, c
-	ld [$ca3d], a
-	ld a, [$ca3f]
+	ld [wMobileSDK_ReceivePacketBuffer + 1], a
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	sub c
 	pop hl
 	ld c, l
@@ -6738,65 +6738,65 @@ Function112bec:
 	call MobileSDK_CopyBytes
 	pop af
 	push de
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	ld e, a
 	ld d, 0
 	add hl, de
 	pop de
 	ld b, c
 	call MobileSDK_CopyBytes
-	ld a, [$ca3d]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 1]
 	sub c
-	ld [$c994], a
-	ld hl, $c827
+	ld [wc994], a
+	ld hl, wc827
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$c991]
+	ld a, [wc991]
 	ld [hli], a
 	xor a
 	ld [hl], a
 	ret
 
 .asm_112c9f
-	ld [$c994], a
+	ld [wc994], a
 	ld a, l
-	ld [$c82b], a
+	ld [wc82b], a
 	ld a, h
-	ld [$c82c], a
+	ld [wc82c], a
 	pop hl
 	pop hl
 	call MobileSDK_CopyBytes
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	sub c
 	push de
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	ld e, a
 	ld d, 0
 	add hl, de
 	pop de
 	ld b, c
 	call MobileSDK_CopyBytes
-	ld a, [$c82d]
+	ld a, [wc82d]
 	add c
-	ld [$c82d], a
-	ld a, [$c82e]
+	ld [wc82d], a
+	ld a, [wc82e]
 	adc 0
-	ld [$c82e], a
-	ld hl, $c829
+	ld [wc82e], a
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
 
 .asm_112cdb
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
 	jr z, .asm_112cea
 	ld a, $2
-	ld [$c86b], a
+	ld [wc86b], a
 	jp .asm_112d09
 
 .asm_112cea
@@ -6807,32 +6807,32 @@ Function112bec:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jp z, Function112a42
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
-	ld hl, $cbc7
+	ld hl, wMobileSDK_PacketBuffer + 128
 	jp Function1127c5
 
 .asm_112d01
 	ld a, $4
-	ld [$c86a], a
+	ld [wc86a], a
 	call Function1128d3
 
 .asm_112d09
-	ld a, [$c86e]
+	ld a, [wc86e]
 	ld l, a
-	ld a, [$c86f]
+	ld a, [wc86f]
 	or l
 	ret z
-	ld hl, $c827
+	ld hl, wc827
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
-	ld hl, $c82d
+	ld hl, wc82d
 	ld b, $2
 	jp MobileSDK_CopyBytes
 
 Function112d20:
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1a
 	jr nz, .asm_112d2d
 	ld de, $0004
@@ -6862,7 +6862,7 @@ Function112d33:
 	ret
 
 .asm_112d4d
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $23
 	jr z, .asm_112d6d
 	cp $1f
@@ -6873,7 +6873,7 @@ Function112d33:
 	jr nz, .asm_112d82
 
 .asm_112d60
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, [hli]
 	cp $1
 	jr nz, .asm_112d82
@@ -6882,21 +6882,21 @@ Function112d33:
 	jr nz, .asm_112d82
 
 .asm_112d6d
-	ld hl, $c86e
+	ld hl, wc86e
 	xor a
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c82b
+	ld hl, wc82b
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	dec [hl]
 
 .asm_112d82
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	ret
 
@@ -6906,14 +6906,14 @@ Function112d33:
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
 
 .asm_112d9f
-	ld a, [$c821]
+	ld a, [wc821]
 	bit 2, a
 	jr z, .asm_112dab
 	ld a, $3
@@ -6924,7 +6924,7 @@ Function112d33:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp MOBILE_COMMAND_TRANSFER_DATA_END | $80
 	jr z, .asm_112dc1
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	ld de, $000b
 	ld hl, wMobileSDK_PacketBuffer
@@ -6932,7 +6932,7 @@ Function112d33:
 	jp PacketSendBytes
 
 .asm_112dc1
-	ld a, [$c989]
+	ld a, [wc989]
 	cp $2
 	jr nc, .asm_112df2
 	call Function112f61
@@ -6942,14 +6942,14 @@ Function112d33:
 	jr z, .asm_112e38
 	cp $1
 	jr nz, .asm_112df2
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1f
 	jr z, .asm_112de1
 	cp $20
 	jr nz, .asm_112df2
 
 .asm_112de1
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, [hli]
 	cp $1
 	jr nz, .asm_112df2
@@ -6957,15 +6957,15 @@ Function112d33:
 	cp [hl]
 	jr nz, .asm_112df2
 	xor a
-	ld [$c990], a
+	ld [wc990], a
 
 .asm_112df2
-	ld a, [$c86e]
+	ld a, [wc86e]
 	ld l, a
-	ld a, [$c86f]
+	ld a, [wc86f]
 	or l
 	ret z
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $13
 	jr z, .asm_112e21
 	cp $14
@@ -6978,61 +6978,61 @@ Function112d33:
 	ret z
 	cp $1f
 	jr nz, .asm_112e21
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, [hli]
 	cp $0
 	ret nz
 	ld a, $2
 	cp [hl]
 	ret nz
-	ld a, [$c86a]
+	ld a, [wc86a]
 
 .asm_112e21
 	cp $24
 	jr nz, .asm_112e2a
-	ld hl, $c878
+	ld hl, wc878
 	jr .asm_112e2d
 
 .asm_112e2a
-	ld hl, $c827
+	ld hl, wc827
 
 .asm_112e2d
 	ld a, [hli]
 	ld e, a
 	ld d, [hl]
-	ld hl, $c82d
+	ld hl, wc82d
 	ld b, $2
 	jp MobileSDK_CopyBytes
 
 .asm_112e38
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	res 0, [hl]
-	ld de, $c98b
+	ld de, wc98b
 	ld a, $24
 	jr .asm_112e95
 
 .asm_112e46
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1f
 	jr z, .asm_112ea6
 	cp $20
 	jr z, .asm_112ea6
-	ld a, [$c98a]
+	ld a, [wc98a]
 	cp $1
 	jr z, .asm_112e65
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $21
 	jp z, .asm_112eea
 	cp $22
 	jp z, .asm_112eea
 
 .asm_112e65
-	ld a, [$c990]
+	ld a, [wc990]
 	or a
 	jp z, .asm_112f3d
 .asm_112e6c
-	ld hl, $c98c
+	ld hl, wc98c
 	ld a, [hld]
 	cp $3
 	jr nz, .asm_112e7f
@@ -7044,11 +7044,11 @@ Function112d33:
 	call Function1133fe
 
 .asm_112e7f
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	res 0, [hl]
-	ld de, $c98b
-	ld a, [$c990]
+	ld de, wc98b
+	ld a, [wc990]
 	cp $1
 	ld a, $32
 	jr z, .asm_112e95
@@ -7057,19 +7057,19 @@ Function112d33:
 	inc a
 
 .asm_112e95
-	ld [$c80f], a
-	ld hl, $c810
+	ld [wc80f], a
+	ld hl, wc810
 	ld a, [de]
 	inc de
 	ld [hli], a
 	ld a, [de]
 	ld [hl], a
 	ld a, $5
-	ld [$c86a], a
+	ld [wc86a], a
 	ret
 
 .asm_112ea6
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -7078,9 +7078,9 @@ Function112d33:
 	ld a, $2
 	cp h
 	jr nz, .asm_112ec1
-	ld a, [$c98d]
+	ld a, [wc98d]
 	ld b, a
-	ld a, [$c98e]
+	ld a, [wc98e]
 	or b
 	jr nz, .asm_112e6c
 	jr .asm_112f3d
@@ -7092,24 +7092,24 @@ Function112d33:
 	ld a, $4
 	cp h
 	jr nz, .asm_112e6c
-	ld a, [$c9a5]
+	ld a, [wc9a5]
 	or a
 	jr nz, .asm_112efb
-	ld a, [$c86e]
+	ld a, [wc86e]
 	ld l, a
-	ld a, [$c86f]
+	ld a, [wc86f]
 	or l
 	jr nz, .asm_112efb
 	ld a, $2
-	ld [$c86a], a
+	ld [wc86a], a
 	xor a
-	ld [$c86d], a
-	ld hl, $c821
+	ld [wc86d], a
+	ld hl, wc821
 	res 0, [hl]
 	ret
 
 .asm_112eea
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -7120,9 +7120,9 @@ Function112d33:
 	jp nz, .asm_112e6c
 
 .asm_112efb
-	ld a, [$c98d]
+	ld a, [wc98d]
 	ld b, a
-	ld a, [$c98e]
+	ld a, [wc98e]
 	cp b
 	jp nz, .asm_112e6c
 	or a
@@ -7130,34 +7130,34 @@ Function112d33:
 	cp $1
 	jp nz, .asm_112e6c
 	ld a, $1
-	ld [$c993], a
+	ld [wc993], a
 
 .asm_112f13
-	ld a, [$c86b]
+	ld a, [wc86b]
 	cp $7
 	jr z, .asm_112f3d
-	ld hl, $c98f
+	ld hl, wc98f
 	inc [hl]
 	ld a, $f
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, $1
-	ld [$c86b], a
-	ld a, [$c86d]
-	ld [$c86e], a
+	ld [wc86b], a
+	ld a, [wc86d]
+	ld [wc86e], a
 	xor a
-	ld [$c989], a
+	ld [wc989], a
 	ld a, $a3
 	ld de, $0010
-	ld hl, $c995
+	ld hl, wc995
 	jp Function111f02
 
 .asm_112f3d
-	ld a, [$c993]
+	ld a, [wc993]
 	cp $1
 	jr nz, .asm_112f52
 	ld a, $2
-	ld [$c990], a
-	ld hl, $c98d
+	ld [wc990], a
+	ld hl, wc98d
 	dec a
 	ld [hli], a
 	ld [hl], a
@@ -7165,20 +7165,20 @@ Function112d33:
 
 .asm_112f52
 	ld a, $2
-	ld [$c86a], a
+	ld [wc86a], a
 	xor a
-	ld [$c86d], a
-	ld hl, $c821
+	ld [wc86d], a
+	ld hl, wc821
 	res 0, [hl]
 	ret
 
 Function112f61:
-	ld hl, $c989
+	ld hl, wc989
 	ld a, [hl]
 	or a
 	jr nz, .asm_112f8a
 	inc [hl]
-	ld hl, $c880
+	ld hl, wc880
 	ld de, $0008
 	add hl, de
 .asm_112f70
@@ -7193,25 +7193,25 @@ Function112f61:
 
 .asm_112f7d
 	ld a, d
-	ld [$c990], a
+	ld [wc990], a
 	call Function112b11
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, e
 	ld [hli], a
 	ld [hl], d
 
 .asm_112f8a
-	ld hl, $c880
-	ld a, [$c82d]
+	ld hl, wc880
+	ld a, [wc82d]
 	ld b, a
 	or a
 	jr nz, .asm_112fa1
-	ld hl, $c98b
+	ld hl, wc98b
 	ld a, $0
 	ld [hli], a
 	ld [hl], a
 	ld a, $1
-	ld [$c990], a
+	ld [wc990], a
 	ret
 
 .asm_112fa1
@@ -7231,17 +7231,17 @@ Function112f61:
 	jr nz, .asm_112fa1
 
 .asm_112fc2
-	ld hl, $c990
+	ld hl, wc990
 	res 2, [hl]
 	jr .asm_112fce
 
 .asm_112fc9
-	ld hl, $c990
+	ld hl, wc990
 	set 2, [hl]
 
 .asm_112fce
 	call Function11306b
-	ld a, [$c990]
+	ld a, [wc990]
 	ret
 
 Function112fd5:
@@ -7265,9 +7265,9 @@ Function112fd5:
 	jr nz, .asm_112fe6
 	pop hl
 	ld c, b
-	ld a, [$c833]
+	ld a, [wc833]
 	ld e, a
-	ld a, [$c834]
+	ld a, [wc834]
 	ld d, a
 	or e
 	jr z, .asm_112ffe
@@ -7293,7 +7293,7 @@ Function113008:
 
 .asm_113013
 	call Function112b11
-	ld hl, $c98d
+	ld hl, wc98d
 	ld a, e
 	ld [hli], a
 	ld [hl], d
@@ -7302,7 +7302,7 @@ Function113008:
 	or e
 	ret z
 	ld a, $2
-	ld [$c990], a
+	ld [wc990], a
 	ret
 
 Function113026:
@@ -7326,10 +7326,10 @@ Function113026:
 	jr nz, .asm_113037
 	pop hl
 	ld c, b
-	ld de, $cb59
+	ld de, wMobileSDK_PacketBuffer + 18
 	call MobileSDK_CopyBytes
-	ld hl, $cb59
-	ld de, $c9b5
+	ld hl, wMobileSDK_PacketBuffer + 18
+	ld de, wc9b5
 	ld b, c
 	call MobileSDK_CopyBytes
 	xor a
@@ -7348,7 +7348,7 @@ Function113054:
 
 .asm_11305f
 	push bc
-	ld de, $c9b5
+	ld de, wc9b5
 	ld b, $30
 	call Function1136c1
 	pop bc
@@ -7356,8 +7356,8 @@ Function113054:
 	ret
 
 Function11306b:
-	ld hl, $c880
-	ld a, [$c82d]
+	ld hl, wc880
+	ld a, [wc82d]
 	ld b, a
 
 Function113072:
@@ -7367,7 +7367,7 @@ Function113072:
 	cp $9f
 	jp nz, Function1131a9
 	push hl
-	ld hl, $c990
+	ld hl, wc990
 	res 2, [hl]
 	pop hl
 	jr Function113095
@@ -7386,13 +7386,13 @@ Function113089:
 Function113095:
 	inc hl
 	push bc
-	ld a, [$c872]
+	ld a, [wc872]
 	ld b, a
-	ld a, [$c873]
+	ld a, [wc873]
 	or b
 	pop bc
 	jr z, .asm_1130b3
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $23
 	jr z, .asm_1130b3
 	cp $20
@@ -7403,12 +7403,12 @@ Function113095:
 
 .asm_1130b3
 	xor a
-	ld hl, $c86e
+	ld hl, wc86e
 	ld [hli], a
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $13
 	jr z, .asm_1130c8
 	cp $14
@@ -7416,23 +7416,23 @@ Function113095:
 
 .asm_1130c8
 	ld a, $6
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	ret z
 	jp Function112430
 
 .asm_1130d6
-	ld a, [$c82b]
+	ld a, [wc82b]
 	ld c, a
 	dec b
 	dec b
 	ld a, b
-	ld [$c82d], a
+	ld [wc82d], a
 	jr z, .asm_11310d
-	ld a, [$c873]
+	ld a, [wc873]
 	ld d, a
-	ld a, [$c872]
+	ld a, [wc872]
 	ld e, a
 	dec de
 	dec de
@@ -7446,13 +7446,13 @@ Function113095:
 .asm_1130f5
 	ld a, e
 	sub b
-	ld [$c82b], a
+	ld [wc82b], a
 	ld a, d
 	sbc $0
-	ld [$c82c], a
-	ld a, [$c874]
+	ld [wc82c], a
+	ld a, [wc874]
 	ld e, a
-	ld a, [$c875]
+	ld a, [wc875]
 	ld d, a
 	inc de
 	inc de
@@ -7462,20 +7462,20 @@ Function113095:
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	cp $9f
 	jr z, .asm_113150
-	ld a, [$ca3f]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 3]
 	or a
 	jr z, .asm_113150
 	ld l, c
 	sub c
 	ld c, a
 	ld a, l
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	add hl, bc
 	ld b, a
 	push de
-	ld a, [$c82b]
+	ld a, [wc82b]
 	ld e, a
-	ld a, [$c82c]
+	ld a, [wc82c]
 	ld d, a
 	xor a
 	or d
@@ -7487,7 +7487,7 @@ Function113095:
 .asm_113135
 	pop de
 	push hl
-	ld hl, $c82d
+	ld hl, wc82d
 	ld a, [hl]
 	add b
 	ld [hli], a
@@ -7497,7 +7497,7 @@ Function113095:
 	ld c, b
 	pop hl
 	call MobileSDK_CopyBytes
-	ld hl, $c82b
+	ld hl, wc82b
 	ld a, [hl]
 	sub c
 	ld [hli], a
@@ -7506,17 +7506,17 @@ Function113095:
 	ld [hl], a
 
 .asm_113150
-	ld hl, $c829
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	ld a, $2
-	ld [$c989], a
+	ld [wc989], a
 	ret
 
 Function113167:
@@ -7563,7 +7563,7 @@ Function113180:
 Function113197:
 	pop hl
 	ld c, b
-	ld de, $cb57
+	ld de, wMobileSDK_PacketBuffer + 16
 	ld a, b
 	ld [de], a
 	inc de
@@ -7577,8 +7577,8 @@ Function113197:
 	ret
 
 Function1131a9:
-	ld hl, $c979
-	ld de, $c880
+	ld hl, wc979
+	ld de, wc880
 	ld b, $0
 	ld c, b
 	ld a, [hl]
@@ -7596,7 +7596,7 @@ Function1131a9:
 	call MobileSDK_CopyBytes
 
 .asm_1131c4
-	ld a, [$c82b]
+	ld a, [wc82b]
 	ld b, a
 	add c
 	ld c, a
@@ -7605,23 +7605,23 @@ Function1131a9:
 	sub b
 	ld c, a
 	ld b, 0
-	ld hl, $ca40
+	ld hl, wMobileSDK_ReceivePacketBuffer + 4
 	add hl, bc
 	pop bc
 	call MobileSDK_CopyBytes
 	ld a, c
-	ld [$c82d], a
+	ld [wc82d], a
 	ld a, $fa
 	sub c
-	ld [$c82b], a
-	ld hl, $c829
+	ld [wc82b], a
+	ld hl, wc829
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hl], a
 	ld l, e
 	ld h, d
-	ld de, $c97a
+	ld de, wc97a
 .asm_1131ef
 	xor a
 	ld [hli], a
@@ -7631,9 +7631,9 @@ Function1131a9:
 	ld a, d
 	cp h
 	jr nz, .asm_1131ef
-	ld hl, $c821
+	ld hl, wc821
 	res 2, [hl]
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	dec [hl]
 	ld a, $4
@@ -7642,60 +7642,60 @@ Function1131a9:
 Function113206:
 	ld a, b
 	sub e
-	ld [$c991], a
-	ld a, [$c821]
+	ld [wc991], a
+	ld a, [wc821]
 	bit 2, a
 	ld a, c
 	jr nz, .asm_113214
 	xor a
 
 .asm_113214
-	ld [$c992], a
+	ld [wc992], a
 	ld b, e
 	ld c, e
-	ld a, [$c874]
+	ld a, [wc874]
 	ld e, a
-	ld a, [$c875]
+	ld a, [wc875]
 	ld d, a
 	inc de
 	inc de
 	call MobileSDK_CopyBytes
-	ld a, [$c991]
-	ld [$c993], a
+	ld a, [wc991]
+	ld [wc993], a
 	ld b, a
-	ld de, $c880
+	ld de, wc880
 	call MobileSDK_CopyBytes
-	ld hl, $c82d
+	ld hl, wc82d
 	ld a, c
 	ld [hli], a
 	xor a
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	set 2, [hl]
 	ld a, $3
-	ld [$c86b], a
+	ld [wc86b], a
 	ret
 
 Function113245:
 	ld a, b
 	sub e
-	ld [$c992], a
-	ld [$c82b], a
+	ld [wc992], a
+	ld [wc82b], a
 	ld b, e
 	ld c, e
 	pop de
 	call MobileSDK_CopyBytes
-	ld hl, $c82d
+	ld hl, wc82d
 	ld a, c
 	add [hl]
 	ld [hli], a
 	ld a, $0
 	adc [hl]
 	ld [hl], a
-	ld hl, $c821
+	ld hl, wc821
 	set 2, [hl]
 	ld a, $3
-	ld [$c86b], a
+	ld [wc86b], a
 	ret
 
 Function113268:
@@ -7776,21 +7776,21 @@ Unknown_11330c:
 
 Function113317:
 	ld a, $1
-	ld [$c86b], a
-	ld de, $cb59
-	ld a, [$c86c]
+	ld [wc86b], a
+	ld de, wMobileSDK_PacketBuffer + 18
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	call Function1126b0
 	ld hl, Unknown_1132dd
-	ld a, [$c9a5]
+	ld a, [wc9a5]
 	or a
 	call nz, MobileSDK_CopyString
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $22
 	jr nz, .asm_113344
-	ld a, [$c98a]
+	ld a, [wc98a]
 	cp $2
 	jr nz, .asm_113351
 	jr .asm_113348
@@ -7800,21 +7800,21 @@ Function113317:
 	jr nz, .asm_113351
 
 .asm_113348
-	ld a, [$c9a5]
+	ld a, [wc9a5]
 	or a
 	jr z, .asm_11336a
 	call Function1133de
 
 .asm_113351
-	ld hl, $c9b5
+	ld hl, wc9b5
 	call MobileSDK_CopyString
 	call Function1126b6
 	ld a, c
-	ld [$cb58], a
+	ld [wMobileSDK_PacketBuffer + 17], a
 	ld b, c
 	call Function111f63
 	ld a, $95
-	ld hl, $cb53
+	ld hl, wMobileSDK_PacketBuffer + 12
 	jp Function111f02
 
 .asm_11336a
@@ -7828,57 +7828,57 @@ Unknown_113372:
 Function113386:
 	call Function113482
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	ld de, wMobileSDK_PacketBuffer
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86c]
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld b, $1
 	call Function111f63
-	ld de, $cb53
+	ld de, wMobileSDK_PacketBuffer + 12
 	ld hl, MobilePacket_TransferData
 	ld b, $6
 	call MobileSDK_CopyBytes
-	ld a, [$c86d]
+	ld a, [wc86d]
 	cp $3
 	jp nz, Function113317
-	ld de, $cb59
-	ld a, [$c86c]
+	ld de, wMobileSDK_PacketBuffer + 18
+	ld a, [wc86c]
 	ld [de], a
 	inc de
 	ld bc, $0001
 	call Function1126b0
-	ld a, [$c994]
+	ld a, [wc994]
 	or a
 	call nz, Function1133de
 	call Function1126b6
 	ld a, c
-	ld [$cb58], a
+	ld [wMobileSDK_PacketBuffer + 17], a
 	ld b, c
 	call Function111f63
 	ld a, $95
-	ld hl, $cb53
+	ld hl, wMobileSDK_PacketBuffer + 12
 	jp Function111f02
 
 Function1133de:
 	call Function1126e6
 	xor a
-	ld [$c86b], a
-	ld a, [$c9aa]
-	ld [$c87c], a
-	ld a, [$c9ab]
-	ld [$c87d], a
-	ld a, [$c9ac]
-	ld [$c87e], a
-	ld a, [$c9ad]
-	ld [$c87f], a
+	ld [wc86b], a
+	ld a, [wc9aa]
+	ld [wc87c], a
+	ld a, [wc9ab]
+	ld [wc87d], a
+	ld a, [wc9ac]
+	ld [wc87e], a
+	ld a, [wc9ad]
+	ld [wc87f], a
 	ret
 
 Function1133fe:
-	ld hl, $cb58
+	ld hl, wMobileSDK_PacketBuffer + 17
 	ld a, [hli]
 	cp $68
 	jr nz, .asm_113432
@@ -7900,8 +7900,8 @@ Function1133fe:
 	ld a, [hli]
 	cp $2f
 	jr nz, .asm_113432
-	ld hl, $cb57
-	ld de, $c880
+	ld hl, wMobileSDK_PacketBuffer + 16
+	ld de, wc880
 	ld a, [hli]
 	ld b, a
 	call MobileSDK_CopyBytes
@@ -7910,11 +7910,11 @@ Function1133fe:
 	ret
 
 .asm_113432
-	ld a, [$cb58]
+	ld a, [wMobileSDK_PacketBuffer + 17]
 	cp $2f
 	jr z, .asm_113460
-	ld de, $c880
-	ld hl, $c9b5
+	ld de, wc880
+	ld hl, wc9b5
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -7935,7 +7935,7 @@ Function1133fe:
 	ld e, l
 	ld d, h
 .asm_113455
-	ld hl, $cb57
+	ld hl, wMobileSDK_PacketBuffer + 16
 	ld a, [hli]
 	ld b, a
 	call MobileSDK_CopyBytes
@@ -7944,8 +7944,8 @@ Function1133fe:
 	ret
 
 .asm_113460
-	ld de, $c880
-	ld hl, $c9b5
+	ld de, wc880
+	ld hl, wc9b5
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -7970,7 +7970,7 @@ Function1133fe:
 	jr .asm_113455
 
 Function113482:
-	ld hl, $c87f
+	ld hl, wc87f
 	ld a, [hld]
 	ld b, a
 	ld a, [hld]
@@ -7989,7 +7989,7 @@ Function113482:
 .asm_113496
 	ld e, l
 	ld d, h
-	ld hl, $c87f
+	ld hl, wc87f
 	ld a, d
 	ld [hld], a
 	ld a, e
@@ -8003,18 +8003,18 @@ Function113482:
 	ld h, a
 	ld a, c
 	inc a
-	ld [$cb4c], a
-	ld de, $cb4e
+	ld [wMobileSDK_PacketBuffer + 5], a
+	ld de, wMobileSDK_PacketBuffer + 7
 	ld b, c
 	call MobileSDK_CopyBytes
 	ld a, l
-	ld [$c87c], a
+	ld [wc87c], a
 	ld a, h
-	ld [$c87d], a
+	ld [wc87d], a
 	ld b, c
 	inc b
 	call Function111f63
-	ld hl, $c86b
+	ld hl, wc86b
 	dec [hl]
 	ld hl, wMobileSDK_PacketBuffer
 	ld a, $95
@@ -8033,14 +8033,14 @@ Function1134cb:
 	ret
 
 .asm_1134d9
-	ld a, [$ca40]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 4]
 	cp $0
 	jr z, .asm_1134f0
 	cp $ff
 	jr z, .asm_1134f0
-	ld a, [$c985]
-	ld [$c86a], a
-	ld hl, $c821
+	ld a, [wc985]
+	ld [wc86a], a
+	ld hl, wc821
 	res 0, [hl]
 	ret
 
@@ -8055,11 +8055,11 @@ Function1134cb:
 	jp PacketSendEmptyBody
 
 .asm_1134fc
-	ld hl, $c86e
+	ld hl, wc86e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [$ca42]
+	ld a, [wMobileSDK_ReceivePacketBuffer + 6]
 	cp $f0
 	jr c, .asm_11350b
 	set 7, [hl]
@@ -8068,7 +8068,7 @@ Function1134cb:
 	jp Function112269
 
 .asm_11350e
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $1e
 	jp nz, Function112251
 	jp Function1116a0
@@ -8090,7 +8090,7 @@ Function113519:
 	jp Function11236b
 
 .asm_11352d
-	ld hl, $c829
+	ld hl, wc829
 	ld a, $e0
 	ld [hli], a
 	ld a, $c8
@@ -8102,7 +8102,7 @@ Function113519:
 	jp Function112269
 
 .asm_11353f
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	cp $4d
 	jr nz, .asm_113586
@@ -8126,13 +8126,13 @@ Function113519:
 	ld a, [hl]
 	cp e
 	jr nz, .asm_11358a
-	ld a, [$c86e]
+	ld a, [wc86e]
 	ld e, a
-	ld a, [$c86f]
+	ld a, [wc86f]
 	ld d, a
 	ld hl, .asm_11357e
 	push hl
-	ld a, [$c86a]
+	ld a, [wc86a]
 	cp $25
 	jr z, Function1135ba
 	cp $26
@@ -8141,7 +8141,7 @@ Function113519:
 	jr z, Function1135ad
 .asm_11357e
 	ld a, $1
-	ld [$c835], a
+	ld [wc835], a
 	jp Function1116a0
 
 .asm_113586
@@ -8170,7 +8170,7 @@ Function11359d:
 	ld b, $20
 	call Function113592
 	ld a, $21
-	ld hl, $c88c
+	ld hl, wc88c
 	call MobileSDK_CopyStringLen
 	xor a
 	ld [de], a
@@ -8180,28 +8180,28 @@ Function1135ad:
 	ld b, $1e
 	call Function113592
 	ld a, $1f
-	ld hl, $c8ac
+	ld hl, wc8ac
 	jp MobileSDK_CopyStringLen
 
 Function1135ba:
 	ld b, $65
 	call Function113592
-	ld hl, $c8f6
+	ld hl, wc8f6
 	call Function1135eb
 	ld a, $11
-	ld hl, $c8fe
+	ld hl, wc8fe
 	call MobileSDK_CopyStringLen
 	inc de
-	ld hl, $c90e
+	ld hl, wc90e
 	call Function1135eb
 	ld a, $11
-	ld hl, $c916
+	ld hl, wc916
 	call MobileSDK_CopyStringLen
 	inc de
-	ld hl, $c926
+	ld hl, wc926
 	call Function1135eb
 	ld a, $11
-	ld hl, $c92e
+	ld hl, wc92e
 	jp MobileSDK_CopyStringLen
 
 Function1135eb:
@@ -8264,14 +8264,14 @@ Function113626:
 	jp Function11234b
 
 .asm_113639
-	ld a, [$c882]
+	ld a, [wc882]
 	or a
 	jr nz, .asm_113642
 	inc [hl]
 	jr .asm_11366c
 
 .asm_113642
-	ld de, $cb4c
+	ld de, wMobileSDK_PacketBuffer + 5
 	ld c, a
 	inc a
 	ld [de], a
@@ -8279,7 +8279,7 @@ Function113626:
 	ld a, $80
 	ld [de], a
 	inc de
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8288,7 +8288,7 @@ Function113626:
 	ld b, c
 	inc b
 	call Function111f63
-	ld a, [$cb4c]
+	ld a, [wMobileSDK_PacketBuffer + 5]
 	add $a
 	ld e, a
 	ld d, 0
@@ -8319,7 +8319,7 @@ Function113672:
 	jp Function11236b
 
 .asm_113686
-	ld a, [$c882]
+	ld a, [wc882]
 	or a
 	jr z, .asm_113693
 	cp $81
@@ -8328,15 +8328,15 @@ Function113672:
 	jr .asm_1136bb
 
 .asm_113693
-	ld hl, $cb4e
+	ld hl, wMobileSDK_PacketBuffer + 7
 	sub $80
 	ld [hld], a
 	ld a, $80
 	ld [hl], a
-	ld de, $cb4f
+	ld de, wMobileSDK_PacketBuffer + 8
 	ld b, $2
 	call Function111f63
-	ld hl, $c880
+	ld hl, wc880
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8344,7 +8344,7 @@ Function113672:
 	add hl, de
 	ld e, h
 	ld a, l
-	ld hl, $c829
+	ld hl, wc829
 	ld [hli], a
 	ld [hl], e
 	ld hl, wMobileSDK_PacketBuffer
@@ -8358,27 +8358,27 @@ Function113672:
 
 Function1136c1:
 	xor a
-	ld [$cc28], a
+	ld [wMobileSDK_PacketBuffer + 225], a
 	ld a, l
-	ld [$cc07], a
+	ld [wMobileSDK_PacketBuffer + 192], a
 	ld a, h
-	ld [$cc08], a
-	ld hl, $cc09
+	ld [wMobileSDK_PacketBuffer + 193], a
+	ld hl, wMobileSDK_PacketBuffer + 194
 	ld a, e
 	ld [hli], a
 	ld a, d
 	ld [hli], a
 	ld a, b
 	ld [hli], a
-	ld hl, $cc07
+	ld hl, wMobileSDK_PacketBuffer + 192
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cb67
+	ld de, wMobileSDK_PacketBuffer + 32
 	ld b, $30
 	ld c, b
 	call MobileSDK_CopyBytes
-	ld hl, $c97f
+	ld hl, wc97f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8392,7 +8392,7 @@ Function1136c1:
 	inc a
 	jr nc, .asm_1136ff
 	ld a, $2
-	ld [$cc28], a
+	ld [wMobileSDK_PacketBuffer + 225], a
 	ld a, $78
 
 .asm_1136ff
@@ -8431,29 +8431,29 @@ Function1136c1:
 	ld [hli], a
 	dec b
 	jr nz, .asm_113725
-	ld de, $cbe7
+	ld de, wMobileSDK_PacketBuffer + 160
 	ld hl, Unknown_113b7e
 	ld b, $10
 	call MobileSDK_CopyBytes
 
 .asm_113734
-	ld hl, $cc0c
+	ld hl, wMobileSDK_PacketBuffer + 197
 	ld a, LOW(MD5_K_Table)
 	ld [hli], a
 	ld a, HIGH(MD5_K_Table)
 	ld [hl], a
-	ld hl, $cc0e
+	ld hl, wMobileSDK_PacketBuffer + 199
 	ld a, LOW(Unknown_113a70)
 	ld [hli], a
 	ld a, HIGH(Unknown_113a70)
 	ld [hl], a
-	ld hl, $cbe7
-	ld de, $cc18
+	ld hl, wMobileSDK_PacketBuffer + 160
+	ld de, wMobileSDK_PacketBuffer + 209
 	ld b, $10
 	call MobileSDK_CopyBytes
 
 .asm_113751
-	ld hl, $cc0e
+	ld hl, wMobileSDK_PacketBuffer + 199
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8461,11 +8461,11 @@ Function1136c1:
 	ld c, a
 	push hl
 	call Function113909
-	ld hl, $cbf7
+	ld hl, wMobileSDK_PacketBuffer + 176
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a32
 	pop hl
 	ld a, [hli]
@@ -8473,7 +8473,7 @@ Function1136c1:
 	inc hl
 	ld e, a
 	push hl
-	ld a, [$cc28]
+	ld a, [wMobileSDK_PacketBuffer + 225]
 	bit 0, a
 	jr z, .asm_11377c
 	ld hl, $0040
@@ -8482,41 +8482,41 @@ Function1136c1:
 	ld d, h
 
 .asm_11377c
-	ld hl, $cb67
+	ld hl, wMobileSDK_PacketBuffer + 32
 	add hl, de
 	ld e, l
 	ld d, h
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a32
-	ld hl, $cc0c
+	ld hl, wMobileSDK_PacketBuffer + 197
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a32
 	pop hl
 	ld a, [hli]
 	ld b, a
 	ld a, l
-	ld [$cc0e], a
+	ld [wMobileSDK_PacketBuffer + 199], a
 	ld a, h
-	ld [$cc0f], a
-	ld hl, $cbff
+	ld [wMobileSDK_PacketBuffer + 200], a
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a40
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a32
-	ld hl, $cbf7
+	ld hl, wMobileSDK_PacketBuffer + 176
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cc0c
+	ld hl, wMobileSDK_PacketBuffer + 197
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8524,47 +8524,47 @@ rept 4
 	inc hl
 endr
 	ld a, h
-	ld [$cc0d], a
+	ld [wMobileSDK_PacketBuffer + 198], a
 	ld a, l
-	ld [$cc0c], a
+	ld [wMobileSDK_PacketBuffer + 197], a
 	cp $8e ; LOW(MD5_K_Table + $100) ???
 	jp nz, .asm_113751
-	ld de, $cc18
-	ld hl, $cbe7
+	ld de, wMobileSDK_PacketBuffer + 209
+	ld hl, wMobileSDK_PacketBuffer + 160
 	call Function113a32
-	ld de, $cc1c
+	ld de, wMobileSDK_PacketBuffer + 213
 	call Function113a32
-	ld de, $cc20
+	ld de, wMobileSDK_PacketBuffer + 217
 	call Function113a32
-	ld de, $cc24
+	ld de, wMobileSDK_PacketBuffer + 221
 	call Function113a32
-	ld hl, $cc28
+	ld hl, wMobileSDK_PacketBuffer + 225
 	bit 1, [hl]
 	jr z, .asm_1137fc
 	dec [hl]
 	jp .asm_113734
 
 .asm_1137fc
-	ld hl, $cb67
-	ld de, $cb97
+	ld hl, wMobileSDK_PacketBuffer + 32
+	ld de, wMobileSDK_PacketBuffer + 80
 	ld bc, $0030
 	call Function113d66
-	ld hl, $cc09
+	ld hl, wMobileSDK_PacketBuffer + 194
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
 	ld hl, Unknown_113a55
 	call MobileSDK_CopyString
-	ld hl, $cb97
+	ld hl, wMobileSDK_PacketBuffer + 80
 	ld bc, $0020
 	call Function113c8e
 	ld a, l
-	ld [$cc09], a
+	ld [wMobileSDK_PacketBuffer + 194], a
 	ld a, h
-	ld [$cc0a], a
+	ld [wMobileSDK_PacketBuffer + 195], a
 	ld b, $12
-	ld hl, $cb97
-	ld de, $cb67
+	ld hl, wMobileSDK_PacketBuffer + 80
+	ld de, wMobileSDK_PacketBuffer + 32
 .asm_11382d
 	ld a, $40
 	and [hl]
@@ -8613,8 +8613,8 @@ endr
 	dec b
 	jr nz, .asm_11382d
 	ld b, $12
-	ld hl, $cbba
-	ld de, $cb8a
+	ld hl, wMobileSDK_PacketBuffer + 115
+	ld de, wMobileSDK_PacketBuffer + 67
 .asm_11386c
 	ld a, $2
 	and [hl]
@@ -8663,11 +8663,11 @@ endr
 	dec b
 	jr nz, .asm_11386c
 	ld b, $10
-	ld de, $cb97
-	ld hl, $cbe7
+	ld de, wMobileSDK_PacketBuffer + 80
+	ld hl, wMobileSDK_PacketBuffer + 160
 	call MobileSDK_CopyBytes
 	ld bc, $0010
-	ld hl, $c97f
+	ld hl, wc97f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -8685,8 +8685,8 @@ endr
 	xor a
 	ld [hl], a
 	ld b, $24
-	ld hl, $cb67
-	ld de, $cb97
+	ld hl, wMobileSDK_PacketBuffer + 32
+	ld de, wMobileSDK_PacketBuffer + 80
 .asm_1138d0
 	ld a, [de]
 	inc de
@@ -8712,11 +8712,11 @@ endr
 	ld [hli], a
 	dec b
 	jr nz, .asm_1138d0
-	ld hl, $cc09
+	ld hl, wMobileSDK_PacketBuffer + 194
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cb67
+	ld hl, wMobileSDK_PacketBuffer + 32
 	ld bc, $0024
 	call Function113c8e
 	ld a, $22
@@ -8748,121 +8748,121 @@ Function11391e:
 	ld d, 0
 	ld hl, Unknown_113b70
 	add hl, de
-	ld de, $cbf7
+	ld de, wMobileSDK_PacketBuffer + 176
 	ld b, $8
 	jp MobileSDK_CopyBytes
 
 Function11392f:
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cbff
+	ld de, wMobileSDK_PacketBuffer + 184
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cbfb
+	ld hl, wMobileSDK_PacketBuffer + 180
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a0b
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cc03
+	ld de, wMobileSDK_PacketBuffer + 188
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 188
 	call Function113a1f
-	ld hl, $cbfd
+	ld hl, wMobileSDK_PacketBuffer + 182
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 188
 	call Function113a0b
-	ld hl, $cbff
-	ld de, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 184
+	ld de, wMobileSDK_PacketBuffer + 188
 	call Function113a15
 	ret
 
 Function113973:
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cbff
+	ld de, wMobileSDK_PacketBuffer + 184
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cbfd
+	ld hl, wMobileSDK_PacketBuffer + 182
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a0b
-	ld hl, $cbfd
+	ld hl, wMobileSDK_PacketBuffer + 182
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cc03
+	ld de, wMobileSDK_PacketBuffer + 188
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 188
 	call Function113a1f
-	ld hl, $cbfb
+	ld hl, wMobileSDK_PacketBuffer + 180
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 188
 	call Function113a0b
-	ld hl, $cbff
-	ld de, $cc03
+	ld hl, wMobileSDK_PacketBuffer + 184
+	ld de, wMobileSDK_PacketBuffer + 188
 	call Function113a15
 	ret
 
 Function1139b7:
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cbff
+	ld de, wMobileSDK_PacketBuffer + 184
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cbfb
+	ld hl, wMobileSDK_PacketBuffer + 180
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a28
-	ld hl, $cbfd
+	ld hl, wMobileSDK_PacketBuffer + 182
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a28
 	ret
 
 Function1139de:
-	ld hl, $cbfd
+	ld hl, wMobileSDK_PacketBuffer + 182
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld de, $cbff
+	ld de, wMobileSDK_PacketBuffer + 184
 	ld b, $4
 	call MobileSDK_CopyBytes
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a1f
-	ld hl, $cbf9
+	ld hl, wMobileSDK_PacketBuffer + 178
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a15
-	ld hl, $cbfb
+	ld hl, wMobileSDK_PacketBuffer + 180
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
-	ld hl, $cbff
+	ld hl, wMobileSDK_PacketBuffer + 184
 	call Function113a28
 	ret
 
@@ -8969,13 +8969,13 @@ Unknown_113a70:
 	db $30, $10, $00, $06, $36, $2c, $00, $0a, $34, $08, $00, $0f, $32, $24, $00, $15
 
 Unknown_113b70:
-	dw $cbe7
-	dw $cbeb
-	dw $cbef
-	dw $cbf3
-	dw $cbe7
-	dw $cbeb
-	dw $cbef
+	dw wMobileSDK_PacketBuffer + 160
+	dw wMobileSDK_PacketBuffer + 164
+	dw wMobileSDK_PacketBuffer + 168
+	dw wMobileSDK_PacketBuffer + 172
+	dw wMobileSDK_PacketBuffer + 160
+	dw wMobileSDK_PacketBuffer + 164
+	dw wMobileSDK_PacketBuffer + 168
 
 Unknown_113b7e:
 	db $01, $23, $45, $67, $89, $ab, $cd, $ef
@@ -9001,9 +9001,9 @@ MD5_K_Table:
 
 Function113c8e:
 	ld a, c
-	ld [$cc10], a
+	ld [wMobileSDK_PacketBuffer + 201], a
 	ld a, b
-	ld [$cc11], a
+	ld [wMobileSDK_PacketBuffer + 202], a
 	ld c, e
 	ld b, d
 	ld e, l
@@ -9011,21 +9011,21 @@ Function113c8e:
 	ld l, c
 	ld h, b
 	xor a
-	ld [$cc16], a
+	ld [wMobileSDK_PacketBuffer + 207], a
 
 .asm_113ca0
 	ld b, $3
 	push hl
-	ld hl, $cc12
+	ld hl, wMobileSDK_PacketBuffer + 203
 .asm_113ca6
 	ld a, [de]
 	inc de
 	ld [hli], a
 	dec b
 	jr nz, .asm_113ca6
-	ld a, [$cc10]
+	ld a, [wMobileSDK_PacketBuffer + 201]
 	ld c, a
-	ld a, [$cc11]
+	ld a, [wMobileSDK_PacketBuffer + 202]
 	ld b, a
 	xor a
 	or b
@@ -9036,7 +9036,7 @@ Function113c8e:
 	push hl
 	dec hl
 	ld a, c
-	ld [$cc16], a
+	ld [wMobileSDK_PacketBuffer + 207], a
 .asm_113cc3
 	xor a
 	ld [hld], a
@@ -9052,9 +9052,9 @@ Function113c8e:
 	dec bc
 	dec bc
 	ld a, c
-	ld [$cc10], a
+	ld [wMobileSDK_PacketBuffer + 201], a
 	ld a, b
-	ld [$cc11], a
+	ld [wMobileSDK_PacketBuffer + 202], a
 	push de
 	dec hl
 	ld c, [hl]
@@ -9108,13 +9108,13 @@ Function113c8e:
 	inc bc
 	call Function113d47
 	ld [hli], a
-	ld a, [$cc10]
+	ld a, [wMobileSDK_PacketBuffer + 201]
 	cp $0
 	jp nz, .asm_113ca0
-	ld a, [$cc11]
+	ld a, [wMobileSDK_PacketBuffer + 202]
 	cp $0
 	jp nz, .asm_113ca0
-	ld a, [$cc16]
+	ld a, [wMobileSDK_PacketBuffer + 207]
 	cp $0
 	jr z, .asm_113d43
 	push hl
@@ -9164,9 +9164,9 @@ Function113d47:
 
 Function113d66:
 	ld a, c
-	ld [$cc10], a
+	ld [wMobileSDK_PacketBuffer + 201], a
 	ld a, b
-	ld [$cc11], a
+	ld [wMobileSDK_PacketBuffer + 202], a
 	ld c, e
 	ld b, d
 	ld e, l
@@ -9174,17 +9174,17 @@ Function113d66:
 	ld l, c
 	ld h, b
 .asm_113d74
-	ld a, [$cc11]
+	ld a, [wMobileSDK_PacketBuffer + 202]
 	or a
 	jr nz, .asm_113d82
-	ld a, [$cc10]
+	ld a, [wMobileSDK_PacketBuffer + 201]
 	cp $4
 	jp c, .asm_113e26
 
 .asm_113d82
 	ld b, $4
 	push hl
-	ld hl, $cc12
+	ld hl, wMobileSDK_PacketBuffer + 203
 .asm_113d88
 	ld a, [de]
 	inc de
@@ -9192,9 +9192,9 @@ Function113d66:
 	ld [hli], a
 	dec b
 	jr nz, .asm_113d88
-	ld a, [$cc10]
+	ld a, [wMobileSDK_PacketBuffer + 201]
 	ld c, a
-	ld a, [$cc11]
+	ld a, [wMobileSDK_PacketBuffer + 202]
 	ld b, a
 rept 4
 	dec bc
@@ -9216,9 +9216,9 @@ endr
 
 .asm_113dae
 	ld a, c
-	ld [$cc10], a
+	ld [wMobileSDK_PacketBuffer + 201], a
 	ld a, b
-	ld [$cc11], a
+	ld [wMobileSDK_PacketBuffer + 202], a
 	push de
 	dec hl
 	ld d, [hl]
@@ -9263,10 +9263,10 @@ endr
 	inc bc
 	ld a, [bc]
 	ld [hli], a
-	ld a, [$cc10]
+	ld a, [wMobileSDK_PacketBuffer + 201]
 	or a
 	jr nz, .asm_113d74
-	ld a, [$cc11]
+	ld a, [wMobileSDK_PacketBuffer + 202]
 	or a
 	jp nz, .asm_113d74
 	xor a
@@ -9300,10 +9300,10 @@ endr
 	pop hl
 	pop hl
 .asm_113e26
-	ld hl, $c821
+	ld hl, wc821
 	set 1, [hl]
 	ld a, $20
-	ld [$c80f], a
+	ld [wc80f], a
 	ret
 
 .asm_113e31
@@ -9342,7 +9342,7 @@ Function113e42:
 	ret
 
 .asm_113e4f
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $8
 	jr nz, .asm_113e58
 .asm_113e56
@@ -9351,10 +9351,10 @@ Function113e42:
 
 .asm_113e58
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld a, $2
-	ld [$c86a], a
-	ld hl, $c821
+	ld [wc86a], a
+	ld hl, wc821
 	ld a, [hl]
 	and $10
 	set 5, a
@@ -9362,7 +9362,7 @@ Function113e42:
 	jp Function113eb8
 
 .asm_113e6d
-	ld a, [$c86d]
+	ld a, [wc86d]
 	or a
 	ld a, [wMobileSDK_ReceivePacketBuffer]
 	jr z, .asm_113e81
@@ -9379,48 +9379,48 @@ Function113e42:
 
 .asm_113e85
 	xor a
-	ld [$c86d], a
+	ld [wc86d], a
 	ld [wMobileSDK_SendCommandID], a
 	ld a, $2
-	ld [$c86a], a
+	ld [wc86a], a
 	ld a, $3
-	ld [$c807], a
-	ld hl, $c821
+	ld [wc807], a
+	ld hl, wc821
 	ld a, [hl]
 	and $10
 	set 5, a
 	ld [hl], a
-	ld hl, $c822
+	ld hl, wc822
 	bit 0, [hl]
 	call z, Function111f97
 	ret
 
 .asm_113ea8
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $8
 	jr z, .asm_113e56
 	ret
 
 .asm_113eb0
 	ld a, $1
-	ld [$c86b], a
+	ld [wc86b], a
 	jp .asm_113e6d
 
 Function113eb8:
 	ld a, $ff
 	ld [wMobileSDK_SendCommandID], a
-	ld hl, $c822
+	ld hl, wc822
 	res 5, [hl]
 	res 0, [hl]
 	jp Function111f97
 
 Function113ec7: ; unreferenced
-	ld hl, $c822
+	ld hl, wc822
 	ld a, [hl]
 	push af
 	res 3, [hl]
 	res 0, [hl]
-	ld hl, $c81a
+	ld hl, wc81a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -9439,7 +9439,7 @@ Function113ec7: ; unreferenced
 	pop af
 	bit 0, a
 	ret z
-	ld hl, $c822
+	ld hl, wc822
 	set 0, [hl]
 	ret
 
@@ -9452,7 +9452,7 @@ Function113ef2:
 	ret
 
 .asm_113efa
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $8
 	jr nz, Function113eb8
 	dec [hl]
@@ -9462,8 +9462,8 @@ Function113ef2:
 	ld a, $26
 	call Function11225d
 	ld a, $2a
-	ld [$c86a], a
-	ld hl, $c820
+	ld [wc86a], a
+	ld hl, wc820
 	ld a, [hld]
 	ld h, [hl]
 	ld l, a
@@ -9473,13 +9473,13 @@ Function113ef2:
 	add hl, de
 	ld e, l
 	ld d, h
-	ld hl, $c815
+	ld hl, wc815
 	ld e, a
 	ld [hli], a
 	ld a, d
 	ld [hl], a
 	xor a
-	ld [$c800], a
+	ld [wc800], a
 	ld hl, wMobileSDK_PacketBuffer
 	ld a, $2
 	ld [hli], a
@@ -9496,7 +9496,7 @@ Function113f2d:
 	ret
 
 .asm_113f35
-	ld a, [$c807]
+	ld a, [wc807]
 	cp $8
 	jr nz, .asm_113f3e
 	dec [hl]
@@ -9513,17 +9513,17 @@ Function113f2d:
 
 .asm_113f4f
 	xor a
-	ld [$c86d], a
-	ld hl, $c821
+	ld [wc86d], a
+	ld hl, wc821
 	set 0, [hl]
-	ld hl, $c822
+	ld hl, wc822
 	xor a
 	ld [hl], a
 	xor a
-	ld [$c80b], a
+	ld [wc80b], a
 	xor a
 	ld [wMobileSDK_PacketBuffer], a
-	ld hl, $c820
+	ld hl, wc820
 	ld a, [hld]
 	ld h, [hl]
 	ld l, a
@@ -9533,13 +9533,13 @@ Function113f2d:
 	add hl, de
 	ld e, l
 	ld d, h
-	ld hl, $c815
+	ld hl, wc815
 	ld e, a
 	ld [hli], a
 	ld a, d
 	ld [hl], a
 	xor a
-	ld [$c800], a
+	ld [wc800], a
 	ld hl, wMobileSDK_PacketBuffer
 	xor a
 	ld [hli], a

--- a/wram.asm
+++ b/wram.asm
@@ -1101,20 +1101,135 @@ wCreditsBlankFrame2bppEnd::
 SECTION UNION "Overworld Map", WRAM0
 
 ; mobile
-	ds 7
-wc807:: ds 1
-	ds 10
+wc800:: db
+wc801:: db
+wc802:: db
+wc803:: db
+wc804:: db
+wc805:: db
+wc806:: db
+wc807:: db
+wc808:: dw
+wc80a:: db
+wc80b:: db
+wc80c:: dw
+wc80e:: db
+wc80f:: db
+wc810:: db
+wc811:: db
 wMobileSDK_PacketChecksum:: dw
-	ds 4
+wc814:: db
+wc815:: db
+wc816:: dw
 wMobileSDK_AdapterType:: db
-	ds 5
+wc819:: db
+wc81a:: db
+wc81b:: db
+wc81c:: db
+wc81d:: db
 wMobileSDK_SendCommandID:: db
-	ds 2
-wc821:: ds 1
-wc822:: ds 525
+wc81f:: db
+wc820:: db
+wc821:: db
+wc822:: db
+wc823:: ds 4
+wc827:: dw
+wc829:: db
+wc82a:: db
+wc82b:: db
+wc82c:: db
+wc82d:: db
+wc82e:: db
+wc82f:: ds 3
+wc832:: db
+wc833:: db
+wc834:: db
+wc835:: db
+wc836:: ds 8
+wc83e:: ds 20
+wc852:: ds 20
+wc866:: ds 4
+wc86a:: db
+wc86b:: db
+wc86c:: db
+wc86d:: db
+wc86e:: db
+wc86f:: db
+wc870:: db
+wc871:: db
+wc872:: db
+wc873:: db
+wc874:: db
+wc875:: db
+wc876:: db
+wc877:: db
+wc878:: dw
+wc87a:: db
+wc87b:: db
+wc87c:: db
+wc87d:: db
+wc87e:: db
+wc87f:: db
+wc880:: db
+wc881:: db
+wc882:: db
+wc883:: db
+wc884:: ds 8
+wc88c:: ds 32
+wc8ac:: ds 26
+wc8c6:: db
+wc8c7:: db
+wc8c8:: db
+wc8c9:: db
+wc8ca:: ds 44
+wc8f6:: ds 8
+wc8fe:: db
+wc8ff:: ds 15
+wc90e:: ds 8
+wc916:: ds 16
+wc926:: ds 8
+wc92e:: ds 75
+wc979:: db
+wc97a:: ds 5
+wc97f:: db
+wc980:: db
+wc981:: db
+wc982:: db
+wc983:: dw
+wc985:: db
+wc986:: db
+wc987:: db
+wc988:: db
+wc989:: db
+wc98a:: db
+wc98b:: db
+wc98c:: db
+wc98d:: db
+wc98e:: db
+wc98f:: db
+wc990:: db
+wc991:: db
+wc992:: db
+wc993:: db
+wc994:: db
+wc995:: ds 16
+wc9a5:: ds 5
+wc9aa:: db
+wc9ab:: db
+wc9ac:: db
+wc9ad:: db
+wc9ae:: db
+wc9af:: dw
+wc9b1:: db
+wc9b2:: ds 3
+wc9b5:: db
+wc9b6:: ds 121
+
 wMobileSDK_ReceivePacketBufferAlt:: ds 11
 wMobileSDK_ReceivedBytes:: dw
-wMobileSDK_ReceivePacketBuffer:: ds 267
+wMobileSDK_ReceivePacketBuffer:: ds 250
+wcb36:: db
+	ds 16
 wMobileSDK_PacketBuffer:: ds 281
 wcc60:: ds 1
 wcc61:: ds 1


### PR DESCRIPTION
Fewer magic numbers is always an improvement, and offsets into the two packet buffers make determining that codes purpose much simpler