### PR TITLE
Document PRZ/BRN enemy switched stat debuff bug

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6407,7 +6407,7 @@ LoadEnemyMon:
 	ld bc, NUM_EXP_STATS * 2
 	call CopyBytes
 
-; BUG: PRZ and BRN stat debuffs sometimes don't apply to switched mons (see docs/bugs_and_glitches.md)
+; BUG: PRZ and BRN stat reductions don't apply to switched Pokémon (see docs/bugs_and_glitches.md)
 	ret
 
 CheckSleepingTreeMon:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6407,6 +6407,7 @@ LoadEnemyMon:
 	ld bc, NUM_EXP_STATS * 2
 	call CopyBytes
 
+; BUG: PRZ and BRN stat debuffs sometimes don't apply to switched mons (see docs/bugs_and_glitches.md)
 	ret
 
 CheckSleepingTreeMon:


### PR DESCRIPTION
Alright I've done some debugging and testing and I believe I have this bug figured out.

The Problem: 
1. `ApplyStatusEffectOnEnemyStats` is only ever called from `InitEnemyMon`.
2. Enemy Mon's (wild, trainer, ect) use `LoadEnemyMon:` for first load and during switching (both forced and AI), with the exception of link battles and the BattleTower, which both use `InitEnemyMon` instead.

Some of the first few lines of `LoadEnemyMon` checks for if we are in a link battle or a BattleTower-Battle:
https://github.com/pret/pokecrystal/blob/c4e3f2bbc23fe731deb177ed5743fdc6ac6572e0/engine/battle/core.asm#L5967-L5975

Since all other Enemy Mons use the full `LoadEnemyMon` routine, they never call `ApplyStatusEffectOnEnemyStats`. Since the stats are recalculated back to base stats during load, the Speed/Attack stat is never lowered based on Status. By simply adding the `ApplyStatusEffectOnEnemyStats` to the end of the `LoadEnemyMon` resolves this issue. This is similar to how `InitEnemyMon` and `InitBattleMon` functions.


@Rangi42 Questions:
>Does it affect link battles too? InitEnemyMon and Function_SetEnemyMonAndSendOutAnimation are called in link battles, but I'd expect a switch-related bug to have been noticed sooner in them.

It does not affect link battles or the BattleTower.


>Does the fix break anything? In particular, if an enemy mon already has PRZ/BRN when the battle starts, would this fix prevent the stat drop? If so, we can't just leave both ApplyStatusEffectOnEnemyStats calls in, since that would change this bug from no drop to a double drop.

I did a fair bit of testing. It appears to work as intended. I also tested an enemy mon already having PRZ/BRN when the battle starts, using some debugging.. There is no double stat drop. Also looking over the code and where it is placed, I don't see any other conflicts that the `ApplyStatusEffectOnEnemyStats` routine would cause here.


Steps to Reproduce problem: (Using forced switch method)
1. Find a trainer with two pokemon.
2. Thunder wave the first pokemon.
3. Observe `wEnemyMonSpeed` stats decrease.
4. Use Whirlwind
5. Kill other mon.
6. PRZ pokemon will return with full Speed stat.


Resolves #746 