### PR TITLE
Document that `farcall` returns `c` in `a` for some code

### DIFF
--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1085,10 +1085,13 @@ TryTileCollisionEvent::
 	call GetFacingTileCoord
 	ld [wFacingTileID], a
 	ld c, a
+	; CheckFacingTileForStdScript preserves c, and
+	; farcall copies c back into a.
 	farcall CheckFacingTileForStdScript
 	jr c, .done
 
-	; CheckCutTreeTile expects c to be copied into a by farcall
+	; CheckCutTreeTile expects a == [wFacingTileID], which
+	; it still is after the previous farcall.
 	call CheckCutTreeTile
 	jr nz, .whirlpool
 	farcall TryCutOW

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1087,6 +1087,7 @@ TryTileCollisionEvent::
 	ld c, a
 	farcall CheckFacingTileForStdScript
 	jr c, .done
+
 	; CheckCutTreeTile expects c to be copied into a by farcall
 	call CheckCutTreeTile
 	jr nz, .whirlpool

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1081,6 +1081,13 @@ LoadScriptBDE::
 	scf
 	ret
 
+; TryTileCollisionEvent loads wFacingTileID into c,
+; then farcalls CheckFacingTileForStdScript,
+; which preserves c, but since it's a farcall,
+; implicitly copies c back into a on return.
+; Then it calls CheckCutTreeTile which checks this value.
+; Every other Check<x>Tile call in the same function
+; explicitly loads wFacingTileID again.
 TryTileCollisionEvent::
 	call GetFacingTileCoord
 	ld [wFacingTileID], a

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1087,7 +1087,6 @@ TryTileCollisionEvent::
 	ld c, a
 	farcall CheckFacingTileForStdScript
 	jr c, .done
-	
 	; CheckCutTreeTile expects c to be copied into a by farcall
 	call CheckCutTreeTile
 	jr nz, .whirlpool

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1081,13 +1081,7 @@ LoadScriptBDE::
 	scf
 	ret
 
-; TryTileCollisionEvent loads wFacingTileID into c,
-; then farcalls CheckFacingTileForStdScript,
-; which preserves c, but since it's a farcall,
-; implicitly copies c back into a on return.
-; Then it calls CheckCutTreeTile which checks this value.
-; Every other Check<x>Tile call in the same function
-; explicitly loads wFacingTileID again.
+; expects c to be copied into a
 TryTileCollisionEvent::
 	call GetFacingTileCoord
 	ld [wFacingTileID], a

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1081,14 +1081,14 @@ LoadScriptBDE::
 	scf
 	ret
 
-; expects c to be copied into a
 TryTileCollisionEvent::
 	call GetFacingTileCoord
 	ld [wFacingTileID], a
 	ld c, a
 	farcall CheckFacingTileForStdScript
 	jr c, .done
-
+	
+	; CheckCutTreeTile expects c to be copied into a by farcall
 	call CheckCutTreeTile
 	jr nz, .whirlpool
 	farcall TryCutOW


### PR DESCRIPTION
Fixes #915
Other code may also do the same thing, would be worth a fine-toothed comb through to check again