### PR TITLE
Replace flawed Metal Powder bugfix

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -18,7 +18,6 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 - [Multi-player battle engine](#multi-player-battle-engine)
   - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
   - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
-  - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
   - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
   - [Moves with a 100% secondary effect chance will not trigger it in 1/256 uses](#moves-with-a-100-secondary-effect-chance-will-not-trigger-it-in-1256-uses)
   - [Belly Drum sharply boosts Attack even with under 50% HP](#belly-drum-sharply-boosts-attack-even-with-under-50-hp)
@@ -174,42 +173,6 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 +
 +.cap
 +	ld hl, MAX_STAT_VALUE
- 	ret
-```
-
-
-### Metal Powder can increase damage taken with boosted (Special) Defense
-
-([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=450))
-
-**Fix:** Edit `DittoMetalPowder` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm):
-
-```diff
- 	ld a, c
- 	srl a
- 	add c
- 	ld c, a
- 	ret nc
-
- 	srl b
- 	ld a, b
- 	and a
- 	jr nz, .done
- 	inc b
- .done
- 	scf
- 	rr c
-+
-+	ld a, HIGH(MAX_STAT_VALUE)
-+	cp b
-+	jr c, .cap
-+	ret nz
-+	ld a, LOW(MAX_STAT_VALUE)
-+	cp c
-+	ret nc
-+
-+.cap
-+	ld bc, MAX_STAT_VALUE
  	ret
 ```
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -18,6 +18,7 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 - [Multi-player battle engine](#multi-player-battle-engine)
   - [Perish Song and Spikes can leave a Pokémon with 0 HP and not faint](#perish-song-and-spikes-can-leave-a-pokémon-with-0-hp-and-not-faint)
   - [Thick Club and Light Ball can make (Special) Attack wrap around above 1024](#thick-club-and-light-ball-can-make-special-attack-wrap-around-above-1024)
+  - [Metal Powder can increase damage taken with boosted (Special) Defense](#metal-powder-can-increase-damage-taken-with-boosted-special-defense)
   - [Reflect and Light Screen can make (Special) Defense wrap around above 1024](#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024)
   - [Moves with a 100% secondary effect chance will not trigger it in 1/256 uses](#moves-with-a-100-secondary-effect-chance-will-not-trigger-it-in-1256-uses)
   - [Belly Drum sharply boosts Attack even with under 50% HP](#belly-drum-sharply-boosts-attack-even-with-under-50-hp)
@@ -175,6 +176,11 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 +	ld hl, MAX_STAT_VALUE
  	ret
 ```
+
+
+### Metal Powder can increase damage taken with boosted (Special) Defense
+
+_TODO: Document a proper fix._
 
 
 ### Reflect and Light Screen can make (Special) Defense wrap around above 1024

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -182,12 +182,11 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 
 ([Video](https://www.youtube.com/watch?v=rGqu3d3pdok&t=450))
 
-**Fix:** Edit `DittoMetalPowder` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm) and `call` it before `TruncateHL_BC`:
+**Fix:** Edit [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm):
 
 ```diff
  DittoMetalPowder:
-
-	...
+ 	...
 
 -	ld a, c
 -	srl a
@@ -203,7 +202,6 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 -.done
 -	scf
 -	rr c
--	ret
 +	ld h, b
 +	ld l, c
 +	srl b
@@ -219,15 +217,14 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 +	ld a, LOW(MAX_STAT_VALUE)
 +	cp c
 +	ret nc
-
++
 +.cap
 +	ld bc, MAX_STAT_VALUE
-+	ret
+ 	ret
 ```
 
 ```diff
  PlayerAttackDamage:
-
  	...
 
  .done
@@ -235,20 +232,19 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 +	call DittoMetalPowder
 +	pop hl
 
-	call TruncateHL_BC
+ 	call TruncateHL_BC
 
-	ld a, [wBattleMonLevel]
-	ld e, a
+ 	ld a, [wBattleMonLevel]
+ 	ld e, a
 -	call DittoMetalPowder
 
-	ld a, 1
-	and a
-	ret
+ 	ld a, 1
+ 	and a
+ 	ret
 ```
 
 ```diff
  EnemyAttackDamage:
-
  	...
 
  .done
@@ -256,15 +252,15 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
 +	call DittoMetalPowder
 +	pop hl
 
-	call TruncateHL_BC
+ 	call TruncateHL_BC
 
-	ld a, [wBattleMonLevel]
-	ld e, a
+ 	ld a, [wBattleMonLevel]
+ 	ld e, a
 -	call DittoMetalPowder
 
-	ld a, 1
-	and a
-	ret
+ 	ld a, 1
+ 	and a
+ 	ret
 ```
 
 
@@ -291,7 +287,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ret
 ```
 
-(This fix also affects Thick Club, Light Ball, and Metal Powder, as described above, but the specific fixes for the first two items allow more accurate damage calculations.)
+(This fix also affects Thick Club, Light Ball, and Metal Powder, as described above, but their specific fixes in the above bugs allow more accurate damage calculations.)
 
 
 ### Moves with a 100% secondary effect chance will not trigger it in 1/256 uses

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -200,7 +200,7 @@ This bug existed for all battles in Gold and Silver, and was only fixed for sing
  	ret
 ```
 
-(This fix also affects Thick Club, Light Ball, and Metal Powder, as described above, but their specific fixes in the above bugs allow more accurate damage calculations.)
+(This fix also affects Thick Club, Light Ball, and Metal Powder, as described above, but the specific fixes for the first two items allow more accurate damage calculations.)
 
 
 ### Moves with a 100% secondary effect chance will not trigger it in 1/256 uses


### PR DESCRIPTION
The Metal Powder fix doesn't work properly because if the user's attack (stored in `b`) is greater than `HIGH(MAX_STAT_VALUE)` (which is $3), it will set the value to 3 and the opponent's defense (stored in `c`) to `LOW(MAX_STAT_VALUE)` ($E7).

The person who implemented the fix treated it as if it was similar to `ThickClubBoost` and `LightBallBoost`, which is not the case.

With simply [fixing TruncateHL_BC](https://github.com/pret/pokecrystal/blob/master/docs/bugs_and_glitches.md#reflect-and-light-screen-can-make-special-defense-wrap-around-above-1024) for Multiplayer battles is enough, since it's called before `DittoMetalPowder`.