### PR TITLE
`MobileCheckOwnMonAnywhere` & `CheckOwnMonAnywhere` Label, comments, formatting

### DIFF
--- a/engine/pokemon/search.asm
+++ b/engine/pokemon/search.asm
@@ -51,6 +51,7 @@ CheckOwnMonAnywhere:
 
 	; If there are no monsters in the party,
 	; the player must not own any yet.
+
 	ld a, [wPartyCount]
 	and a
 	ret z
@@ -61,9 +62,10 @@ CheckOwnMonAnywhere:
 	ld bc, wPartyMonOTs
 
 	; Run CheckOwnMon on each Pokémon in the party.
+
 .partymon
 	call CheckOwnMon
-	ret c ; found!
+	ret c
 
 	push bc
 	ld bc, PARTYMON_STRUCT_LENGTH
@@ -74,6 +76,7 @@ CheckOwnMonAnywhere:
 	jr nz, .partymon
 
 	; Run CheckOwnMon on each Pokémon in the PC.
+
 	ld a, BANK(sBoxCount)
 	call OpenSRAM
 	ld a, [sBoxCount]
@@ -87,7 +90,6 @@ CheckOwnMonAnywhere:
 	call CheckOwnMon
 	jr nc, .loop
 
-	; found!
 	call CloseSRAM
 	ret
 
@@ -101,6 +103,7 @@ CheckOwnMonAnywhere:
 	jr nz, .openboxmon
 
 	; Run CheckOwnMon on each monster in the other 13 PC boxes.
+
 .boxes
 	call CloseSRAM
 
@@ -113,6 +116,7 @@ CheckOwnMonAnywhere:
 	jr z, .loopbox
 
 	; Load the box.
+
 	ld hl, SearchBoxAddressTable
 	ld b, 0
 	add hl, bc
@@ -125,6 +129,7 @@ CheckOwnMonAnywhere:
 	ld l, a
 
 	; Number of monsters in the box
+
 	ld a, [hl]
 	and a
 	jr z, .loopbox
@@ -150,7 +155,6 @@ CheckOwnMonAnywhere:
 	call CheckOwnMon
 	jr nc, .loopboxmon
 
-	; found!
 	pop bc
 	call CloseSRAM
 	ret
@@ -171,13 +175,14 @@ CheckOwnMonAnywhere:
 	cp NUM_BOXES
 	jr c, .box
 
-	; not found
 	call CloseSRAM
 	and a
 	ret
 
 CheckOwnMon:
 ; Check if a Pokémon belongs to the player and is of a specific species.
+; We compare the species we are looking for in [wScriptVar] to the species
+; we have in [hl].
 
 ; inputs:
 ; hl, pointer to PartyMonNSpecies
@@ -193,26 +198,26 @@ CheckOwnMon:
 	ld d, b
 	ld e, c
 
-; check species
-	ld a, [wScriptVar] ; species we're looking for
-	ld b, [hl] ; species we have
-	cp b
-	jr nz, .notfound ; species doesn't match
+	; check species
 
-; check ID number
+	ld a, [wScriptVar]
+	ld b, [hl]
+	cp b
+	jr nz, .notfound
+
+	; check ID number
+
 	ld bc, MON_ID
-	add hl, bc ; now hl points to ID number
+	add hl, bc
 	ld a, [wPlayerID]
 	cp [hl]
-	jr nz, .notfound ; ID doesn't match
+	jr nz, .notfound
 	inc hl
 	ld a, [wPlayerID + 1]
 	cp [hl]
-	jr nz, .notfound ; ID doesn't match
+	jr nz, .notfound
 
-; check OT
-; This only checks five characters, which is fine for the Japanese version,
-; but in the English version the player name is 7 characters, so this is wrong.
+	; check OT
 
 	ld hl, wPlayerName
 
@@ -221,7 +226,7 @@ rept NAME_LENGTH_JAPANESE - 2 ; should be PLAYER_NAME_LENGTH - 2
 	cp [hl]
 	jr nz, .notfound
 	cp "@"
-	jr z, .found ; reached end of string
+	jr z, .found
 	inc hl
 	inc de
 endr


### PR DESCRIPTION
Was looking through the Mobile code, and saw that this function had already been marked as being very similar to `CheckOwnMonAnywhere`. So I brought over some of the labels, comments, and formatting from that function.