### PR TITLE
feat():Launch make compare only for pret repo and not fork #856

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,19 @@ jobs:
           rm -rf rgbds
 
       - name: Compare
+        if: ${{ github.repository_owner == 'pret' }}
         run: |
           make DEBUG=1 -j$(nproc) compare
+          if ! git diff-index --quiet HEAD --; then
+            echo 'Uncommitted changes detected:'
+            git diff-index HEAD --
+            return 1
+          fi
+
+      - name: Make
+        if: ${{ github.repository_owner != 'pret' }}
+        run: |
+          make -j$(nproc)
           if ! git diff-index --quiet HEAD --; then
             echo 'Uncommitted changes detected:'
             git diff-index HEAD --


### PR DESCRIPTION
Related to the suggestion of @Rangi42 on issue #856 to edit github actions to launch `make compare` only for the original repository and not on forks repository