### PR TITLE
mobile/mobile_45.asm -> lib/mobile/mail.asm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ rom_obj := \
 	gfx/pics.o \
 	gfx/sprites.o \
 	gfx/tilesets.o \
-	lib/mobile/main.o
+	lib/mobile/main.o \
+	lib/mobile/mail.o
 
 pokecrystal_obj         := $(rom_obj:.o=.o)
 pokecrystal11_obj       := $(rom_obj:.o=11.o)

--- a/layout.link
+++ b/layout.link
@@ -185,6 +185,7 @@ ROMX $43
 ROMX $44
 	"Mobile Adapter SDK"
 ROMX $45
+	"Mobile Adapter SDK Mail"
 	"mobile45"
 ROMX $46
 	"mobile46"

--- a/lib/mobile/mail.asm
+++ b/lib/mobile/mail.asm
@@ -1,5 +1,14 @@
-pushc
-setcharmap ascii
+; A library included as part of the Mobile Adapter GB SDK.
+
+INCLUDE "macros/code.asm"
+INCLUDE "macros/const.asm"
+INCLUDE "macros/gfx.asm"
+INCLUDE "constants/gfx_constants.asm"
+INCLUDE "constants/hardware_constants.asm"
+INCLUDE "constants/mobile_constants.asm"
+INCLUDE "constants/text_constants.asm"
+
+SECTION "Mobile Adapter SDK Mail", ROMX
 
 String_114000:
 	db "---", 0
@@ -5154,5 +5163,3 @@ Function115d80:
 	ld d, $a0
 	ld e, $0
 	ret
-
-popc

--- a/main.asm
+++ b/main.asm
@@ -518,7 +518,6 @@ INCLUDE "engine/movie/title.asm"
 
 SECTION "mobile45", ROMX
 
-INCLUDE "mobile/mobile_45.asm"
 INCLUDE "mobile/mobile_45_sprite_engine.asm"
 INCLUDE "mobile/mobile_45_2.asm"
 INCLUDE "mobile/mobile_45_stadium.asm"


### PR DESCRIPTION
This file is part of the official mobile adapter SDK, although unlike
lib/mobile/main.asm, this file was included as source code the
developers could modify.
