### PR TITLE
Warning fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ tools:
 	$(MAKE) -C tools/
 
 
-RGBASMFLAGS = -L -Weverything -Wnumeric-string=2 -Wtruncation=1
+RGBASMFLAGS = -L -H -Weverything -Wnumeric-string=2 -Wtruncation=1
 # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
 ifeq ($(DEBUG),1)
 RGBASMFLAGS += -E

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 CC := gcc
-CFLAGS := -O3 -flto -std=c11 -Wall -Wextra -pedantic -Wno-missing-field-initializers
+CFLAGS := -O3 -flto -std=c11 -Wall -Wextra -pedantic
 
 tools := \
 	bpp2png \


### PR DESCRIPTION
No real reason to have the missing field initializers warning in place in the tools makefile because no such warnings exist.
Also fixes a -Wobsolete warning that happens with the latest RGBDS and pokecrystal where `nop` after `halt` won't be the default anymore soon, so to continue using this behavior a makefile tweak is required.