### PR TITLE
Correct ClearChannels:: Comment

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -2800,7 +2800,6 @@ ChannelPointers:
 
 ClearChannels::
 ; runs ClearChannel for all 4 channels
-; doesn't seem to be used, but functionally identical to InitSound
 	ld hl, rNR50
 	xor a
 	ld [hli], a


### PR DESCRIPTION
I noticed a potentially inaccurate comment while digging through the code. The comment states that `ClearChannels` doesn't seem to to be used. This is not the case, as it is used by `ExchangeMysteryGiftData` and `ExchangeNameCardData`.

This will need to be fixed in `pokegold` as well.