### PR TITLE
Use NO_INPUT instead of magic number

### DIFF
--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -76,7 +76,7 @@ _UnownPrinter:
 	ldh a, [hJoyPressed]
 	vc_patch Forbid_printing_Unown
 if DEF(_CRYSTAL11_VC)
-	and 0
+	and NO_INPUT
 else
 	and A_BUTTON
 endc

--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -69,7 +69,7 @@ ReadAnyMail:
 	jr z, .loop
 	vc_patch Forbid_printing_mail
 if DEF(_CRYSTAL11_VC)
-	and 0
+	and NO_INPUT
 else
 	and START
 endc


### PR DESCRIPTION
This is for the Virtual Console builds, where it disables the print functions of Unown and Mail.