### PR TITLE
Add documentation for "Options Menu fails to clear joypad state on initialization"

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -103,7 +103,7 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
   - [`ReadObjectEvents` overflows into `wObjectMasks`](#readobjectevents-overflows-into-wobjectmasks)
   - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
   - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
-  - [Options Menu fails to clear joypad state on initialization](#options-menu-fails-to-clear-joypad-state-on-initialization)
+  - [Options menu fails to clear joypad state on initialization](#options-menu-fails-to-clear-joypad-state-on-initialization)
 
 
 ## Multi-player battle engine

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2634,6 +2634,8 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
 
 ### Options menu fails to clear joypad state on initialization
 
+[Video](https://www.youtube.com/watch?v=uhDSIkXkl3g)
+
 This bug allows all the options to be updated at once if the left or right buttons are pressed on the same frame that the options menu is opened.
 
 **Fix:** Edit `_Option` in [engine/menus/options_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/menus/options_menu.asm):

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2640,8 +2640,9 @@ This bug allows all the options to be updated at once if the left or right butto
 
 ```diff
  _Option:
+-; BUG: Options menu fails to clear joypad state on initialization (see docs/bugs_and_glitches.md)
 +	call ClearJoypad
-	ld hl, hInMenu
-	ld a, [hl]
-	push af
+ 	ld hl, hInMenu
+ 	ld a, [hl]
+ 	push af
 ```

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2632,9 +2632,9 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
 ```
 
 
-### Options Menu fails to clear joypad state on initialization
+### Options menu fails to clear joypad state on initialization
 
-This bug (or feature!) results in all options being shifted left or right if the respective direction is pressed on the same frame the options menu is opened. The bug also exists in pokeyellow and pokegold.
+This bug allows all the options to be updated at once if the left or right buttons are pressed on the same frame that the options menu is opened.
 
 **Fix:** Edit `_Option` in [engine/menus/options_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/menus/options_menu.asm):
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2634,7 +2634,7 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
 
 ### Options menu fails to clear joypad state on initialization
 
-[Video](https://www.youtube.com/watch?v=uhDSIkXkl3g)
+([Video](https://www.youtube.com/watch?v=uhDSIkXkl3g))
 
 This bug allows all the options to be updated at once if the left or right buttons are pressed on the same frame that the options menu is opened.
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -103,6 +103,7 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
   - [`ReadObjectEvents` overflows into `wObjectMasks`](#readobjectevents-overflows-into-wobjectmasks)
   - [`ClearWRAM` only clears WRAM bank 1](#clearwram-only-clears-wram-bank-1)
   - [`BattleAnimCmd_ClearObjs` only clears the first 6⅔ objects](#battleanimcmd_clearobjs-only-clears-the-first-6-objects)
+  - [Options Menu fails to clear joypad state on initialization](#options-menu-fails-to-clear-joypad-state-on-initialization)
 
 
 ## Multi-player battle engine
@@ -2628,4 +2629,19 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
  	dec a
  	jr nz, .loop
  	ret
+```
+
+
+### Options Menu fails to clear joypad state on initialization
+
+This bug (or feature!) results in all options being shifted left or right if the respective direction is pressed on the same frame the options menu is opened. The bug also exists in pokeyellow and pokegold.
+
+**Fix:** Edit `_Option` in [engine/menus/options_menu.asm](https://github.com/pret/pokecrystal/blob/master/engine/menus/options_menu.asm):
+
+```diff
+ _Option:
++	call ClearJoypad
+	ld hl, hInMenu
+	ld a, [hl]
+	push af
 ```

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -11,6 +11,7 @@
 DEF NUM_OPTIONS EQU const_value ; 8
 
 _Option:
+; BUG: Options menu fails to clear joypad state on initialization (see docs/bugs_and_glitches.md)
 	ld hl, hInMenu
 	ld a, [hl]
 	push af


### PR DESCRIPTION
Addresses the bug documented in the [pokeyellow repo here](https://github.com/pret/pokeyellow/blob/master/docs/bugs_and_glitches.md#options-menu-code-fails-to-clear-joypad-state-on-initialization)