### PR TITLE
`.CheckNPC` label and comment correction

### DIFF
--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -613,7 +613,8 @@ ENDM
 .CheckNPC:
 ; Returns 0 if there is an NPC in front that you can't move
 ; Returns 1 if there is no NPC in front
-; Returns 2 if there is a movable NPC in front
+; Returns 2 if there is a movable NPC in front. The game actually treats
+; this the same as an NPC in front (bump).
 	ld a, 0
 	ldh [hMapObjectIndex], a
 ; Load the next X coordinate into d
@@ -631,14 +632,14 @@ ENDM
 ; Find an object struct with coordinates equal to d,e
 	ld bc, wObjectStructs ; redundant
 	farcall IsNPCAtCoord
-	jr nc, .is_npc
+	jr nc, .no_npc
 	call .CheckStrengthBoulder
 	jr c, .no_bump
 
-	xor a
+	xor a ; bump
 	ret
 
-.is_npc
+.no_npc
 	ld a, 1
 	ret
 


### PR DESCRIPTION
The `.is_npc` label is incorrect. In fact, returning 1 means that there is NOT an NPC in front.

Also I expanded on the `.no_bump` comment (returning 2) as this actually does the SAME as if you returned 0.

See:  
https://github.com/pret/pokecrystal/blob/41d5ea0482f4ef577df600d2d8b5cad70f74a396/engine/overworld/player_movement.asm#L267-L271  
and  
https://github.com/pret/pokecrystal/blob/41d5ea0482f4ef577df600d2d8b5cad70f74a396/engine/overworld/player_movement.asm#L325-L330

The former of which has an unused/unreferenced local label next to the `.bump` label. Presumably this would have handled the `.no_bump` functionality at one time.