### PR TITLE
Define all unused type names with `rept`

### DIFF
--- a/data/types/names.asm
+++ b/data/types/names.asm
@@ -1,6 +1,7 @@
 TypeNames:
 ; entries correspond to types (see constants/type_constants.asm)
 	table_width 2, TypeNames
+
 	dw Normal
 	dw Fighting
 	dw Flying
@@ -12,17 +13,13 @@ TypeNames:
 	dw Ghost
 	dw Steel
 	assert_table_length UNUSED_TYPES
+
+rept UNUSED_TYPES_END - UNUSED_TYPES - 1 ; discount CURSE_TYPE
 	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
-	dw Normal
+endr
 	dw CurseType
 	assert_table_length UNUSED_TYPES_END
+
 	dw Fire
 	dw Water
 	dw Grass


### PR DESCRIPTION
Fixes #1070