### PR TITLE
Add object priority mode constant and remove unnecessary constants

### DIFF
--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -155,7 +155,7 @@ DEF rBGPD                EQU $ff69 ; CGB Mode Only - Background Palette Data
 DEF rOBPI                EQU $ff6a ; CGB Mode Only - Sprite Palette Index
 DEF rOBPI_AUTO_INCREMENT EQU 7     ; increment rOBPI after write to rOBPD
 DEF rOBPD                EQU $ff6b ; CGB Mode Only - Sprite Palette Data
-DEF rUNKNOWN1            EQU $ff6c ; (FEh) Bit 0 (Read/Write) - CGB Mode Only
+DEF rOPRI                EQU $ff6c ; CGB Mode Only - Object Priority Mode
 DEF rSVBK                EQU $ff70 ; CGB Mode Only - WRAM Bank
 DEF rUNKNOWN2            EQU $ff72 ; (00h) - Bit 0-7 (Read/Write)
 DEF rUNKNOWN3            EQU $ff73 ; (00h) - Bit 0-7 (Read/Write)

--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -157,10 +157,6 @@ DEF rOBPI_AUTO_INCREMENT EQU 7     ; increment rOBPI after write to rOBPD
 DEF rOBPD                EQU $ff6b ; CGB Mode Only - Sprite Palette Data
 DEF rOPRI                EQU $ff6c ; CGB Mode Only - Object Priority Mode
 DEF rSVBK                EQU $ff70 ; CGB Mode Only - WRAM Bank
-DEF rUNKNOWN2            EQU $ff72 ; (00h) - Bit 0-7 (Read/Write)
-DEF rUNKNOWN3            EQU $ff73 ; (00h) - Bit 0-7 (Read/Write)
-DEF rUNKNOWN4            EQU $ff74 ; (00h) - Bit 0-7 (Read/Write) - CGB Mode Only
-DEF rUNKNOWN5            EQU $ff75 ; (8Fh) - Bit 4-6 (Read/Write)
 DEF rPCM12               EQU $ff76 ; Channel 1 & 2 Amplitude (R)
 DEF rPCM34               EQU $ff77 ; Channel 3 & 4 Amplitude (R)
 DEF rIE                  EQU $ffff ; Interrupt Enable (R/W)


### PR DESCRIPTION
One of the unknown register constants, labelled as `rUNKNOWN1` in `hardware_constants.asm`, was looked up in the Game Boy Pan Docs and the actual register it matches to is the Object Priority Mode register `rOPRI`.
The rest of these unknown constants linked to registers that aren't even proper 'registers' in the Game Boy itself.
This PR aims to add this constant definition and remove the other unknown constant definitions in `hardware_constants.asm`.