### PR TITLE
`make` defaults to quiet output

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,6 +3,8 @@
 CC := gcc
 CFLAGS := -O3 -flto -std=c11 -Wall -Wextra -pedantic
 
+Q := @
+
 tools := \
 	bpp2png \
 	lzcomp \
@@ -18,7 +20,7 @@ all: $(tools)
 	@:
 
 clean:
-	$(RM) $(tools)
+	$(Q)$(RM) $(tools)
 
 gfx: common.h
 png_dimensions: common.h
@@ -28,11 +30,11 @@ scan_includes: common.h
 stadium: common.h
 
 bpp2png: bpp2png.c lodepng/lodepng.c common.h lodepng/lodepng.h
-	$(CC) $(CFLAGS) -o $@ bpp2png.c lodepng/lodepng.c
+	$(Q)$(CC) $(CFLAGS) -o $@ bpp2png.c lodepng/lodepng.c
 
 lzcomp: CFLAGS += -Wno-strict-overflow -Wno-sign-compare
 lzcomp: $(wildcard lz/*.c) $(wildcard lz/*.h)
-	$(CC) $(CFLAGS) -o $@ lz/*.c
+	$(Q)$(CC) $(CFLAGS) -o $@ lz/*.c
 
 %: %.c
-	$(CC) $(CFLAGS) -o $@ $<
+	$(Q)$(CC) $(CFLAGS) -o $@ $<


### PR DESCRIPTION
This may help beginners who don't notice success/error messages among all the `make` noise. Experienced users can run `make Q=`, or modify their Makefile to do so by default.

```
$ make clean
Deleting build products...
Deleting intermediate build products...

$ make compare -j
Building tools...
Checking RGBDS version...
Finding VC patch values...
Building ROM pokecrystal_debug.gbc...
Building ROM pokecrystal11_debug.gbc...
Building ROM pokecrystal.gbc...
Building ROM pokecrystal11.gbc...
Building ROM pokecrystal11_vc.gbc...
Building ROM pokecrystal_au.gbc...
Building VC patch pokecrystal11.patch...
Comparing output ROMs with originals...
pokecrystal.gbc: OK
pokecrystal11.gbc: OK
pokecrystal_au.gbc: OK
pokecrystal_debug.gbc: OK
pokecrystal11_debug.gbc: OK
pokecrystal11.patch: OK

$ make -j
Building tools...
make: Nothing to be done for 'all'.
```

The downside is that seeing all those individual commands is a definite indicator that progress is happening; but I think just waiting quietly is also okay, since the process isn't going to infinitely loop/hang, there'd be a visible error message. (Also, even currently, there's a rather long wait period before any messages show up, I think because `scan_includes` is running.)

I'm not committed to this change, just wanted feedback on a concrete implementation. Like if those explicit `echo`ed messages should be edited or have more/fewer of them.