### PR TITLE
Ensure linked songs are in the same bank

### DIFF
--- a/audio.asm
+++ b/audio.asm
@@ -77,23 +77,32 @@ SECTION "Songs 4", ROMX
 
 INCLUDE "audio/music/viridiancity.asm"
 INCLUDE "audio/music/celadoncity.asm"
+
 INCLUDE "audio/music/wildpokemonvictory.asm"
 INCLUDE "audio/music/successfulcapture.asm"
+assert BANK(Music_WildPokemonVictory) == BANK(Music_SuccessfulCapture)
+
 INCLUDE "audio/music/gymleadervictory.asm"
 INCLUDE "audio/music/mtmoonsquare.asm"
 INCLUDE "audio/music/gym.asm"
 INCLUDE "audio/music/pallettown.asm"
 INCLUDE "audio/music/profoakspokemontalk.asm"
 INCLUDE "audio/music/profoak.asm"
+
 INCLUDE "audio/music/lookrival.asm"
 INCLUDE "audio/music/aftertherivalfight.asm"
+assert BANK(Music_LookRival) == BANK(Music_AfterTheRivalFight)
+
 INCLUDE "audio/music/surf.asm"
 INCLUDE "audio/music/nationalpark.asm"
 INCLUDE "audio/music/azaleatown.asm"
 INCLUDE "audio/music/cherrygrovecity.asm"
 INCLUDE "audio/music/unioncave.asm"
+
 INCLUDE "audio/music/johtowildbattle.asm"
 INCLUDE "audio/music/johtowildbattlenight.asm"
+assert BANK(Music_JohtoWildBattle) == BANK(Music_JohtoWildBattleNight)
+
 INCLUDE "audio/music/johtotrainerbattle.asm"
 INCLUDE "audio/music/lookyoungster.asm"
 INCLUDE "audio/music/tintower.asm"
@@ -106,8 +115,11 @@ INCLUDE "audio/music/pokemonmarch.asm"
 INCLUDE "audio/music/goldsilveropening.asm"
 INCLUDE "audio/music/goldsilveropening2.asm"
 INCLUDE "audio/music/lookhiker.asm"
+
 INCLUDE "audio/music/lookrocket.asm"
 INCLUDE "audio/music/rockettheme.asm"
+assert BANK(Music_LookRocket) == BANK(Music_RocketTheme)
+
 INCLUDE "audio/music/mainmenu.asm"
 INCLUDE "audio/music/lookkimonogirl.asm"
 INCLUDE "audio/music/pokeflutechannel.asm"


### PR DESCRIPTION
If someone decides to shuffle song data around, this prevents certain songs from silently breaking.