### PR TITLE
`TrainerWalkToPlayer:` should reference `wSeenTrainerDistance`

### DIFF
--- a/engine/overworld/player_object.asm
+++ b/engine/overworld/player_object.asm
@@ -519,7 +519,7 @@ TrainerWalkToPlayer:
 	call InitMovementBuffer
 	ld a, movement_step_sleep
 	call AppendToMovementBuffer
-	ld a, [wWalkingIntoNPC]
+	ld a, [wSeenTrainerDistance]
 	dec a
 	jr z, .TerminateStep
 	ldh a, [hLastTalked]


### PR DESCRIPTION
After doing a deep dive, I believe that `TrainerWalkToPlayer:` should instead reference `wSeenTrainerDistance` instead as mentioned in #1019. As well, It seems that `wWalkingIntoNPC` is only referenced in `DoPlayerMovement.TrySurf`. I believe it is probably safe to say for now that `wWalkingIntoNPC` was set in this routine, but never ended up being used elsewhere. Thus, we should be good to close the PR as well.

Resolves #1019 