### PR TITLE
Fix -Wobsolete warning when building in latest rgbds master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ tools:
 	$(MAKE) -C tools/
 
 
-RGBASMFLAGS = -L -Weverything -Wnumeric-string=2 -Wtruncation=1
+RGBASMFLAGS = -L -H -Weverything -Wnumeric-string=2 -Wtruncation=1
 # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
 ifeq ($(DEBUG),1)
 RGBASMFLAGS += -E


### PR DESCRIPTION
Second part of #935 addressed