### PR TITLE
Fixed the wrong CheckHiddenOpponent bugfix

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -614,10 +614,15 @@ This bug affects Attract, Curse, Foresight, Mean Look, Mimic, Nightmare, Spider 
 ```diff
  CheckHiddenOpponent:
 -; BUG: Lock-On and Mind Reader don't always bypass Fly and Dig (see docs/bugs_and_glitches.md)
--	ld a, BATTLE_VARS_SUBSTATUS3_OPP
--	call GetBattleVar
--	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
-+	xor a
++	ld a, BATTLE_VARS_SUBSTATUS5_OPP
++	call GetBattleVar
++	cpl
++	and 1 << SUBSTATUS_LOCK_ON
++	ret z
++
+	ld a, BATTLE_VARS_SUBSTATUS3_OPP
+	call GetBattleVar
+	and 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND
  	ret
 ```
 


### PR DESCRIPTION
The old bugfix caused more bugs than it fixed.
It allowed the moves that called `CheckHiddenOpponent` to always hit in the semi-invulnerable turn of Fly and Dig, regardless of the Lock-On state of the opponent.

The new check accounts for the Lock-On state of the opponent, and reinstates the vanilla code that checked for the Flying and Underground states of the opponent.