### PR TITLE
Minor formatting fix to the Sunny Day moves fix

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1344,7 +1344,7 @@ The `[hInMenu]` value determines this button behavior. However, the battle moves
 
 ### Solar Beam, Flame Wheel, and Moonlight are not in the "Smart" AI's list of moves that encourage Sunny Day
 
-**Fix:** Edit [data/battle/ai/sunny_day_moves.asm])(https://github.com/pret/pokecrystal/blob/master/data/battle/ai/sunny_day_moves.asm):
+**Fix:** Edit [data/battle/ai/sunny_day_moves.asm](https://github.com/pret/pokecrystal/blob/master/data/battle/ai/sunny_day_moves.asm):
 
 ```diff
 SunnyDayMoves:


### PR DESCRIPTION
Builds on top of #849
In the previous PR, I made a small typo with the brackets causing the formatting to go slightly wonky with the Sunny Day moves fix. This one should fix that small issue.