### PR TITLE
Use BattleAnim_Dummy in data/moves/animations.asm

### DIFF
--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -120,7 +120,7 @@ BattleAnimations::
 	dw BattleAnim_FocusEnergy
 	dw BattleAnim_Bide
 	dw BattleAnim_Metronome
-	dw BattleAnim_Dummy
+	dw BattleAnim_MirrorMove
 	dw BattleAnim_Selfdestruct
 	dw BattleAnim_EggBomb
 	dw BattleAnim_Lick
@@ -285,6 +285,7 @@ BattleAnimations::
 	assert_table_length NUM_BATTLE_ANIMS + 1
 
 BattleAnim_Dummy:
+BattleAnim_MirrorMove:
 	anim_ret
 
 BattleAnim_SweetScent2:

--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -1,7 +1,7 @@
 BattleAnimations::
 ; entries correspond to constants/move_constants.asm
 	table_width 2, BattleAnimations
-	dw BattleAnim_0
+	dw BattleAnim_Dummy
 	dw BattleAnim_Pound
 	dw BattleAnim_KarateChop
 	dw BattleAnim_Doubleslap
@@ -120,7 +120,7 @@ BattleAnimations::
 	dw BattleAnim_FocusEnergy
 	dw BattleAnim_Bide
 	dw BattleAnim_Metronome
-	dw BattleAnim_MirrorMove
+	dw BattleAnim_Dummy
 	dw BattleAnim_Selfdestruct
 	dw BattleAnim_EggBomb
 	dw BattleAnim_Lick
@@ -254,9 +254,9 @@ BattleAnimations::
 	dw BattleAnim_Whirlpool
 	dw BattleAnim_BeatUp
 	assert_table_length NUM_ATTACKS + 1
-	dw BattleAnim_252
-	dw BattleAnim_253
-	dw BattleAnim_254
+	dw BattleAnim_Dummy
+	dw BattleAnim_Dummy
+	dw BattleAnim_Dummy
 	dw BattleAnim_SweetScent2
 	assert_table_length $100
 ; $100
@@ -284,11 +284,7 @@ BattleAnimations::
 	dw BattleAnim_HitConfusion
 	assert_table_length NUM_BATTLE_ANIMS + 1
 
-BattleAnim_0:
-BattleAnim_252:
-BattleAnim_253:
-BattleAnim_254:
-BattleAnim_MirrorMove:
+BattleAnim_Dummy:
 	anim_ret
 
 BattleAnim_SweetScent2:


### PR DESCRIPTION
Resolves #1047

For the one that used to be `BattleAnim_MirrorMove` that is now `BattleAnim_Dummy` should we add a comment next to it mentioning mirror move? Might help making searching for it easier.