### PR TITLE
CI copy `.map` files to symbols branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,11 +66,12 @@ jobs:
         if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         run: |
           cp -v *.sym symbols/
+          cp -v *.map symbols/
 
       - name: Update symbols
         if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         uses: EndBug/add-and-commit@v9
         with:
           cwd: "./symbols"
-          add: "*.sym"
+          add: "*.sym *.map"
           message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
~~Omit symbols from `*.map` files; They are really so much easier to read after this is done.~~

I also thought it would be nice to have the `.map` files on the `symbols` branch as well. If you disagree, then I can easily remove that commit.  