### PR TITLE
Map/object/event renaming

### DIFF
--- a/constants/map_object_constants.asm
+++ b/constants/map_object_constants.asm
@@ -1,39 +1,39 @@
 ; object_struct members (see macros/ram.asm)
 rsreset
-DEF OBJECT_SPRITE           rb ; 00
-DEF OBJECT_MAP_OBJECT_INDEX rb ; 01
-DEF OBJECT_SPRITE_TILE      rb ; 02
-DEF OBJECT_MOVEMENT_TYPE    rb ; 03
-DEF OBJECT_FLAGS1           rb ; 04
-DEF OBJECT_FLAGS2           rb ; 05
-DEF OBJECT_PALETTE          rb ; 06
-DEF OBJECT_WALKING          rb ; 07
-DEF OBJECT_DIRECTION        rb ; 08
-DEF OBJECT_STEP_TYPE        rb ; 09
-DEF OBJECT_STEP_DURATION    rb ; 0a
-DEF OBJECT_ACTION           rb ; 0b
-DEF OBJECT_STEP_FRAME       rb ; 0c
-DEF OBJECT_FACING           rb ; 0d
-DEF OBJECT_TILE             rb ; 0e
-DEF OBJECT_LAST_TILE        rb ; 0f
-DEF OBJECT_MAP_X            rb ; 10
-DEF OBJECT_MAP_Y            rb ; 11
-DEF OBJECT_LAST_MAP_X       rb ; 12
-DEF OBJECT_LAST_MAP_Y       rb ; 13
-DEF OBJECT_INIT_X           rb ; 14
-DEF OBJECT_INIT_Y           rb ; 15
-DEF OBJECT_RADIUS           rb ; 16
-DEF OBJECT_SPRITE_X         rb ; 17
-DEF OBJECT_SPRITE_Y         rb ; 18
-DEF OBJECT_SPRITE_X_OFFSET  rb ; 19
-DEF OBJECT_SPRITE_Y_OFFSET  rb ; 1a
-DEF OBJECT_MOVEMENT_INDEX   rb ; 1b
-DEF OBJECT_STEP_INDEX       rb ; 1c
-DEF OBJECT_1D               rb ; 1d
-DEF OBJECT_1E               rb ; 1e
-DEF OBJECT_JUMP_HEIGHT      rb ; 1f
-DEF OBJECT_RANGE            rb ; 20
-                            rb_skip 7
+DEF OBJECT_SPRITE             rb ; 00
+DEF OBJECT_OBJECT_EVENT_INDEX rb ; 01
+DEF OBJECT_SPRITE_TILE        rb ; 02
+DEF OBJECT_MOVEMENT_TYPE      rb ; 03
+DEF OBJECT_FLAGS1             rb ; 04
+DEF OBJECT_FLAGS2             rb ; 05
+DEF OBJECT_PALETTE            rb ; 06
+DEF OBJECT_WALKING            rb ; 07
+DEF OBJECT_DIRECTION          rb ; 08
+DEF OBJECT_STEP_TYPE          rb ; 09
+DEF OBJECT_STEP_DURATION      rb ; 0a
+DEF OBJECT_ACTION             rb ; 0b
+DEF OBJECT_STEP_FRAME         rb ; 0c
+DEF OBJECT_FACING             rb ; 0d
+DEF OBJECT_TILE               rb ; 0e
+DEF OBJECT_LAST_TILE          rb ; 0f
+DEF OBJECT_MAP_X              rb ; 10
+DEF OBJECT_MAP_Y              rb ; 11
+DEF OBJECT_LAST_MAP_X         rb ; 12
+DEF OBJECT_LAST_MAP_Y         rb ; 13
+DEF OBJECT_INIT_X             rb ; 14
+DEF OBJECT_INIT_Y             rb ; 15
+DEF OBJECT_RADIUS             rb ; 16
+DEF OBJECT_SPRITE_X           rb ; 17
+DEF OBJECT_SPRITE_Y           rb ; 18
+DEF OBJECT_SPRITE_X_OFFSET    rb ; 19
+DEF OBJECT_SPRITE_Y_OFFSET    rb ; 1a
+DEF OBJECT_MOVEMENT_INDEX     rb ; 1b
+DEF OBJECT_STEP_INDEX         rb ; 1c
+DEF OBJECT_1D                 rb ; 1d
+DEF OBJECT_1E                 rb ; 1e
+DEF OBJECT_JUMP_HEIGHT        rb ; 1f
+DEF OBJECT_RANGE              rb ; 20
+                              rb_skip 7
 DEF OBJECT_LENGTH EQU _RS
 DEF NUM_OBJECT_STRUCTS EQU 13 ; see wObjectStructs
 
@@ -96,32 +96,32 @@ DEF ABSOLUTE_TILE_ID_F    EQU 2
 DEF RELATIVE_ATTRIBUTES EQU 1 << RELATIVE_ATTRIBUTES_F
 DEF ABSOLUTE_TILE_ID    EQU 1 << ABSOLUTE_TILE_ID_F
 
-; map_object struct members (see macros/ram.asm)
+; object_event_struct members (see macros/ram.asm)
 ; struct initialized by object_event macro (see macros/scripts/maps.asm)
 rsreset
-DEF MAPOBJECT_OBJECT_STRUCT_ID rb ; 0
-DEF MAPOBJECT_SPRITE           rb ; 1
-DEF MAPOBJECT_Y_COORD          rb ; 2
-DEF MAPOBJECT_X_COORD          rb ; 3
-DEF MAPOBJECT_MOVEMENT         rb ; 4
-DEF MAPOBJECT_RADIUS           rb ; 5
-DEF MAPOBJECT_HOUR_1           rb ; 6
-DEF MAPOBJECT_HOUR_2           rb ; 7
-rsset MAPOBJECT_HOUR_2
-DEF MAPOBJECT_TIMEOFDAY        rb ; 7
-DEF MAPOBJECT_PALETTE          rb ; 8
-rsset MAPOBJECT_PALETTE
-DEF MAPOBJECT_TYPE             rb ; 8
-DEF MAPOBJECT_SIGHT_RANGE      rb ; 9
-DEF MAPOBJECT_SCRIPT_POINTER   rw ; a
-DEF MAPOBJECT_EVENT_FLAG       rw ; c
+DEF OBJECT_EVENT_OBJECT_STRUCT_ID rb ; 0
+DEF OBJECT_EVENT_SPRITE           rb ; 1
+DEF OBJECT_EVENT_Y_COORD          rb ; 2
+DEF OBJECT_EVENT_X_COORD          rb ; 3
+DEF OBJECT_EVENT_MOVEMENT         rb ; 4
+DEF OBJECT_EVENT_RADIUS           rb ; 5
+DEF OBJECT_EVENT_HOUR_1           rb ; 6
+DEF OBJECT_EVENT_HOUR_2           rb ; 7
+rsset OBJECT_EVENT_HOUR_2
+DEF OBJECT_EVENT_TIMEOFDAY        rb ; 7
+DEF OBJECT_EVENT_PALETTE          rb ; 8
+rsset OBJECT_EVENT_PALETTE
+DEF OBJECT_EVENT_TYPE             rb ; 8
+DEF OBJECT_EVENT_SIGHT_RANGE      rb ; 9
+DEF OBJECT_EVENT_SCRIPT_POINTER   rw ; a
+DEF OBJECT_EVENT_EVENT_FLAG       rw ; c
                                rb_skip 2
-DEF MAPOBJECT_LENGTH EQU _RS
-DEF NUM_OBJECTS EQU 16
+DEF OBJECT_EVENT_LENGTH EQU _RS
+DEF NUM_OBJECT_EVENT_STRUCTS EQU 16
 DEF PLAYER_OBJECT EQU 0
 
-DEF MAPOBJECT_PALETTE_MASK EQU %11110000
-DEF MAPOBJECT_TYPE_MASK    EQU %00001111
+DEF OBJECT_EVENT_PALETTE_MASK EQU %11110000
+DEF OBJECT_EVENT_TYPE_MASK    EQU %00001111
 
 ; SpriteMovementData struct members (see data/sprites/map_objects.asm)
 rsreset
@@ -133,8 +133,8 @@ DEF SPRITEMOVEATTR_FLAGS2   rb ; 4
 DEF SPRITEMOVEATTR_PALFLAGS rb ; 5
 DEF NUM_SPRITEMOVEDATA_FIELDS EQU _RS
 
-DEF MAPOBJECT_SCREEN_WIDTH  EQU (SCREEN_WIDTH / 2) + 2
-DEF MAPOBJECT_SCREEN_HEIGHT EQU (SCREEN_HEIGHT / 2) + 2
+DEF OBJECT_EVENT_SCREEN_WIDTH  EQU (SCREEN_WIDTH / 2) + 2
+DEF OBJECT_EVENT_SCREEN_HEIGHT EQU (SCREEN_HEIGHT / 2) + 2
 
 ; SpriteMovementData indexes (see data/sprites/map_objects.asm)
 	const_def

--- a/constants/script_constants.asm
+++ b/constants/script_constants.asm
@@ -112,8 +112,8 @@ DEF CALLBACK_SIZE     EQU  3 ; callback
 DEF WARP_EVENT_SIZE   EQU  5 ; warp_event
 DEF COORD_EVENT_SIZE  EQU  8 ; coord_event
 DEF BG_EVENT_SIZE     EQU  5 ; bg_event
-; An object_event is a map_object without its initial MAPOBJECT_OBJECT_STRUCT_ID or final padding
-DEF OBJECT_EVENT_SIZE EQU MAPOBJECT_LENGTH - 3 ; 13
+; An object_event is a map_object without its initial OBJECT_EVENT_OBJECT_STRUCT_ID or final padding
+DEF OBJECT_EVENT_SIZE EQU OBJECT_EVENT_LENGTH - 3 ; 13
 
 ; A coord_event for scene -1 will always activate,
 ; regardless of the map's scene variable value.

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2638,13 +2638,13 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
 **Fix:** Edit `ReadObjectEvents` in [home/map.asm](https://github.com/pret/pokecrystal/blob/master/home/map.asm):
 
 ```diff
--; get NUM_OBJECTS - [wCurMapObjectEventCount]
-+; get NUM_OBJECTS - [wCurMapObjectEventCount] - 1
+-; get NUM_OBJECT_EVENT_STRUCTS - [wCurMapObjectEventCount]
++; get NUM_OBJECT_EVENT_STRUCTS - [wCurMapObjectEventCount] - 1
 -; BUG: ReadObjectEvents overflows into wObjectMasks (see docs/bugs_and_glitches.md)
  	ld a, [wCurMapObjectEventCount]
  	ld c, a
--	ld a, NUM_OBJECTS
-+	ld a, NUM_OBJECTS - 1
+-	ld a, NUM_OBJECT_EVENT_STRUCTS
++	ld a, NUM_OBJECT_EVENT_STRUCTS - 1
  	sub c
  	jr z, .skip
 +	jr c, .skip
@@ -2652,7 +2652,7 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
  	; could have done "inc hl" instead
  	ld bc, 1
  	add hl, bc
- 	ld bc, MAPOBJECT_LENGTH
+ 	ld bc, OBJECT_EVENT_LENGTH
  .loop
  	ld [hl],  0
  	inc hl

--- a/engine/events/battle_tower/battle_tower.asm
+++ b/engine/events/battle_tower/battle_tower.asm
@@ -1559,7 +1559,7 @@ LoadOpponentTrainerAndPokemonWithOTSprite:
 	ld c, a
 	ld b, 0
 	ld d, 0
-	ld hl, wMapObjects
+	ld hl, wObjectEventStructs
 	add hl, bc
 	inc hl
 	ld a, [wBTTempOTSprite]

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -1338,12 +1338,12 @@ GetFacingObject:
 
 	ldh a, [hObjectStructIndex]
 	call GetObjectStruct
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	ldh [hLastTalked], a
 	call GetMapObject
-	ld hl, MAPOBJECT_MOVEMENT
+	ld hl, OBJECT_EVENT_MOVEMENT
 	add hl, bc
 	ld a, [hl]
 	ld d, a

--- a/engine/overworld/cmd_queue.asm
+++ b/engine/overworld/cmd_queue.asm
@@ -248,14 +248,14 @@ CmdQueue_Type3:
 
 .IsPlayerFacingDown:
 	push bc
-	ld bc, wPlayerStruct
+	ld bc, wPlayerObjectStruct
 	call GetSpriteDirection
 	and a
 	pop bc
 	ret
 
 CmdQueue_StoneTable:
-	ld de, wPlayerStruct
+	ld de, wPlayerObjectStruct
 	ld a, NUM_OBJECT_STRUCTS
 .loop
 	push af

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -539,17 +539,17 @@ TryObjectEvent:
 	call PlayTalkObject
 	ldh a, [hObjectStructIndex]
 	call GetObjectStruct
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	ldh [hLastTalked], a
 
 	ldh a, [hLastTalked]
 	call GetMapObject
-	ld hl, MAPOBJECT_TYPE
+	ld hl, OBJECT_EVENT_TYPE
 	add hl, bc
 	ld a, [hl]
-	and MAPOBJECT_TYPE_MASK
+	and OBJECT_EVENT_TYPE_MASK
 
 ; BUG: TryObjectEvent arbitrary code execution (see docs/bugs_and_glitches.md)
 	push bc
@@ -583,7 +583,7 @@ ObjectEventTypeArray:
 	db -1 ; end
 
 .script
-	ld hl, MAPOBJECT_SCRIPT_POINTER
+	ld hl, OBJECT_EVENT_SCRIPT_POINTER
 	add hl, bc
 	ld a, [hli]
 	ld h, [hl]
@@ -593,7 +593,7 @@ ObjectEventTypeArray:
 	ret
 
 .itemball
-	ld hl, MAPOBJECT_SCRIPT_POINTER
+	ld hl, OBJECT_EVENT_SCRIPT_POINTER
 	add hl, bc
 	ld a, [hli]
 	ld h, [hl]

--- a/engine/overworld/map_objects.asm
+++ b/engine/overworld/map_objects.asm
@@ -4,7 +4,7 @@ INCLUDE "data/sprites/map_objects.asm"
 
 DeleteMapObject::
 	push bc
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	push af
@@ -45,7 +45,7 @@ CheckObjectStillVisible:
 	add 1
 	sub e
 	jr c, .ok
-	cp MAPOBJECT_SCREEN_WIDTH
+	cp OBJECT_EVENT_SCREEN_WIDTH
 	jr nc, .ok
 	ld a, [wYCoord]
 	ld e, a
@@ -55,7 +55,7 @@ CheckObjectStillVisible:
 	add 1
 	sub e
 	jr c, .ok
-	cp MAPOBJECT_SCREEN_HEIGHT
+	cp OBJECT_EVENT_SCREEN_HEIGHT
 	jr nc, .ok
 	jr .yes
 
@@ -71,7 +71,7 @@ CheckObjectStillVisible:
 	add 1
 	sub e
 	jr c, .ok2
-	cp MAPOBJECT_SCREEN_WIDTH
+	cp OBJECT_EVENT_SCREEN_WIDTH
 	jr nc, .ok2
 	ld a, [wYCoord]
 	ld e, a
@@ -81,7 +81,7 @@ CheckObjectStillVisible:
 	add 1
 	sub e
 	jr c, .ok2
-	cp MAPOBJECT_SCREEN_HEIGHT
+	cp OBJECT_EVENT_SCREEN_HEIGHT
 	jr nc, .ok2
 .yes
 	and a
@@ -409,7 +409,7 @@ GetMapObjectField: ; unreferenced
 	push bc
 	ld e, a
 	ld d, 0
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	call GetMapObject
@@ -419,14 +419,14 @@ GetMapObjectField: ; unreferenced
 	ret
 
 RestoreDefaultMovement:
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jr z, .ok
 	push bc
 	call GetMapObject
-	ld hl, MAPOBJECT_MOVEMENT
+	ld hl, OBJECT_EVENT_MOVEMENT
 	add hl, bc
 	ld a, [hl]
 	pop bc
@@ -1659,7 +1659,7 @@ StepFunction_StrengthBoulder:
 	ld hl, OBJECT_MAP_Y
 	add hl, bc
 	ld e, [hl]
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	ld b, a
@@ -2212,10 +2212,10 @@ RespawnPlayer:
 	ret
 
 RespawnObject:
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	ret nc
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
@@ -2299,7 +2299,7 @@ CheckObjectOnScreen:
 	cp d
 	jr z, .equal_x
 	jr nc, .nope
-	add MAPOBJECT_SCREEN_WIDTH - 1
+	add OBJECT_EVENT_SCREEN_WIDTH - 1
 	cp d
 	jr c, .nope
 .equal_x
@@ -2307,7 +2307,7 @@ CheckObjectOnScreen:
 	cp e
 	jr z, .equal_y
 	jr nc, .nope
-	add MAPOBJECT_SCREEN_HEIGHT - 1
+	add OBJECT_EVENT_SCREEN_HEIGHT - 1
 	cp e
 	jr c, .nope
 .equal_y
@@ -2508,7 +2508,7 @@ SpawnInCustomFacing:
 SpawnInFacingDown:
 	ld a, DOWN
 _ContinueSpawnFacing:
-	ld bc, wPlayerStruct
+	ld bc, wPlayerObjectStruct
 	call SetSpriteDirection
 	ret
 
@@ -2526,7 +2526,7 @@ _SetPlayerPalette:
 	swap a
 	and PALETTE_MASK
 	ld d, a
-	ld bc, wPlayerStruct
+	ld bc, wPlayerObjectStruct
 	ld hl, OBJECT_PALETTE
 	add hl, bc
 	ld a, [hl]
@@ -2638,7 +2638,7 @@ _UnfreezeFollowerObject::
 	ret z
 	push bc
 	call GetObjectStruct
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	pop bc
@@ -2685,14 +2685,14 @@ UnfreezeObject: ; unreferenced
 	ret
 
 ResetObject:
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jp z, .set_standing
 	push bc
 	call GetMapObject
-	ld hl, MAPOBJECT_MOVEMENT
+	ld hl, OBJECT_EVENT_MOVEMENT
 	add hl, bc
 	ld a, [hl]
 	pop bc
@@ -3029,16 +3029,16 @@ InitSprites:
 	ret
 
 .Addresses:
-	dw wPlayerStruct
-	dw wObject1Struct
-	dw wObject2Struct
-	dw wObject3Struct
-	dw wObject4Struct
-	dw wObject5Struct
-	dw wObject6Struct
-	dw wObject7Struct
-	dw wObject8Struct
-	dw wObject9Struct
-	dw wObject10Struct
-	dw wObject11Struct
-	dw wObject12Struct
+	dw wPlayerObjectStruct
+	dw wObjectStruct1
+	dw wObjectStruct2
+	dw wObjectStruct3
+	dw wObjectStruct4
+	dw wObjectStruct5
+	dw wObjectStruct6
+	dw wObjectStruct7
+	dw wObjectStruct8
+	dw wObjectStruct9
+	dw wObjectStruct10
+	dw wObjectStruct11
+	dw wObjectStruct12

--- a/engine/overworld/map_objects_2.asm
+++ b/engine/overworld/map_objects_2.asm
@@ -1,10 +1,10 @@
 LoadObjectMasks:
 	ld hl, wObjectMasks
 	xor a
-	ld bc, NUM_OBJECTS
+	ld bc, NUM_OBJECT_EVENT_STRUCTS
 	call ByteFill
 	nop
-	ld bc, wMapObjects
+	ld bc, wObjectEventStructs
 	ld de, wObjectMasks
 	xor a
 .loop
@@ -19,23 +19,23 @@ LoadObjectMasks:
 	ld [de], a
 	inc de
 	pop bc
-	ld hl, MAPOBJECT_LENGTH
+	ld hl, OBJECT_EVENT_LENGTH
 	add hl, bc
 	ld b, h
 	ld c, l
 	pop af
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop
 	ret
 
 CheckObjectFlag:
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, bc
 	ld a, [hl]
 	and a
 	jr z, .masked
-	ld hl, MAPOBJECT_EVENT_FLAG
+	ld hl, OBJECT_EVENT_EVENT_FLAG
 	add hl, bc
 	ld a, [hli]
 	ld e, a

--- a/engine/overworld/overworld.asm
+++ b/engine/overworld/overworld.asm
@@ -86,7 +86,7 @@ GetPlayerSprite:
 .finish
 	ld [wUsedSprites + 0], a
 	ld [wPlayerSprite], a
-	ld [wPlayerObjectSprite], a
+	ld [wPlayerObjectEventSprite], a
 	ret
 
 INCLUDE "data/sprites/player_sprites.asm"
@@ -103,17 +103,17 @@ AddMapSprites:
 	ret
 
 AddIndoorSprites:
-	ld hl, wMap1ObjectSprite
+	ld hl, wObjectEvent1Sprite
 	ld a, 1
 .loop
 	push af
 	ld a, [hl]
 	call AddSpriteGFX
-	ld de, MAPOBJECT_LENGTH
+	ld de, OBJECT_EVENT_LENGTH
 	add hl, de
 	pop af
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop
 	ret
 

--- a/engine/overworld/player_object.asm
+++ b/engine/overworld/player_object.asm
@@ -27,7 +27,7 @@ SpawnPlayer:
 	call PlayerSpawn_ConvertCoords
 	ld a, PLAYER_OBJECT
 	call GetMapObject
-	ld hl, MAPOBJECT_PALETTE
+	ld hl, OBJECT_EVENT_PALETTE
 	add hl, bc
 	ln e, PAL_NPC_RED, OBJECTTYPE_SCRIPT
 	ld a, [wPlayerSpriteSetupFlags]
@@ -42,7 +42,7 @@ SpawnPlayer:
 	ld [hl], e
 	ld a, PLAYER_OBJECT
 	ldh [hMapObjectIndex], a
-	ld bc, wMapObjects
+	ld bc, wObjectEventStructs
 	ld a, PLAYER_OBJECT
 	ldh [hObjectStructIndex], a
 	ld de, wObjectStructs
@@ -62,10 +62,10 @@ CopyDECoordsToMapObject::
 	ld a, b
 	call GetMapObject
 	pop de
-	ld hl, MAPOBJECT_X_COORD
+	ld hl, OBJECT_EVENT_X_COORD
 	add hl, bc
 	ld [hl], d
-	ld hl, MAPOBJECT_Y_COORD
+	ld hl, OBJECT_EVENT_Y_COORD
 	add hl, bc
 	ld [hl], e
 	ret
@@ -106,7 +106,7 @@ RefreshPlayerCoords:
 	ld hl, wPlayerMapX
 	sub [hl]
 	ld [hl], d
-	ld hl, wMapObjects + MAPOBJECT_X_COORD
+	ld hl, wObjectEventStructs + OBJECT_EVENT_X_COORD
 	ld [hl], d
 	ld hl, wPlayerLastMapX
 	ld [hl], d
@@ -117,7 +117,7 @@ RefreshPlayerCoords:
 	ld hl, wPlayerMapY
 	sub [hl]
 	ld [hl], e
-	ld hl, wMapObjects + MAPOBJECT_Y_COORD
+	ld hl, wObjectEventStructs + OBJECT_EVENT_Y_COORD
 	ld [hl], e
 	ld hl, wPlayerLastMapY
 	ld [hl], e
@@ -169,14 +169,14 @@ CopyMapObjectToObjectStruct:
 
 .CopyMapObjectToTempObject:
 	ldh a, [hObjectStructIndex]
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld [hl], a
 
 	ldh a, [hMapObjectIndex]
 	ld [wTempObjectCopyMapObjectIndex], a
 
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopySprite], a
@@ -188,54 +188,54 @@ CopyMapObjectToObjectStruct:
 	call GetSpritePalette
 	ld [wTempObjectCopyPalette], a
 
-	ld hl, MAPOBJECT_PALETTE
+	ld hl, OBJECT_EVENT_PALETTE
 	add hl, bc
 	ld a, [hl]
-	and MAPOBJECT_PALETTE_MASK
+	and OBJECT_EVENT_PALETTE_MASK
 	jr z, .skip_color_override
 	swap a
 	and PALETTE_MASK
 	ld [wTempObjectCopyPalette], a
 
 .skip_color_override
-	ld hl, MAPOBJECT_MOVEMENT
+	ld hl, OBJECT_EVENT_MOVEMENT
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopyMovement], a
 
-	ld hl, MAPOBJECT_SIGHT_RANGE
+	ld hl, OBJECT_EVENT_SIGHT_RANGE
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopyRange], a
 
-	ld hl, MAPOBJECT_X_COORD
+	ld hl, OBJECT_EVENT_X_COORD
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopyX], a
 
-	ld hl, MAPOBJECT_Y_COORD
+	ld hl, OBJECT_EVENT_Y_COORD
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopyY], a
 
-	ld hl, MAPOBJECT_RADIUS
+	ld hl, OBJECT_EVENT_RADIUS
 	add hl, bc
 	ld a, [hl]
 	ld [wTempObjectCopyRadius], a
 	ret
 
 InitializeVisibleSprites:
-	ld bc, wMap1Object
+	ld bc, wObjectEventStruct1
 	ld a, 1
 .loop
 	ldh [hMapObjectIndex], a
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, bc
 	ld a, [hl]
 	and a
 	jr z, .next
 
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
@@ -246,24 +246,24 @@ InitializeVisibleSprites:
 	ld a, [wYCoord]
 	ld e, a
 
-	ld hl, MAPOBJECT_X_COORD
+	ld hl, OBJECT_EVENT_X_COORD
 	add hl, bc
 	ld a, [hl]
 	add 1
 	sub d
 	jr c, .next
 
-	cp MAPOBJECT_SCREEN_WIDTH
+	cp OBJECT_EVENT_SCREEN_WIDTH
 	jr nc, .next
 
-	ld hl, MAPOBJECT_Y_COORD
+	ld hl, OBJECT_EVENT_Y_COORD
 	add hl, bc
 	ld a, [hl]
 	add 1
 	sub e
 	jr c, .next
 
-	cp MAPOBJECT_SCREEN_HEIGHT
+	cp OBJECT_EVENT_SCREEN_HEIGHT
 	jr nc, .next
 
 	push bc
@@ -272,13 +272,13 @@ InitializeVisibleSprites:
 	jp c, .ret
 
 .next
-	ld hl, MAPOBJECT_LENGTH
+	ld hl, OBJECT_EVENT_LENGTH
 	add hl, bc
 	ld b, h
 	ld c, l
 	ldh a, [hMapObjectIndex]
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop
 	ret
 
@@ -312,32 +312,32 @@ CheckObjectEnteringVisibleRange::
 	ld d, a
 	ld a, [wXCoord]
 	ld e, a
-	ld bc, wMap1Object
+	ld bc, wObjectEventStruct1
 	ld a, 1
 .loop_v
 	ldh [hMapObjectIndex], a
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, bc
 	ld a, [hl]
 	and a
 	jr z, .next_v
-	ld hl, MAPOBJECT_Y_COORD
+	ld hl, OBJECT_EVENT_Y_COORD
 	add hl, bc
 	ld a, d
 	cp [hl]
 	jr nz, .next_v
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jr nz, .next_v
-	ld hl, MAPOBJECT_X_COORD
+	ld hl, OBJECT_EVENT_X_COORD
 	add hl, bc
 	ld a, [hl]
 	add 1
 	sub e
 	jr c, .next_v
-	cp MAPOBJECT_SCREEN_WIDTH
+	cp OBJECT_EVENT_SCREEN_WIDTH
 	jr nc, .next_v
 	push de
 	push bc
@@ -346,13 +346,13 @@ CheckObjectEnteringVisibleRange::
 	pop de
 
 .next_v
-	ld hl, MAPOBJECT_LENGTH
+	ld hl, OBJECT_EVENT_LENGTH
 	add hl, bc
 	ld b, h
 	ld c, l
 	ldh a, [hMapObjectIndex]
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop_v
 	ret
 
@@ -368,32 +368,32 @@ CheckObjectEnteringVisibleRange::
 	ld e, a
 	ld a, [wYCoord]
 	ld d, a
-	ld bc, wMap1Object
+	ld bc, wObjectEventStruct1
 	ld a, 1
 .loop_h
 	ldh [hMapObjectIndex], a
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, bc
 	ld a, [hl]
 	and a
 	jr z, .next_h
-	ld hl, MAPOBJECT_X_COORD
+	ld hl, OBJECT_EVENT_X_COORD
 	add hl, bc
 	ld a, e
 	cp [hl]
 	jr nz, .next_h
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jr nz, .next_h
-	ld hl, MAPOBJECT_Y_COORD
+	ld hl, OBJECT_EVENT_Y_COORD
 	add hl, bc
 	ld a, [hl]
 	add 1
 	sub d
 	jr c, .next_h
-	cp MAPOBJECT_SCREEN_HEIGHT
+	cp OBJECT_EVENT_SCREEN_HEIGHT
 	jr nc, .next_h
 	push de
 	push bc
@@ -402,19 +402,19 @@ CheckObjectEnteringVisibleRange::
 	pop de
 
 .next_h
-	ld hl, MAPOBJECT_LENGTH
+	ld hl, OBJECT_EVENT_LENGTH
 	add hl, bc
 	ld b, h
 	ld c, l
 	ldh a, [hMapObjectIndex]
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop_h
 	ret
 
 CopyTempObjectToObjectStruct:
 	ld a, [wTempObjectCopyMapObjectIndex]
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, de
 	ld [hl], a
 
@@ -540,7 +540,7 @@ TrainerWalkToPlayer:
 ; get player object struct, load to de
 	ld a, c
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	call GetObjectStruct
@@ -551,7 +551,7 @@ TrainerWalkToPlayer:
 	pop bc
 	ld a, b
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	call GetObjectStruct
@@ -695,7 +695,7 @@ GetRelativeFacing::
 ; Determines which way map object e would have to turn to face map object d.  Returns carry if it's impossible for whatever reason.
 	ld a, d
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp NUM_OBJECT_STRUCTS
@@ -703,7 +703,7 @@ GetRelativeFacing::
 	ld d, a
 	ld a, e
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp NUM_OBJECT_STRUCTS

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -987,7 +987,7 @@ Script_disappear:
 ApplyEventActionAppearDisappear:
 	push bc
 	call GetMapObject
-	ld hl, MAPOBJECT_EVENT_FLAG
+	ld hl, OBJECT_EVENT_EVENT_FLAG
 	add hl, bc
 	pop bc
 	ld e, [hl]

--- a/home/map.asm
+++ b/home/map.asm
@@ -569,7 +569,7 @@ ReadObjectEvents::
 	push hl
 	call ClearObjectStructs
 	pop de
-	ld hl, wMap1Object
+	ld hl, wObjectEventStruct1
 	ld a, [de]
 	inc de
 	ld [wCurMapObjectEventCount], a
@@ -581,18 +581,18 @@ ReadObjectEvents::
 	ld a, [wCurMapObjectEventCount]
 	call CopyMapObjectEvents
 
-; get NUM_OBJECTS - [wCurMapObjectEventCount]
+; get NUM_OBJECT_EVENT_STRUCTS - [wCurMapObjectEventCount]
 ; BUG: ReadObjectEvents overflows into wObjectMasks (see docs/bugs_and_glitches.md)
 	ld a, [wCurMapObjectEventCount]
 	ld c, a
-	ld a, NUM_OBJECTS
+	ld a, NUM_OBJECT_EVENT_STRUCTS
 	sub c
 	jr z, .skip
 
 	; could have done "inc hl" instead
 	ld bc, 1
 	add hl, bc
-	ld bc, MAPOBJECT_LENGTH
+	ld bc, OBJECT_EVENT_LENGTH
 .loop
 	ld [hl],  0
 	inc hl
@@ -626,7 +626,7 @@ CopyMapObjectEvents::
 	jr nz, .loop2
 
 	pop hl
-	ld bc, MAPOBJECT_LENGTH
+	ld bc, OBJECT_EVENT_LENGTH
 	add hl, bc
 	pop bc
 	dec c
@@ -634,13 +634,13 @@ CopyMapObjectEvents::
 	ret
 
 ClearObjectStructs::
-	ld hl, wObject1Struct
+	ld hl, wObjectStruct1
 	ld bc, OBJECT_LENGTH * (NUM_OBJECT_STRUCTS - 1)
 	xor a
 	call ByteFill
 
 ; Just to make sure (this is rather pointless)
-	ld hl, wObject1Struct
+	ld hl, wObjectStruct1
 	ld de, OBJECT_LENGTH
 	ld c, NUM_OBJECT_STRUCTS - 1
 	xor a

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -201,8 +201,8 @@ CheckStandingOnEntrance::
 
 GetMapObject::
 ; Return the location of map object a in bc.
-	ld hl, wMapObjects
-	ld bc, MAPOBJECT_LENGTH
+	ld hl, wObjectEventStructs
+	ld bc, OBJECT_EVENT_LENGTH
 	call AddNTimes
 	ld b, h
 	ld c, l
@@ -212,7 +212,7 @@ CheckObjectVisibility::
 ; Sets carry if the object is not visible on the screen.
 	ldh [hMapObjectIndex], a
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
@@ -227,12 +227,12 @@ CheckObjectVisibility::
 	ret
 
 CheckObjectTime::
-	ld hl, MAPOBJECT_HOUR_1
+	ld hl, OBJECT_EVENT_HOUR_1
 	add hl, bc
 	ld a, [hl]
 	cp -1
 	jr nz, .check_hour
-	ld hl, MAPOBJECT_TIMEOFDAY
+	ld hl, OBJECT_EVENT_TIMEOFDAY
 	add hl, bc
 	ld a, [hl]
 	cp -1
@@ -246,7 +246,7 @@ CheckObjectTime::
 
 .ok
 	ld a, [hl]
-	ld hl, MAPOBJECT_TIMEOFDAY
+	ld hl, OBJECT_EVENT_TIMEOFDAY
 	add hl, bc
 	and [hl]
 	jr nz, .timeofday_always
@@ -264,10 +264,10 @@ CheckObjectTime::
 	db NITE
 
 .check_hour
-	ld hl, MAPOBJECT_HOUR_1
+	ld hl, OBJECT_EVENT_HOUR_1
 	add hl, bc
 	ld d, [hl]
-	ld hl, MAPOBJECT_HOUR_2
+	ld hl, OBJECT_EVENT_HOUR_2
 	add hl, bc
 	ld e, [hl]
 	ld hl, hHours
@@ -317,7 +317,7 @@ UnmaskCopyMapObjectStruct::
 ApplyDeletionToMapObject::
 	ldh [hMapObjectIndex], a
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	cp -1
@@ -358,19 +358,19 @@ CopyPlayerObjectTemplate::
 	ld [de], a
 	inc de
 	pop hl
-	ld bc, MAPOBJECT_LENGTH - 1
+	ld bc, OBJECT_EVENT_LENGTH - 1
 	call CopyBytes
 	ret
 
 DeleteFollowerMapObject: ; unreferenced
 	call GetMapObject
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, bc
 	ld a, [hl]
 	push af
 	ld [hl], -1
 	inc hl
-	ld bc, MAPOBJECT_LENGTH - 1
+	ld bc, OBJECT_EVENT_LENGTH - 1
 	xor a
 	call ByteFill
 	pop af

--- a/home/stone_queue.asm
+++ b/home/stone_queue.asm
@@ -11,7 +11,7 @@ HandleStoneQueue::
 	ret
 
 .WarpAction:
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, de
 	ld a, [hl]
 	cp $ff

--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -15,7 +15,7 @@ _CheckTrainerBattle::
 
 ; Skip the player object.
 	ld a, 1
-	ld de, wMap1Object
+	ld de, wObjectEventStruct1
 
 .loop
 
@@ -24,22 +24,22 @@ _CheckTrainerBattle::
 	push de
 
 ; Has a sprite
-	ld hl, MAPOBJECT_SPRITE
+	ld hl, OBJECT_EVENT_SPRITE
 	add hl, de
 	ld a, [hl]
 	and a
 	jr z, .next
 
 ; Is a trainer
-	ld hl, MAPOBJECT_TYPE
+	ld hl, OBJECT_EVENT_TYPE
 	add hl, de
 	ld a, [hl]
-	and MAPOBJECT_TYPE_MASK
+	and OBJECT_EVENT_TYPE_MASK
 	cp OBJECTTYPE_TRAINER
 	jr nz, .next
 
 ; Is visible on the map
-	ld hl, MAPOBJECT_OBJECT_STRUCT_ID
+	ld hl, OBJECT_EVENT_OBJECT_STRUCT_ID
 	add hl, de
 	ld a, [hl]
 	cp -1
@@ -51,7 +51,7 @@ _CheckTrainerBattle::
 	jr nc, .next
 
 ; ...within their sight range
-	ld hl, MAPOBJECT_SIGHT_RANGE
+	ld hl, OBJECT_EVENT_SIGHT_RANGE
 	add hl, de
 	ld a, [hl]
 	cp b
@@ -60,7 +60,7 @@ _CheckTrainerBattle::
 ; And hasn't already been beaten
 	push bc
 	push de
-	ld hl, MAPOBJECT_SCRIPT_POINTER
+	ld hl, OBJECT_EVENT_SCRIPT_POINTER
 	add hl, de
 	ld a, [hli]
 	ld h, [hl]
@@ -78,14 +78,14 @@ _CheckTrainerBattle::
 
 .next
 	pop de
-	ld hl, MAPOBJECT_LENGTH
+	ld hl, OBJECT_EVENT_LENGTH
 	add hl, de
 	ld d, h
 	ld e, l
 
 	pop af
 	inc a
-	cp NUM_OBJECTS
+	cp NUM_OBJECT_EVENT_STRUCTS
 	jr nz, .loop
 	xor a
 	ret
@@ -113,7 +113,7 @@ LoadTrainer_continue::
 	ldh a, [hLastTalked]
 	call GetMapObject
 
-	ld hl, MAPOBJECT_SCRIPT_POINTER
+	ld hl, OBJECT_EVENT_SCRIPT_POINTER
 	add hl, bc
 	ld a, [wSeenTrainerBank]
 	call GetFarWord
@@ -205,11 +205,11 @@ FacingPlayerDistance::
 
 CheckTrainerFlag:: ; unreferenced
 	push bc
-	ld hl, OBJECT_MAP_OBJECT_INDEX
+	ld hl, OBJECT_OBJECT_EVENT_INDEX
 	add hl, bc
 	ld a, [hl]
 	call GetMapObject
-	ld hl, MAPOBJECT_SCRIPT_POINTER
+	ld hl, OBJECT_EVENT_SCRIPT_POINTER
 	add hl, bc
 	ld a, [hli]
 	ld h, [hl]

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -329,21 +329,21 @@ MACRO object_struct
 \1StructEnd::
 ENDM
 
-MACRO map_object
-\1ObjectStructID::   db
-\1ObjectSprite::     db
-\1ObjectYCoord::     db
-\1ObjectXCoord::     db
-\1ObjectMovement::   db
-\1ObjectRadius::     db
-\1ObjectHour1::      db
-\1ObjectHour2::
-\1ObjectTimeOfDay::  db
-\1ObjectPalette::
-\1ObjectType::       db
-\1ObjectSightRange:: db
-\1ObjectScript::     dw
-\1ObjectEventFlag::  dw
+MACRO object_event_struct
+\1ID::   db
+\1Sprite::     db
+\1YCoord::     db
+\1XCoord::     db
+\1Movement::   db
+\1Radius::     db
+\1Hour1::      db
+\1Hour2::
+\1TimeOfDay::  db
+\1Palette::
+\1Type::       db
+\1SightRange:: db
+\1Script::     dw
+\1EventFlag::  dw
 	ds 2
 ENDM
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2931,24 +2931,24 @@ wFollowerMovementQueueLength:: db
 wFollowMovementQueue:: ds 5
 
 wObjectStructs::
-wPlayerStruct:: object_struct wPlayer ; player is object struct 0
+wPlayerObjectStruct:: object_struct wPlayer ; player is object struct 0
 ; wObjectStruct1 - wObjectStruct12
 for n, 1, NUM_OBJECT_STRUCTS
-wObject{d:n}Struct:: object_struct wObject{d:n}
+wObjectStruct{d:n}:: object_struct wObject{d:n}
 endr
 
 wCmdQueue:: ds CMDQUEUE_CAPACITY * CMDQUEUE_ENTRY_SIZE
 
 	ds 40
 
-wMapObjects::
-wPlayerObject:: map_object wPlayer ; player is map object 0
-; wMap1Object - wMap15Object
-for n, 1, NUM_OBJECTS
-wMap{d:n}Object:: map_object wMap{d:n}
+wObjectEventStructs::
+wPlayerObjectEventStruct:: object_event_struct wPlayerObjectEvent ; player is object event 0
+; wObjectEventStruct1 - wObjectEventStruct15
+for n, 1, NUM_OBJECT_EVENT_STRUCTS
+wObjectEventStruct{d:n}:: object_event_struct wObjectEvent{d:n}
 endr
 
-wObjectMasks:: ds NUM_OBJECTS
+wObjectMasks:: ds NUM_OBJECT_EVENT_STRUCTS
 
 wVariableSprites:: ds $100 - SPRITE_VARS
 


### PR DESCRIPTION
Resolves: #1032 #655 

This is what I ended up going with:  
  
| Original Labels | Recommended Labels |  
|------| --------|  
|\`object\_struct\` | (current name is fine) |  
|\`wObjectStructs\` | (current name is fine) |  
|\`wPlayerStruct\` / \`wPlayerSprite\` | `wPlayerObjectS`truct/\`wPlayerSprite\` |  
|\`wObject#Struct\` / \`wObject#Sprite\` | `wObjectS`truct#/\`wObject#Sprite\` |  
|\`NUM\_OBJECT\_STRUCTS\` | (current name is fine) |  
|\`OBJECT\_LENGTH\` | (current name is fine) |

| Original Labels | Recommended Labels |  
|------| --------|  
|\`map\_object\` | \`object\_event\_struct\` |  
| \`wMapObjects\` | `wO`bjectEventStructs |  
| \`wPlayerObject\`/\`wPlayerObjectSprite\` | `wPlayerObjectEventS`truct/\`wPlayerObjectEventSprite\` |  
| \`wMap#Object\`/\`wMap#ObjectSprite\` | \`wObjectEventStruct#\` / \`wObjectEvent#Sprite\` |

|\`NUM\_OBJECTS\` | `NUM_OBJECT_EVENT_STRUCTS` |  
| \`MAPOBJECT\_LENGTH\` | \`OBJECT\_EVENT\_LENGTH\` |  
| `MAPOBJECT_*` | `OBJECT_EVENT_*` |  
  
Anywho; this is just to keep the conversation going; I don't mind reworking this if we decide to do something different.