### PR TITLE
IlexForestKurtStepsDownMovement Capitilzation Typo

### DIFF
--- a/maps/IlexForest.asm
+++ b/maps/IlexForest.asm
@@ -475,7 +475,7 @@ IlexForestShrineScript:
 	writetext Text_KurtCaughtCelebi
 	waitbutton
 	closetext
-	applymovement ILEXFOREST_KURT, IlexFOrestKurtStepsDownMovement
+	applymovement ILEXFOREST_KURT, IlexForestKurtStepsDownMovement
 	disappear ILEXFOREST_KURT
 .DidntCatchCelebi:
 	end
@@ -722,7 +722,7 @@ IlexForestKurtStepsUpMovement:
 	step UP
 	step_end
 
-IlexFOrestKurtStepsDownMovement:
+IlexForestKurtStepsDownMovement:
 	step DOWN
 	step DOWN
 	step DOWN


### PR DESCRIPTION
Noticed this while attempting to port the GS-Event to Gold/Silver

The O in IlexFOrestKurtStepsDownMovement is captilized, when it should be lowercase to match the Variable Naming Convention.

Corrected the name, and tested the whole event in game to verify functionality.