### PR TITLE
Remove Redundant Comments referencing labels

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -109,8 +109,6 @@ DoMove:
 
 CheckTurn:
 BattleCommand_CheckTurn:
-; checkturn
-
 ; Repurposed as hardcoded turn handling. Useless as a command.
 
 ; Move $ff immediately ends the turn.
@@ -631,8 +629,6 @@ HitConfusion:
 	jp BattleCommand_RaiseSub
 
 BattleCommand_CheckObedience:
-; checkobedience
-
 	; Enemy can't disobey
 	ldh a, [hBattleTurn]
 	and a
@@ -942,7 +938,6 @@ IgnoreSleepOnly:
 	ret
 
 BattleCommand_UsedMoveText:
-; usedmovetext
 	farcall DisplayUsedMoveText
 	ret
 
@@ -1123,8 +1118,6 @@ CheckMimicUsed:
 	ret
 
 BattleCommand_Critical:
-; critical
-
 ; Determine whether this attack's hit will be critical.
 
 	xor a
@@ -1505,8 +1498,6 @@ INCLUDE "engine/battle/ai/switch.asm"
 INCLUDE "data/types/type_matchups.asm"
 
 BattleCommand_DamageVariation:
-; damagevariation
-
 ; Modify the damage spread between 85% and 100%.
 
 ; Because of the method of division the probability distribution
@@ -1557,8 +1548,6 @@ BattleCommand_DamageVariation:
 	ret
 
 BattleCommand_CheckHit:
-; checkhit
-
 	call .DreamEater
 	jp z, .Miss
 
@@ -1864,8 +1853,6 @@ BattleCommand_CheckHit:
 INCLUDE "data/battle/accuracy_multipliers.asm"
 
 BattleCommand_EffectChance:
-; effectchance
-
 	xor a
 	ld [wEffectFailed], a
 	call CheckSubstituteOpp
@@ -1893,8 +1880,6 @@ BattleCommand_EffectChance:
 	ret
 
 BattleCommand_LowerSub:
-; lowersub
-
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVar
 	bit SUBSTATUS_SUBSTITUTE, a
@@ -1961,7 +1946,6 @@ BattleCommand_LowerSub:
 	ret
 
 BattleCommand_MoveAnim:
-; moveanim
 	call BattleCommand_LowerSub
 	call BattleCommand_MoveAnimNoSub
 	jp BattleCommand_RaiseSub
@@ -2062,16 +2046,12 @@ BattleCommand_StatUpDownAnim:
 	jp PlayFXAnimID
 
 BattleCommand_SwitchTurn:
-; switchturn
-
 	ldh a, [hBattleTurn]
 	xor 1
 	ldh [hBattleTurn], a
 	ret
 
 BattleCommand_RaiseSub:
-; raisesub
-
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVar
 	bit SUBSTATUS_SUBSTITUTE, a
@@ -2089,7 +2069,6 @@ BattleCommand_RaiseSub:
 	jp LoadAnim
 
 BattleCommand_FailureText:
-; failuretext
 ; If the move missed or failed, load the appropriate
 ; text, and end the effects of multi-turn or multi-
 ; hit moves.
@@ -2131,8 +2110,6 @@ BattleCommand_FailureText:
 	jp EndMoveEffect
 
 BattleCommand_ApplyDamage:
-; applydamage
-
 	ld a, BATTLE_VARS_SUBSTATUS1_OPP
 	call GetBattleVar
 	bit SUBSTATUS_ENDURE, a
@@ -2301,7 +2278,6 @@ BattleCommand_BideFailText:
 	jp PrintButItFailed
 
 BattleCommand_CriticalText:
-; criticaltext
 ; Prints the message for critical hits or one-hit KOs.
 
 ; If there is no message to be printed, wait 20 frames.
@@ -2332,8 +2308,6 @@ BattleCommand_CriticalText:
 	dw OneHitKOText
 
 BattleCommand_StartLoop:
-; startloop
-
 	ld hl, wPlayerRolloutCount
 	ldh a, [hBattleTurn]
 	and a
@@ -2345,8 +2319,6 @@ BattleCommand_StartLoop:
 	ret
 
 BattleCommand_SuperEffectiveLoopText:
-; supereffectivelooptext
-
 	ld a, BATTLE_VARS_SUBSTATUS3
 	call GetBattleVarAddr
 	bit SUBSTATUS_IN_LOOP, a
@@ -2355,8 +2327,6 @@ BattleCommand_SuperEffectiveLoopText:
 	; fallthrough
 
 BattleCommand_SuperEffectiveText:
-; supereffectivetext
-
 	ld a, [wTypeModifier]
 	and $7f
 	cp EFFECTIVE
@@ -2368,8 +2338,6 @@ BattleCommand_SuperEffectiveText:
 	jp StdBattleTextbox
 
 BattleCommand_CheckFaint:
-; checkfaint
-
 ; Faint the opponent if its HP reached zero
 ;  and faint the user along with it if it used Destiny Bond.
 ; Ends the move effect if the opponent faints.
@@ -2457,8 +2425,6 @@ BattleCommand_CheckFaint:
 	jp EndMoveEffect
 
 BattleCommand_BuildOpponentRage:
-; buildopponentrage
-
 	jp .start
 
 .start
@@ -2488,8 +2454,6 @@ BattleCommand_BuildOpponentRage:
 	jp BattleCommand_SwitchTurn
 
 BattleCommand_RageDamage:
-; ragedamage
-
 	ld a, [wCurDamage]
 	ld h, a
 	ld b, a
@@ -2563,8 +2527,6 @@ DittoMetalPowder:
 	ret
 
 BattleCommand_DamageStats:
-; damagestats
-
 	ldh a, [hBattleTurn]
 	and a
 	jp nz, EnemyAttackDamage
@@ -2895,7 +2857,6 @@ EnemyAttackDamage:
 INCLUDE "engine/battle/move_effects/beat_up.asm"
 
 BattleCommand_ClearMissDamage:
-; clearmissdamage
 	ld a, [wAttackMissed]
 	and a
 	ret z
@@ -2939,8 +2900,6 @@ HitSelfInConfusion:
 	ret
 
 BattleCommand_DamageCalc:
-; damagecalc
-
 ; Return a damage value for move power d, player level e, enemy defense c and player attack b.
 
 ; Return 1 if successful, else 0.
@@ -3175,8 +3134,6 @@ DAMAGE_CAP EQU MAX_DAMAGE - MIN_DAMAGE
 INCLUDE "data/types/type_boost_items.asm"
 
 BattleCommand_ConstantDamage:
-; constantdamage
-
 	ld hl, wBattleMonLevel
 	ldh a, [hBattleTurn]
 	and a
@@ -3349,7 +3306,6 @@ INCLUDE "engine/battle/move_effects/lock_on.asm"
 INCLUDE "engine/battle/move_effects/sketch.asm"
 
 BattleCommand_DefrostOpponent:
-; defrostopponent
 ; Thaw the opponent if frozen, and
 ; raise the user's Attack one stage.
 
@@ -3616,8 +3572,6 @@ UpdateMoveData:
 	jp CopyName1
 
 BattleCommand_SleepTarget:
-; sleeptarget
-
 	call GetOpponentItem
 	ld a, b
 	cp HELD_PREVENT_SLEEP
@@ -3715,8 +3669,6 @@ BattleCommand_SleepTarget:
 	ret
 
 BattleCommand_PoisonTarget:
-; poisontarget
-
 	call CheckSubstituteOpp
 	ret nz
 	ld a, BATTLE_VARS_STATUS_OPP
@@ -3750,8 +3702,6 @@ BattleCommand_PoisonTarget:
 	ret
 
 BattleCommand_Poison:
-; poison
-
 	ld hl, DoesntAffectText
 	ld a, [wTypeModifier]
 	and $7f
@@ -3878,13 +3828,11 @@ PoisonOpponent:
 	jp UpdateOpponentInParty
 
 BattleCommand_DrainTarget:
-; draintarget
 	call SapHealth
 	ld hl, SuckedHealthText
 	jp StdBattleTextbox
 
 BattleCommand_EatDream:
-; eatdream
 	call SapHealth
 	ld hl, DreamEatenText
 	jp StdBattleTextbox
@@ -3983,8 +3931,6 @@ SapHealth:
 	jp UpdateBattleMonInParty
 
 BattleCommand_BurnTarget:
-; burntarget
-
 	xor a
 	ld [wNumHits], a
 	call CheckSubstituteOpp
@@ -4049,8 +3995,6 @@ Defrost:
 	jp StdBattleTextbox
 
 BattleCommand_FreezeTarget:
-; freezetarget
-
 	xor a
 	ld [wNumHits], a
 	call CheckSubstituteOpp
@@ -4102,8 +4046,6 @@ BattleCommand_FreezeTarget:
 	ret
 
 BattleCommand_ParalyzeTarget:
-; paralyzetarget
-
 	xor a
 	ld [wNumHits], a
 	call CheckSubstituteOpp
@@ -4138,77 +4080,62 @@ BattleCommand_ParalyzeTarget:
 	jp CallBattleCore
 
 BattleCommand_AttackUp:
-; attackup
 	ld b, ATTACK
 	jr BattleCommand_StatUp
 
 BattleCommand_DefenseUp:
-; defenseup
 	ld b, DEFENSE
 	jr BattleCommand_StatUp
 
 BattleCommand_SpeedUp:
-; speedup
 	ld b, SPEED
 	jr BattleCommand_StatUp
 
 BattleCommand_SpecialAttackUp:
-; specialattackup
 	ld b, SP_ATTACK
 	jr BattleCommand_StatUp
 
 BattleCommand_SpecialDefenseUp:
-; specialdefenseup
 	ld b, SP_DEFENSE
 	jr BattleCommand_StatUp
 
 BattleCommand_AccuracyUp:
-; accuracyup
 	ld b, ACCURACY
 	jr BattleCommand_StatUp
 
 BattleCommand_EvasionUp:
-; evasionup
 	ld b, EVASION
 	jr BattleCommand_StatUp
 
 BattleCommand_AttackUp2:
-; attackup2
 	ld b, $10 | ATTACK
 	jr BattleCommand_StatUp
 
 BattleCommand_DefenseUp2:
-; defenseup2
 	ld b, $10 | DEFENSE
 	jr BattleCommand_StatUp
 
 BattleCommand_SpeedUp2:
-; speedup2
 	ld b, $10 | SPEED
 	jr BattleCommand_StatUp
 
 BattleCommand_SpecialAttackUp2:
-; specialattackup2
 	ld b, $10 | SP_ATTACK
 	jr BattleCommand_StatUp
 
 BattleCommand_SpecialDefenseUp2:
-; specialdefenseup2
 	ld b, $10 | SP_DEFENSE
 	jr BattleCommand_StatUp
 
 BattleCommand_AccuracyUp2:
-; accuracyup2
 	ld b, $10 | ACCURACY
 	jr BattleCommand_StatUp
 
 BattleCommand_EvasionUp2:
-; evasionup2
 	ld b, $10 | EVASION
 	jr BattleCommand_StatUp
 
 BattleCommand_StatUp:
-; statup
 	call RaiseStat
 	ld a, [wFailedMessage]
 	and a
@@ -4339,77 +4266,61 @@ MinimizeDropSub:
 	jp BattleCommand_MoveDelay
 
 BattleCommand_AttackDown:
-; attackdown
 	ld a, ATTACK
 	jr BattleCommand_StatDown
 
 BattleCommand_DefenseDown:
-; defensedown
 	ld a, DEFENSE
 	jr BattleCommand_StatDown
 
 BattleCommand_SpeedDown:
-; speeddown
 	ld a, SPEED
 	jr BattleCommand_StatDown
 
 BattleCommand_SpecialAttackDown:
-; specialattackdown
 	ld a, SP_ATTACK
 	jr BattleCommand_StatDown
 
 BattleCommand_SpecialDefenseDown:
-; specialdefensedown
 	ld a, SP_DEFENSE
 	jr BattleCommand_StatDown
 
 BattleCommand_AccuracyDown:
-; accuracydown
 	ld a, ACCURACY
 	jr BattleCommand_StatDown
 
 BattleCommand_EvasionDown:
-; evasiondown
 	ld a, EVASION
 	jr BattleCommand_StatDown
 
 BattleCommand_AttackDown2:
-; attackdown2
 	ld a, $10 | ATTACK
 	jr BattleCommand_StatDown
 
 BattleCommand_DefenseDown2:
-; defensedown2
 	ld a, $10 | DEFENSE
 	jr BattleCommand_StatDown
 
 BattleCommand_SpeedDown2:
-; speeddown2
 	ld a, $10 | SPEED
 	jr BattleCommand_StatDown
 
 BattleCommand_SpecialAttackDown2:
-; specialattackdown2
 	ld a, $10 | SP_ATTACK
 	jr BattleCommand_StatDown
 
 BattleCommand_SpecialDefenseDown2:
-; specialdefensedown2
 	ld a, $10 | SP_DEFENSE
 	jr BattleCommand_StatDown
 
 BattleCommand_AccuracyDown2:
-; accuracydown2
 	ld a, $10 | ACCURACY
 	jr BattleCommand_StatDown
 
 BattleCommand_EvasionDown2:
-; evasiondown2
 	ld a, $10 | EVASION
 
 BattleCommand_StatDown:
-; statdown
-
 	ld [wLoweredStat], a
 
 	call CheckMist
@@ -4659,7 +4570,6 @@ TryLowerStat:
 	ret
 
 BattleCommand_StatUpFailText:
-; statupfailtext
 	ld a, [wFailedMessage]
 	and a
 	ret z
@@ -4677,7 +4587,6 @@ BattleCommand_StatUpFailText:
 	jp StdBattleTextbox
 
 BattleCommand_StatDownFailText:
-; statdownfailtext
 	ld a, [wFailedMessage]
 	and a
 	ret z
@@ -4719,8 +4628,6 @@ INCLUDE "data/battle/stat_names.asm"
 INCLUDE "data/battle/stat_multipliers.asm"
 
 BattleCommand_AllStatsUp:
-; allstatsup
-
 ; Attack
 	call ResetMiss
 	call BattleCommand_AttackUp
@@ -4823,8 +4730,6 @@ LowerStat:
 	ret
 
 BattleCommand_TriStatusChance:
-; tristatuschance
-
 	call BattleCommand_EffectChance
 .loop
 	; 1/3 chance of each status
@@ -4843,7 +4748,6 @@ BattleCommand_TriStatusChance:
 	dw BattleCommand_BurnTarget ; burn
 
 BattleCommand_Curl:
-; curl
 	ld a, BATTLE_VARS_SUBSTATUS2
 	call GetBattleVarAddr
 	set SUBSTATUS_CURLED, [hl]
@@ -4984,8 +4888,6 @@ CalcBattleStats:
 INCLUDE "engine/battle/move_effects/bide.asm"
 
 BattleCommand_CheckRampage:
-; checkrampage
-
 	ld de, wPlayerRolloutCount
 	ldh a, [hBattleTurn]
 	and a
@@ -5021,8 +4923,6 @@ BattleCommand_CheckRampage:
 	jp SkipToBattleCommand
 
 BattleCommand_Rampage:
-; rampage
-
 ; No rampage during Sleep Talk.
 	ld a, BATTLE_VARS_STATUS
 	call GetBattleVar
@@ -5057,8 +4957,6 @@ SetBattleDraw:
 	ret
 
 BattleCommand_ForceSwitch:
-; forceswitch
-
 	ld a, [wBattleType]
 	cp BATTLETYPE_SHINY
 	jp z, .fail
@@ -5305,8 +5203,6 @@ CheckPlayerHasMonToSwitchTo:
 	ret
 
 BattleCommand_EndLoop:
-; endloop
-
 ; Loop back to 'critical'.
 
 	ld de, wPlayerRolloutCount
@@ -5523,8 +5419,6 @@ BattleCommand_HeldFlinch:
 	ret
 
 BattleCommand_OHKO:
-; ohko
-
 	call ResetDamage
 	ld a, [wTypeModifier]
 	and $7f
@@ -5569,8 +5463,6 @@ BattleCommand_OHKO:
 	ret
 
 BattleCommand_CheckCharge:
-; checkcharge
-
 	ld a, BATTLE_VARS_SUBSTATUS3
 	call GetBattleVarAddr
 	bit SUBSTATUS_CHARGED, [hl]
@@ -5582,8 +5474,6 @@ BattleCommand_CheckCharge:
 	jp SkipToBattleCommand
 
 BattleCommand_Charge:
-; charge
-
 	call BattleCommand_ClearText
 	ld a, BATTLE_VARS_STATUS
 	call GetBattleVar
@@ -5721,8 +5611,6 @@ BattleCommand_Unused3C:
 	ret
 
 BattleCommand_TrapTarget:
-; traptarget
-
 	ld a, [wAttackMissed]
 	and a
 	ret nz
@@ -5781,8 +5669,6 @@ INCLUDE "engine/battle/move_effects/mist.asm"
 INCLUDE "engine/battle/move_effects/focus_energy.asm"
 
 BattleCommand_Recoil:
-; recoil
-
 	ld hl, wBattleMonMaxHP
 	ldh a, [hBattleTurn]
 	and a
@@ -5845,8 +5731,6 @@ BattleCommand_Recoil:
 	jp StdBattleTextbox
 
 BattleCommand_ConfuseTarget:
-; confusetarget
-
 	call GetOpponentItem
 	ld a, b
 	cp HELD_PREVENT_CONFUSE
@@ -5865,8 +5749,6 @@ BattleCommand_ConfuseTarget:
 	jr BattleCommand_FinishConfusingTarget
 
 BattleCommand_Confuse:
-; confuse
-
 	call GetOpponentItem
 	ld a, b
 	cp HELD_PREVENT_CONFUSE
@@ -5948,8 +5830,6 @@ BattleCommand_Confuse_CheckSnore_Swagger_ConfuseHit:
 	jp PrintDidntAffect2
 
 BattleCommand_Paralyze:
-; paralyze
-
 	ld a, BATTLE_VARS_STATUS_OPP
 	call GetBattleVar
 	bit PAR, a
@@ -6065,7 +5945,6 @@ CheckMoveTypeMatchesTarget:
 INCLUDE "engine/battle/move_effects/substitute.asm"
 
 BattleCommand_RechargeNextTurn:
-; rechargenextturn
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVarAddr
 	set SUBSTATUS_RECHARGE, [hl]
@@ -6082,7 +5961,6 @@ EndRechargeOpp:
 INCLUDE "engine/battle/move_effects/rage.asm"
 
 BattleCommand_DoubleFlyingDamage:
-; doubleflyingdamage
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	bit SUBSTATUS_FLYING, a
@@ -6090,7 +5968,6 @@ BattleCommand_DoubleFlyingDamage:
 	jr DoubleDamage
 
 BattleCommand_DoubleUndergroundDamage:
-; doubleundergrounddamage
 	ld a, BATTLE_VARS_SUBSTATUS3_OPP
 	call GetBattleVar
 	bit SUBSTATUS_UNDERGROUND, a
@@ -6124,8 +6001,6 @@ INCLUDE "engine/battle/move_effects/pay_day.asm"
 INCLUDE "engine/battle/move_effects/conversion.asm"
 
 BattleCommand_ResetStats:
-; resetstats
-
 	ld a, BASE_STAT_LEVEL
 	ld hl, wPlayerStatLevels
 	call .Fill
@@ -6157,8 +6032,6 @@ BattleCommand_ResetStats:
 	ret
 
 BattleCommand_Heal:
-; heal
-
 	ld de, wBattleMonHP
 	ld hl, wBattleMonMaxHP
 	ldh a, [hBattleTurn]
@@ -6273,8 +6146,6 @@ ResetActorDisable:
 	ret
 
 BattleCommand_Screen:
-; screen
-
 	ld hl, wPlayerScreens
 	ld bc, wPlayerLightScreenCount
 	ldh a, [hBattleTurn]
@@ -6318,12 +6189,10 @@ BattleCommand_Screen:
 	jp PrintButItFailed
 
 PrintDoesntAffect:
-; 'it doesn't affect'
 	ld hl, DoesntAffectText
 	jp StdBattleTextbox
 
 PrintNothingHappened:
-; 'but nothing happened!'
 	ld hl, NothingHappenedText
 	jp StdBattleTextbox
 
@@ -6335,7 +6204,6 @@ TryPrintButItFailed:
 	; fallthrough
 
 PrintButItFailed:
-; 'but it failed!'
 	ld hl, ButItFailedText
 	jp StdBattleTextbox
 
@@ -6349,7 +6217,6 @@ FailMimic:
 	jp FailText_CheckOpponentProtect
 
 PrintDidntAffect:
-; 'it didn't affect'
 	ld hl, DidntAffect1Text
 	jp StdBattleTextbox
 
@@ -6417,8 +6284,6 @@ ResetTurn:
 INCLUDE "engine/battle/move_effects/thief.asm"
 
 BattleCommand_ArenaTrap:
-; arenatrap
-
 ; Doesn't work on an absent opponent.
 
 	call CheckHiddenOpponent
@@ -6445,8 +6310,6 @@ BattleCommand_ArenaTrap:
 INCLUDE "engine/battle/move_effects/nightmare.asm"
 
 BattleCommand_Defrost:
-; defrost
-
 ; Thaw the user.
 
 	ld a, BATTLE_VARS_STATUS
@@ -6521,7 +6384,6 @@ SafeCheckSafeguard:
 	ret
 
 BattleCommand_CheckSafeguard:
-; checksafeguard
 	ld hl, wEnemyScreens
 	ldh a, [hBattleTurn]
 	and a
@@ -6546,17 +6408,14 @@ INCLUDE "engine/battle/move_effects/pursuit.asm"
 INCLUDE "engine/battle/move_effects/rapid_spin.asm"
 
 BattleCommand_HealMorn:
-; healmorn
 	ld b, MORN_F
 	jr BattleCommand_TimeBasedHealContinue
 
 BattleCommand_HealDay:
-; healday
 	ld b, DAY_F
 	jr BattleCommand_TimeBasedHealContinue
 
 BattleCommand_HealNite:
-; healnite
 	ld b, NITE_F
 	; fallthrough
 
@@ -6655,8 +6514,6 @@ INCLUDE "engine/battle/move_effects/psych_up.asm"
 INCLUDE "engine/battle/move_effects/mirror_coat.asm"
 
 BattleCommand_DoubleMinimizeDamage:
-; doubleminimizedamage
-
 	ld hl, wEnemyMinimized
 	ldh a, [hBattleTurn]
 	and a
@@ -6850,14 +6707,11 @@ AnimateFailedMove:
 	jp BattleCommand_RaiseSub
 
 BattleCommand_MoveDelay:
-; movedelay
 ; Wait 40 frames.
 	ld c, 40
 	jp DelayFrames
 
 BattleCommand_ClearText:
-; cleartext
-
 ; Used in multi-hit moves.
 	ld hl, .text
 	jp BattleTextbox

--- a/engine/battle/move_effects/attract.asm
+++ b/engine/battle/move_effects/attract.asm
@@ -1,5 +1,4 @@
 BattleCommand_Attract:
-; attract
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed

--- a/engine/battle/move_effects/baton_pass.asm
+++ b/engine/battle/move_effects/baton_pass.asm
@@ -1,6 +1,4 @@
 BattleCommand_BatonPass:
-; batonpass
-
 	ldh a, [hBattleTurn]
 	and a
 	jp nz, .Enemy

--- a/engine/battle/move_effects/beat_up.asm
+++ b/engine/battle/move_effects/beat_up.asm
@@ -1,6 +1,4 @@
 BattleCommand_BeatUp:
-; beatup
-
 	call ResetDamage
 	ldh a, [hBattleTurn]
 	and a
@@ -198,8 +196,6 @@ BattleCommand_BeatUp:
 	jp SkipToBattleCommand
 
 BattleCommand_BeatUpFailText:
-; beatupfailtext
-
 	ld a, [wBeatUpHitAtLeastOnce]
 	and a
 	ret nz

--- a/engine/battle/move_effects/belly_drum.asm
+++ b/engine/battle/move_effects/belly_drum.asm
@@ -1,5 +1,4 @@
 BattleCommand_BellyDrum:
-; bellydrum
 ; This command is buggy because it raises the user's attack
 ; before checking that it has enough HP to use the move.
 ; Swap the order of these two blocks to fix.

--- a/engine/battle/move_effects/bide.asm
+++ b/engine/battle/move_effects/bide.asm
@@ -1,6 +1,4 @@
 BattleCommand_StoreEnergy:
-; storeenergy
-
 	ld a, BATTLE_VARS_SUBSTATUS3
 	call GetBattleVar
 	bit SUBSTATUS_BIDE, a
@@ -70,8 +68,6 @@ BattleCommand_StoreEnergy:
 	jp EndMoveEffect
 
 BattleCommand_UnleashEnergy:
-; unleashenergy
-
 	ld de, wPlayerDamageTaken
 	ld bc, wPlayerRolloutCount
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/conversion.asm
+++ b/engine/battle/move_effects/conversion.asm
@@ -1,6 +1,4 @@
 BattleCommand_Conversion:
-; conversion
-
 	ld hl, wBattleMonMoves
 	ld de, wBattleMonType1
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/conversion2.asm
+++ b/engine/battle/move_effects/conversion2.asm
@@ -1,6 +1,4 @@
 BattleCommand_Conversion2:
-; conversion2
-
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed

--- a/engine/battle/move_effects/counter.asm
+++ b/engine/battle/move_effects/counter.asm
@@ -1,6 +1,4 @@
 BattleCommand_Counter:
-; counter
-
 	ld a, 1
 	ld [wAttackMissed], a
 	ld a, BATTLE_VARS_LAST_COUNTER_MOVE_OPP

--- a/engine/battle/move_effects/curse.asm
+++ b/engine/battle/move_effects/curse.asm
@@ -1,6 +1,4 @@
 BattleCommand_Curse:
-; curse
-
 	ld de, wBattleMonType1
 	ld bc, wPlayerStatLevels
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/destiny_bond.asm
+++ b/engine/battle/move_effects/destiny_bond.asm
@@ -1,6 +1,4 @@
 BattleCommand_DestinyBond:
-; destinybond
-
 	ld a, BATTLE_VARS_SUBSTATUS5
 	call GetBattleVarAddr
 	set SUBSTATUS_DESTINY_BOND, [hl]

--- a/engine/battle/move_effects/disable.asm
+++ b/engine/battle/move_effects/disable.asm
@@ -1,6 +1,4 @@
 BattleCommand_Disable:
-; disable
-
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed

--- a/engine/battle/move_effects/encore.asm
+++ b/engine/battle/move_effects/encore.asm
@@ -1,6 +1,4 @@
 BattleCommand_Encore:
-; encore
-
 	ld hl, wEnemyMonMoves
 	ld de, wEnemyEncoreCount
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/endure.asm
+++ b/engine/battle/move_effects/endure.asm
@@ -1,6 +1,4 @@
 BattleCommand_Endure:
-; endure
-
 ; Endure shares code with Protect. See protect.asm.
 
 	call ProtectChance

--- a/engine/battle/move_effects/false_swipe.asm
+++ b/engine/battle/move_effects/false_swipe.asm
@@ -1,6 +1,4 @@
 BattleCommand_FalseSwipe:
-; falseswipe
-
 ; Makes sure wCurDamage < MonHP
 
 	ld hl, wEnemyMonHP

--- a/engine/battle/move_effects/focus_energy.asm
+++ b/engine/battle/move_effects/focus_energy.asm
@@ -1,6 +1,4 @@
 BattleCommand_FocusEnergy:
-; focusenergy
-
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVarAddr
 	bit SUBSTATUS_FOCUS_ENERGY, [hl]

--- a/engine/battle/move_effects/foresight.asm
+++ b/engine/battle/move_effects/foresight.asm
@@ -1,6 +1,4 @@
 BattleCommand_Foresight:
-; foresight
-
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .failed

--- a/engine/battle/move_effects/frustration.asm
+++ b/engine/battle/move_effects/frustration.asm
@@ -1,5 +1,4 @@
 BattleCommand_FrustrationPower:
-; frustrationpower
 	push bc
 	ld hl, wBattleMonHappiness
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/fury_cutter.asm
+++ b/engine/battle/move_effects/fury_cutter.asm
@@ -1,6 +1,4 @@
 BattleCommand_FuryCutter:
-; furycutter
-
 	ld hl, wPlayerFuryCutterCount
 	ldh a, [hBattleTurn]
 	and a

--- a/engine/battle/move_effects/future_sight.asm
+++ b/engine/battle/move_effects/future_sight.asm
@@ -1,6 +1,4 @@
 BattleCommand_CheckFutureSight:
-; checkfuturesight
-
 	ld hl, wPlayerFutureSightCount
 	ld de, wPlayerFutureSightDamage
 	ldh a, [hBattleTurn]
@@ -26,8 +24,6 @@ BattleCommand_CheckFutureSight:
 	jp SkipToBattleCommand
 
 BattleCommand_FutureSight:
-; futuresight
-
 	call CheckUserIsCharging
 	jr nz, .AlreadyChargingFutureSight
 	ld a, BATTLE_VARS_MOVE_ANIM

--- a/engine/battle/move_effects/heal_bell.asm
+++ b/engine/battle/move_effects/heal_bell.asm
@@ -1,6 +1,4 @@
 BattleCommand_HealBell:
-; healbell
-
 	ld a, BATTLE_VARS_SUBSTATUS1
 	call GetBattleVarAddr
 	res SUBSTATUS_NIGHTMARE, [hl]

--- a/engine/battle/move_effects/hidden_power.asm
+++ b/engine/battle/move_effects/hidden_power.asm
@@ -1,6 +1,4 @@
 BattleCommand_HiddenPower:
-; hiddenpower
-
 	ld a, [wAttackMissed]
 	and a
 	ret nz

--- a/engine/battle/move_effects/leech_seed.asm
+++ b/engine/battle/move_effects/leech_seed.asm
@@ -1,5 +1,4 @@
 BattleCommand_LeechSeed:
-; leechseed
 	ld a, [wAttackMissed]
 	and a
 	jr nz, .evaded

--- a/engine/battle/move_effects/lock_on.asm
+++ b/engine/battle/move_effects/lock_on.asm
@@ -1,6 +1,4 @@
 BattleCommand_LockOn:
-; lockon
-
 	call CheckSubstituteOpp
 	jr nz, .fail
 

--- a/engine/battle/move_effects/magnitude.asm
+++ b/engine/battle/move_effects/magnitude.asm
@@ -1,6 +1,4 @@
 BattleCommand_GetMagnitude:
-; getmagnitude
-
 	push bc
 	call BattleRandom
 	ld b, a

--- a/engine/battle/move_effects/metronome.asm
+++ b/engine/battle/move_effects/metronome.asm
@@ -1,6 +1,4 @@
 BattleCommand_Metronome:
-; metronome
-
 	call ClearLastMove
 	call CheckUserIsCharging
 	jr nz, .charging

--- a/engine/battle/move_effects/mimic.asm
+++ b/engine/battle/move_effects/mimic.asm
@@ -1,6 +1,4 @@
 BattleCommand_Mimic:
-; mimic
-
 	call ClearLastMove
 	call BattleCommand_MoveDelay
 	ld a, [wAttackMissed]

--- a/engine/battle/move_effects/mirror_coat.asm
+++ b/engine/battle/move_effects/mirror_coat.asm
@@ -1,6 +1,4 @@
 BattleCommand_MirrorCoat:
-; mirrorcoat
-
 	ld a, 1
 	ld [wAttackMissed], a
 

--- a/engine/battle/move_effects/mirror_move.asm
+++ b/engine/battle/move_effects/mirror_move.asm
@@ -1,6 +1,4 @@
 BattleCommand_MirrorMove:
-; mirrormove
-
 	call ClearLastMove
 
 	ld a, BATTLE_VARS_MOVE

--- a/engine/battle/move_effects/mist.asm
+++ b/engine/battle/move_effects/mist.asm
@@ -1,6 +1,4 @@
 BattleCommand_Mist:
-; mist
-
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVarAddr
 	bit SUBSTATUS_MIST, [hl]

--- a/engine/battle/move_effects/nightmare.asm
+++ b/engine/battle/move_effects/nightmare.asm
@@ -1,6 +1,4 @@
 BattleCommand_Nightmare:
-; nightmare
-
 ; Can't hit an absent opponent.
 
 	call CheckHiddenOpponent

--- a/engine/battle/move_effects/pain_split.asm
+++ b/engine/battle/move_effects/pain_split.asm
@@ -1,6 +1,4 @@
 BattleCommand_PainSplit:
-; painsplit
-
 	ld a, [wAttackMissed]
 	and a
 	jp nz, .ButItFailed

--- a/engine/battle/move_effects/pay_day.asm
+++ b/engine/battle/move_effects/pay_day.asm
@@ -1,6 +1,4 @@
 BattleCommand_PayDay:
-; payday
-
 	xor a
 	ld hl, wStringBuffer1
 	ld [hli], a

--- a/engine/battle/move_effects/perish_song.asm
+++ b/engine/battle/move_effects/perish_song.asm
@@ -1,6 +1,4 @@
 BattleCommand_PerishSong:
-; perishsong
-
 	ld hl, wPlayerSubStatus1
 	ld de, wEnemySubStatus1
 	bit SUBSTATUS_PERISH, [hl]

--- a/engine/battle/move_effects/present.asm
+++ b/engine/battle/move_effects/present.asm
@@ -1,6 +1,4 @@
 BattleCommand_Present:
-; present
-
 	ld a, [wLinkMode]
 	cp LINK_COLOSSEUM
 	jr z, .colosseum_skippush

--- a/engine/battle/move_effects/protect.asm
+++ b/engine/battle/move_effects/protect.asm
@@ -1,5 +1,4 @@
 BattleCommand_Protect:
-; protect
 	call ProtectChance
 	ret c
 

--- a/engine/battle/move_effects/psych_up.asm
+++ b/engine/battle/move_effects/psych_up.asm
@@ -1,6 +1,4 @@
 BattleCommand_PsychUp:
-; psychup
-
 	ld hl, wEnemyStatLevels
 	ld de, wPlayerStatLevels
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/pursuit.asm
+++ b/engine/battle/move_effects/pursuit.asm
@@ -1,5 +1,4 @@
 BattleCommand_Pursuit:
-; pursuit
 ; Double damage if the opponent is switching.
 
 	ld hl, wEnemyIsSwitching

--- a/engine/battle/move_effects/rage.asm
+++ b/engine/battle/move_effects/rage.asm
@@ -1,5 +1,4 @@
 BattleCommand_Rage:
-; rage
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVarAddr
 	set SUBSTATUS_RAGE, [hl]

--- a/engine/battle/move_effects/rain_dance.asm
+++ b/engine/battle/move_effects/rain_dance.asm
@@ -1,5 +1,4 @@
 BattleCommand_StartRain:
-; startrain
 	ld a, WEATHER_RAIN
 	ld [wBattleWeather], a
 	ld a, 5

--- a/engine/battle/move_effects/rapid_spin.asm
+++ b/engine/battle/move_effects/rapid_spin.asm
@@ -1,6 +1,4 @@
 BattleCommand_ClearHazards:
-; clearhazards
-
 	ld a, BATTLE_VARS_SUBSTATUS4
 	call GetBattleVarAddr
 	bit SUBSTATUS_LEECH_SEED, [hl]

--- a/engine/battle/move_effects/return.asm
+++ b/engine/battle/move_effects/return.asm
@@ -1,5 +1,4 @@
 BattleCommand_HappinessPower:
-; happinesspower
 	push bc
 	ld hl, wBattleMonHappiness
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/rollout.asm
+++ b/engine/battle/move_effects/rollout.asm
@@ -1,8 +1,6 @@
 MAX_ROLLOUT_COUNT EQU 5
 
 BattleCommand_CheckCurl:
-; checkcurl
-
 	ld de, wPlayerRolloutCount
 	ldh a, [hBattleTurn]
 	and a
@@ -23,8 +21,6 @@ BattleCommand_CheckCurl:
 	ret
 
 BattleCommand_RolloutPower:
-; rolloutpower
-
 	ld a, BATTLE_VARS_STATUS
 	call GetBattleVar
 	and SLP

--- a/engine/battle/move_effects/safeguard.asm
+++ b/engine/battle/move_effects/safeguard.asm
@@ -1,6 +1,4 @@
 BattleCommand_Safeguard:
-; safeguard
-
 	ld hl, wPlayerScreens
 	ld de, wPlayerSafeguardCount
 	ldh a, [hBattleTurn]

--- a/engine/battle/move_effects/sandstorm.asm
+++ b/engine/battle/move_effects/sandstorm.asm
@@ -1,6 +1,4 @@
 BattleCommand_StartSandstorm:
-; startsandstorm
-
 	ld a, [wBattleWeather]
 	cp WEATHER_SANDSTORM
 	jr z, .failed

--- a/engine/battle/move_effects/sketch.asm
+++ b/engine/battle/move_effects/sketch.asm
@@ -1,6 +1,4 @@
 BattleCommand_Sketch:
-; sketch
-
 	call ClearLastMove
 ; Don't sketch during a link battle
 	ld a, [wLinkMode]

--- a/engine/battle/move_effects/sleep_talk.asm
+++ b/engine/battle/move_effects/sleep_talk.asm
@@ -1,6 +1,4 @@
 BattleCommand_SleepTalk:
-; sleeptalk
-
 	call ClearLastMove
 	ld a, [wAttackMissed]
 	and a

--- a/engine/battle/move_effects/snore.asm
+++ b/engine/battle/move_effects/snore.asm
@@ -1,5 +1,4 @@
 BattleCommand_Snore:
-; snore
 	ld a, BATTLE_VARS_STATUS
 	call GetBattleVar
 	and SLP

--- a/engine/battle/move_effects/spikes.asm
+++ b/engine/battle/move_effects/spikes.asm
@@ -1,6 +1,4 @@
 BattleCommand_Spikes:
-; spikes
-
 	ld hl, wEnemyScreens
 	ldh a, [hBattleTurn]
 	and a

--- a/engine/battle/move_effects/spite.asm
+++ b/engine/battle/move_effects/spite.asm
@@ -1,6 +1,4 @@
 BattleCommand_Spite:
-; spite
-
 	ld a, [wAttackMissed]
 	and a
 	jp nz, .failed

--- a/engine/battle/move_effects/substitute.asm
+++ b/engine/battle/move_effects/substitute.asm
@@ -1,6 +1,4 @@
 BattleCommand_Substitute:
-; substitute
-
 	call BattleCommand_MoveDelay
 	ld hl, wBattleMonMaxHP
 	ld de, wPlayerSubstituteHP

--- a/engine/battle/move_effects/sunny_day.asm
+++ b/engine/battle/move_effects/sunny_day.asm
@@ -1,5 +1,4 @@
 BattleCommand_StartSun:
-; startsun
 	ld a, WEATHER_SUN
 	ld [wBattleWeather], a
 	ld a, 5

--- a/engine/battle/move_effects/teleport.asm
+++ b/engine/battle/move_effects/teleport.asm
@@ -1,6 +1,4 @@
 BattleCommand_Teleport:
-; teleport
-
 	ld a, [wBattleType]
 	cp BATTLETYPE_SHINY
 	jr z, .failed

--- a/engine/battle/move_effects/thief.asm
+++ b/engine/battle/move_effects/thief.asm
@@ -1,6 +1,4 @@
 BattleCommand_Thief:
-; thief
-
 	ldh a, [hBattleTurn]
 	and a
 	jr nz, .enemy

--- a/engine/battle/move_effects/thunder.asm
+++ b/engine/battle/move_effects/thunder.asm
@@ -1,6 +1,4 @@
 BattleCommand_ThunderAccuracy:
-; thunderaccuracy
-
 	ld a, BATTLE_VARS_MOVE_TYPE
 	call GetBattleVarAddr
 	inc hl

--- a/engine/battle/move_effects/transform.asm
+++ b/engine/battle/move_effects/transform.asm
@@ -1,6 +1,4 @@
 BattleCommand_Transform:
-; transform
-
 	call ClearLastMove
 	ld a, BATTLE_VARS_SUBSTATUS5_OPP
 	call GetBattleVarAddr

--- a/engine/battle/move_effects/triple_kick.asm
+++ b/engine/battle/move_effects/triple_kick.asm
@@ -1,6 +1,4 @@
 BattleCommand_TripleKick:
-; triplekick
-
 	ld a, [wBattleAnimParam]
 	ld b, a
 	inc b
@@ -27,8 +25,6 @@ BattleCommand_TripleKick:
 	ret
 
 BattleCommand_KickCounter:
-; kickcounter
-
 	ld hl, wBattleAnimParam
 	inc [hl]
 	ret

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -278,7 +278,6 @@ FlashFunction:
 	ret
 
 .CheckUseFlash:
-; Flash
 	ld de, ENGINE_ZEPHYRBADGE
 	farcall CheckBadge
 	jr c, .nozephyrbadge
@@ -557,7 +556,6 @@ FlyFunction:
  	dw .FailFly
 
 .TryFly:
-; Fly
 	ld de, ENGINE_STORMBADGE
 	call CheckBadge
 	jr c, .nostormbadge
@@ -637,7 +635,6 @@ WaterfallFunction:
 	ret
 
 .TryWaterfall:
-; Waterfall
 	ld de, ENGINE_RISINGBADGE
 	farcall CheckBadge
 	ld a, $80
@@ -963,7 +960,6 @@ StrengthFunction:
 	ret
 
 .TryStrength:
-; Strength
 	ld de, ENGINE_PLAINBADGE
 	call CheckBadge
 	jr c, .Failed

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -391,17 +391,17 @@ StubbedTrainerRankings_Unused3: ; unreferenced
 	ld hl, sTrainerRankingUnused3
 	jr StubbedTrainerRankings_Increment3Byte
 
-StubbedTrainerRankings_ColosseumWins: ; win
+StubbedTrainerRankings_ColosseumWins:
 	ret
 	ld hl, sTrainerRankingColosseumWins
 	jr StubbedTrainerRankings_Increment3Byte
 
-StubbedTrainerRankings_ColosseumLosses: ; lose
+StubbedTrainerRankings_ColosseumLosses:
 	ret
 	ld hl, sTrainerRankingColosseumLosses
 	jr StubbedTrainerRankings_Increment3Byte
 
-StubbedTrainerRankings_ColosseumDraws: ; draw
+StubbedTrainerRankings_ColosseumDraws:
 	ret
 	ld hl, sTrainerRankingColosseumDraws
 	jr StubbedTrainerRankings_Increment3Byte


### PR DESCRIPTION
Some labels have redundant comments, this resolves #916 

- [x] PR for pokegold:  https://github.com/pret/pokegold/pull/85