### PR TITLE
Replace numbers with constants in PlayHitSound

### DIFF
--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -1312,9 +1312,9 @@ endr
 
 PlayHitSound:
 	ld a, [wNumHits]
-	cp $1
+	cp BATTLEANIM_ENEMY_DAMAGE
 	jr z, .okay
-	cp $4
+	cp BATTLEANIM_PLAYER_DAMAGE
 	ret nz
 
 .okay


### PR DESCRIPTION
Encountered a bug in the hack I work on that was a result of magic numbers in this function. Figured I'd push a fix here as well