### PR TITLE
Correct constant for default Mystery Gift decoration

### DIFF
--- a/engine/link/mystery_gift_2.asm
+++ b/engine/link/mystery_gift_2.asm
@@ -142,7 +142,7 @@ MysteryGiftGetDecoration:
 	ret
 
 MysteryGiftFallbackItem:
-	ld c, DECO_POLKADOT_BED ; GREAT_BALL
+	ld c, DECOFLAG_RED_CARPET ; GREAT_BALL
 	ret
 
 INCLUDE "data/items/mystery_gift_items.asm"


### PR DESCRIPTION
As mentioned in #1082, the previous Mystery Gift macros referred to incorrect decorations.

While most of these were fixed in [pokegold#108](https://github.com/pret/pokegold/pull/108) (which has already been merged into pokecrystal), it did not include a fix for the default Mystery Gift decoration. As [documented by bayleaf on the Project Pokémon forums](https://projectpokemon.org/home/forums/topic/43930-mystery-gift-reverse-engineering-of-ir-protocol/), the default decoration should be a Red Carpet (not a Polkadot Bed).

Just like the other fixes in pokegold#108, this fix is as simple as replacing the old DECO macro with a DECOFLAG macro.