### PR TITLE
Add documentation for the caught level design flaw

### DIFF
--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -773,7 +773,7 @@ Edit `GetForestTreeFrame`:
 ```
 
 
-### The 6-bit caught level can only record up to level 63
+## The 6-bit caught level can only record up to level 63
 
 The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63 normally.
 

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -742,7 +742,7 @@ When a Pokémon is caught, it stores its caught data in two bytes as part of the
 byte uses 2 bits for `CAUGHT_TIME` and 6 bits for `CAUGHT_LEVEL`. The second byte uses 1 bit for
 `CAUGHT_GENDER` and 7 bits for `CAUGHT_LOCATION`. When a Pokémon greater than level 63 is
 caught, the game first stores `CAUGHT_TIME` in the first two bits of the first byte, and then does an `OR`
-operation on that byte with [wCurPartyLevel] during execution of `SetCaughtData:`. The result is that
+operation on that byte with `[wCurPartyLevel]` during execution of `SetCaughtData:`. The result is that
 `CAUGHT_TIME` may become corrupted, and the `CAUGHT_LEVEL` reporting incorrectly. For example:
 
 A level 70 Pokémon caught at Morning: (% means binary)

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -777,5 +777,5 @@ Edit `GetForestTreeFrame`:
 
 The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63 normally.
 
-**Fix:** Repurpose a free bit from `MON_LEVEL` (1 free bit), `MON_EXP` (3 free bits), etc.
+**Possible Solution:** Repurpose a free bit from `MON_LEVEL` (1 free bit), `MON_EXP` (3 free bits), etc.
 An example of such a fix was used in https://github.com/thegsproj/pokegscrystal/pull/8.

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -738,27 +738,25 @@ ENDM
 
 ## The 6-bit caught level can only record up to level 63
 
-When a Pokémon is caught, it stores its caught data in two bytes as part of the `party_struct`. The first
-byte uses 2 bits for `CAUGHT_TIME` and 6 bits for `CAUGHT_LEVEL`. The second byte uses 1 bit for
-`CAUGHT_GENDER` and 7 bits for `CAUGHT_LOCATION`. When a Pokémon greater than level 63 is
-caught, the game first stores `CAUGHT_TIME` in the first two bits of the first byte, and then does an `OR`
-operation on that byte with `[wCurPartyLevel]` during execution of `SetCaughtData:`. The result is that
-`CAUGHT_TIME` may become corrupted, and the `CAUGHT_LEVEL` reporting incorrectly. For example:
+When a Pokémon is caught, it stores its caught data in two bytes as part of the `party_struct`. The first byte uses 2 bits for `CAUGHT_TIME` and 6 bits for `CAUGHT_LEVEL`. The second byte uses 1 bit for `CAUGHT_GENDER` and 7 bits for `CAUGHT_LOCATION`. When a Pokémon greater than level 63 is caught, the game first stores `CAUGHT_TIME` in the first two bits of the first byte, and then does an `OR`
+operation on that byte with `[wCurPartyLevel]` during execution of `SetCaughtData:`. The result is that `CAUGHT_TIME` may become corrupted, and the `CAUGHT_LEVEL` reporting incorrectly. For example:
 
 A level 70 Pokémon caught at Morning: (% means binary)
+
 `%00000000` = Morning
+
 `%01000110` = Level 70
+
 Since level 70 takes up 7 bits, when you apply an OR operation here you get:
 `%01000110` = Level 6 Pokémon caught at Day.
 The game only looks at the first two bits for Time and last 6 bits for Level due to:
+
 ```asm
 DEF CAUGHT_TIME_MASK  EQU %11000000
 DEF CAUGHT_LEVEL_MASK EQU %00111111
 ```
 
-**Possible Fix:** Add an extra struct byte, free up other struct bytes (Ex. [Replace stat experience with EVs](https://github.com/pret/pokecrystal/wiki/Replace-stat-experience-with-EVs)), or
-repurposing a free unused bit from another existing byte (`MON_LEVEL` has one free bit and `MON_EXP` has three
-free bits). 
+**Possible Fix:** Add an extra struct byte, free up other struct bytes (Ex. [Replace stat experience with EVs](https://github.com/pret/pokecrystal/wiki/Replace-stat-experience-with-EVs)), or repurposing a free unused bit from another existing byte (`MON_LEVEL` has one free bit and `MON_EXP` has three free bits). 
 
 
 ## `GetForestTreeFrame` works, but it's still bad

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -777,5 +777,5 @@ Edit `GetForestTreeFrame`:
 
 The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63 normally.
 
-**Possible Solution:** Repurpose a free bit from `MON_LEVEL` (1 free bit), `MON_EXP` (3 free bits), etc.
+**Possible Fix:** Repurpose an unused bit from `MON_LEVEL` (one free bit), `MON_EXP` (three free bits), or somewhere else.
 An example of such a fix was used in https://github.com/thegsproj/pokegscrystal/pull/8.

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -775,7 +775,7 @@ Edit `GetForestTreeFrame`:
 
 ## The 6-bit caught level can only record up to level 63
 
-The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63 normally.
+The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63.
 
 **Possible Fix:** Repurpose an unused bit from `MON_LEVEL` (one free bit), `MON_EXP` (three free bits), or somewhere else.
 An example of such a fix was used in https://github.com/thegsproj/pokegscrystal/pull/8.

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -13,6 +13,7 @@ These are parts of the code that do not work *incorrectly*, like [bugs and glitc
 - [Pokédex entry banks are derived from their species IDs](#pokédex-entry-banks-are-derived-from-their-species-ids)
 - [Identical sine wave code and data is repeated five times](#identical-sine-wave-code-and-data-is-repeated-five-times)
 - [`GetForestTreeFrame` works, but it's still bad](#getforesttreeframe-works-but-its-still-bad)
+- [The 6-bit caught level can only record up to level 63](#the-6-bit-caught-level-can-only-record-up-to-level-63)
 
 
 ## Pic banks are offset by `PICS_FIX`
@@ -770,3 +771,11 @@ Edit `GetForestTreeFrame`:
 +	add a
  	ret
 ```
+
+
+### The 6-bit caught level can only record up to level 63
+
+The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63 normally.
+
+**Fix:** Repurpose a free bit from `MON_LEVEL` (1 free bit), `MON_EXP` (3 free bits), etc.
+An example of such a fix was used in https://github.com/thegsproj/pokegscrystal/pull/8.

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -12,8 +12,8 @@ These are parts of the code that do not work *incorrectly*, like [bugs and glitc
 - [`ITEM_C3` and `ITEM_DC` break up the continuous sequence of TM items](#item_c3-and-item_dc-break-up-the-continuous-sequence-of-tm-items)
 - [Pokédex entry banks are derived from their species IDs](#pokédex-entry-banks-are-derived-from-their-species-ids)
 - [Identical sine wave code and data is repeated five times](#identical-sine-wave-code-and-data-is-repeated-five-times)
-- [`GetForestTreeFrame` works, but it's still bad](#getforesttreeframe-works-but-its-still-bad)
 - [The 6-bit caught level can only record up to level 63](#the-6-bit-caught-level-can-only-record-up-to-level-63)
+- [`GetForestTreeFrame` works, but it's still bad](#getforesttreeframe-works-but-its-still-bad)
 
 
 ## Pic banks are offset by `PICS_FIX`
@@ -736,6 +736,13 @@ ENDM
 **Fix:** Edit [home/sine.asm](https://github.com/pret/pokecrystal/blob/master/home/sine.asm) to contain a single copy of the (co)sine code in bank 0, and call it from those five sites.
 
 
+## The 6-bit caught level can only record up to level 63
+
+The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63.
+
+**Possible Fix:** Repurpose an unused bit from `MON_LEVEL` (one free bit), `MON_EXP` (three free bits), or somewhere else.
+
+
 ## `GetForestTreeFrame` works, but it's still bad
 
 The routine `GetForestTreeFrame` in [engine/tilesets/tileset_anims.asm](https://github.com/pret/pokecrystal/blob/master/engine/tilesets/tileset_anims.asm) is hilariously inefficient.
@@ -771,11 +778,3 @@ Edit `GetForestTreeFrame`:
 +	add a
  	ret
 ```
-
-
-## The 6-bit caught level can only record up to level 63
-
-The 6-bit field that is normally used to record the caught level of Pokémon can only record up to level 63.
-
-**Possible Fix:** Repurpose an unused bit from `MON_LEVEL` (one free bit), `MON_EXP` (three free bits), or somewhere else.
-An example of such a fix was used in https://github.com/thegsproj/pokegscrystal/pull/8.

--- a/docs/design_flaws.md
+++ b/docs/design_flaws.md
@@ -738,23 +738,7 @@ ENDM
 
 ## The 6-bit caught level can only record up to level 63
 
-When a Pokémon is caught, it stores its caught data in two bytes as part of the `party_struct`. The first byte uses 2 bits for `CAUGHT_TIME` and 6 bits for `CAUGHT_LEVEL`. The second byte uses 1 bit for `CAUGHT_GENDER` and 7 bits for `CAUGHT_LOCATION`. When a Pokémon greater than level 63 is caught, the game first stores `CAUGHT_TIME` in the first two bits of the first byte, and then does an `OR`
-operation on that byte with `[wCurPartyLevel]` during execution of `SetCaughtData:`. The result is that `CAUGHT_TIME` may become corrupted, and the `CAUGHT_LEVEL` reporting incorrectly. For example:
-
-A level 70 Pokémon caught at Morning: (% means binary)
-
-`%00000000` = Morning
-
-`%01000110` = Level 70
-
-Since level 70 takes up 7 bits, when you apply an OR operation here you get:
-`%01000110` = Level 6 Pokémon caught at Day.
-The game only looks at the first two bits for Time and last 6 bits for Level due to:
-
-```asm
-DEF CAUGHT_TIME_MASK  EQU %11000000
-DEF CAUGHT_LEVEL_MASK EQU %00111111
-```
+Pokémon that are caught above level 63 (`%00111111`) overflow into `CAUGHT_TIME`. The `party_struct` for a Pokémon stores both `CAUGHT_TIME` and `CAUGHT_LEVEL` in a single byte (The first byte of two in `CAUGHT_DATA`). The game uses `CAUGHT_TIME_MASK` (`%11000000`) and `CAUGHT_LEVEL_MASK` (`%00111111`) when reading from the byte. When a Pokémon is caught the game first stores `CAUGHT_TIME` into that byte and rotates the byte twice to the right so that `CAUGHT_TIME` would occupy bits 6 & 7. Then it performs an `OR` operation on that byte with the value in `[wCurPartyLevel]`. This means a level 70 Pokémon (`%01000110`) caught at Morning (`%00000000` or masked `$00`) is stored as (`%01000110`), and read as a Level 6 Pokémon (`%00000110`) Caught at Day (`%01000000` or masked `%01`).
 
 **Possible Fix:** Add an extra struct byte, free up other struct bytes (Ex. [Replace stat experience with EVs](https://github.com/pret/pokecrystal/wiki/Replace-stat-experience-with-EVs)), or repurposing a free unused bit from another existing byte (`MON_LEVEL` has one free bit and `MON_EXP` has three free bits). 
 


### PR DESCRIPTION
This PR aims to document the design flaw where only up to Level 63 encountered Pokémon are properly registered and recorded in the Pokédex upon capture, as well as document a solution to said design flaw.
Fixes https://github.com/pret/pokecrystal/issues/901