### PR TITLE
Update to RGBDS 0.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: rgbds
-          ref: v0.6.1
+          ref: v0.7.0
           repository: gbdev/rgbds
 
       - name: Install rgbds

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,15 +41,15 @@ You need to install `gcc`. If you're using Cygwin, re-run its setup, and at "Sel
 
 ### "ERROR: `UNION` already defined"
 
-Download [**rgbds 0.6.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.7.0**][rgbds] or newer. Older versions will not work.
 
 ### "ERROR: Macro not defined"
 
-Download [**rgbds 0.6.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.7.0**][rgbds] or newer. Older versions will not work.
 
 ### "Expression must be 8-bit"
 
-Download [**rgbds 0.6.0**][rgbds] or newer. Older versions will not work.
+Download [**rgbds 0.7.0**][rgbds] or newer. Older versions will not work.
 
 ### "Segmentation fault" from `rgbgfx`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,9 +42,9 @@ Run setup and leave the default settings. At the "**Select Packages**" step, cho
 
 Double click on the text that says "**Skip**" next to each package to select the most recent version to install.
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for Windows with Cygwin to install **rgbds 0.6.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for Windows with Cygwin to install **rgbds 0.7.0**.
 
-**Note:** If you already have an installed rgbds older than 0.6.0, you will need to update to 0.6.0 or 0.6.1. Ignore this if you have never installed rgbds before. If a version newer than 0.6.1 does not work, try downloading 0.6.1.
+**Note:** If you already have an installed rgbds older than 0.7.0, you will need to update to 0.7.0. Ignore this if you have never installed rgbds before. If a version newer than 0.7.0 does not work, try downloading 0.7.0.
 
 Now open the **Cygwin terminal** and enter the following commands.
 
@@ -67,7 +67,7 @@ Install [**Homebrew**](https://brew.sh/). Follow the official instructions.
 
 Open **Terminal** and prepare to enter commands.
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for macOS to install **rgbds 0.6.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for macOS to install **rgbds 0.7.0**.
 
 Now you're ready to [build **pokecrystal**](#build-pokecrystal).
 
@@ -84,7 +84,7 @@ To install the software required for **pokecrystal**:
 sudo apt-get install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### OpenSUSE
 
@@ -94,7 +94,7 @@ To install the software required for **pokecrystal**:
 sudo zypper install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Arch Linux
 
@@ -104,7 +104,7 @@ To install the software required for **pokecrystal**:
 sudo pacman -S make gcc git rgbds
 ```
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Termux
 
@@ -120,7 +120,7 @@ To install **rgbds**:
 sudo apt install rgbds
 ```
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Other distros
 
@@ -131,7 +131,7 @@ If your distro is not listed here, try to find the required software in its repo
 - `git`
 - `rgbds`
 
-If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 Now you're ready to [build **pokecrystal**](#build-pokecrystal).
 
@@ -159,12 +159,12 @@ make crystal11
 
 ### Build with a local rgbds version
 
-If you have different projects that require different versions of `rgbds`, it might not be convenient to install rgbds 0.6.1 globally. Instead, you can put its files in a directory within pokecrystal, such as `pokecrystal/rgbds-0.6.1/`. Then specify it when you run `make`:
+If you have different projects that require different versions of `rgbds`, it might not be convenient to install rgbds 0.7.0 globally. Instead, you can put its files in a directory within pokecrystal, such as `pokecrystal/rgbds-0.7.0/`. Then specify it when you run `make`:
 
 ```bash
-make RGBDS=rgbds-0.6.1/
+make RGBDS=rgbds-0.7.0/
 ```
 
 ```bash
-make RGBDS=rgbds-0.6.1/ crystal11
+make RGBDS=rgbds-0.7.0/ crystal11
 ```

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ tools:
 	$(MAKE) -C tools/
 
 
-RGBASMFLAGS = -hL -Q8 -P includes.asm -Weverything -Wnumeric-string=2 -Wtruncation=1
+RGBASMFLAGS = -Q8 -P includes.asm -Weverything -Wnumeric-string=2 -Wtruncation=1
 # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
 ifeq ($(DEBUG),1)
 RGBASMFLAGS += -E

--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -3,19 +3,6 @@
 ; https://github.com/gbdev/hardware.inc
 ; http://gameboy.mongenel.com/dmg/asmmemmap.html
 
-; memory map
-DEF VRAM_Begin  EQU $8000
-DEF VRAM_End    EQU $a000
-DEF SRAM_Begin  EQU $a000
-DEF SRAM_End    EQU $c000
-DEF WRAM0_Begin EQU $c000
-DEF WRAM0_End   EQU $d000
-DEF WRAM1_Begin EQU $d000
-DEF WRAM1_End   EQU $e000
-; hardware registers $ff00-$ff80 (see below)
-DEF HRAM_Begin  EQU $ff80
-DEF HRAM_End    EQU $ffff
-
 ; MBC3
 DEF MBC3SRamEnable EQU $0000
 DEF MBC3RomBank    EQU $2000

--- a/data/maps/blocks.asm
+++ b/data/maps/blocks.asm
@@ -1045,3 +1045,5 @@ BetaBlank_Blocks: ; unreferenced
 
 GoldenrodDeptStoreRoof_Blocks:
 	INCBIN "maps/GoldenrodDeptStoreRoof.blk"
+
+ENDSECTION

--- a/data/maps/scripts.asm
+++ b/data/maps/scripts.asm
@@ -484,3 +484,5 @@ SECTION "Map Scripts 25", ROMX
 
 INCLUDE "maps/SilverCaveOutside.asm"
 INCLUDE "maps/Route10North.asm"
+
+ENDSECTION

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2679,8 +2679,8 @@ If `IsInArray` returns `nc`, data at `bc` will be executed as code.
  	push af
  	ldh [rSVBK], a
  	xor a
- 	ld hl, WRAM1_Begin
- 	ld bc, WRAM1_End - WRAM1_Begin
+ 	ld hl, STARTOF(WRAMX)
+ 	ld bc, SIZEOF(WRAMX)
  	call ByteFill
  	pop af
  	inc a

--- a/engine/debug/color_picker.asm
+++ b/engine/debug/color_picker.asm
@@ -129,15 +129,15 @@ endr
 DebugColor_InitVRAM:
 	ld a, $1
 	ldh [rVBK], a
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 
 	ld a, $0
 	ldh [rVBK], a
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -979,8 +979,8 @@ PushSGBBorder:
 	ret
 
 SGB_ClearVRAM:
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 	ret

--- a/engine/gfx/load_push_oam.asm
+++ b/engine/gfx/load_push_oam.asm
@@ -1,6 +1,6 @@
 WriteOAMDMACodeToHRAM::
 	ld c, LOW(hTransferShadowOAM)
-	ld b, OAMDMACodeEnd - OAMDMACode
+	ld b, OAMDMACode.End - OAMDMACode
 	ld hl, OAMDMACode
 .copy
 	ld a, [hli]
@@ -25,4 +25,4 @@ hTransferShadowOAM::
 	jr nz, .wait
 	ret
 ENDL
-OAMDMACodeEnd:
+.End:

--- a/engine/menus/empty_sram.asm
+++ b/engine/menus/empty_sram.asm
@@ -7,8 +7,8 @@ endr
 
 .EmptyBank:
 	call OpenSRAM
-	ld hl, SRAM_Begin
-	ld bc, SRAM_End - SRAM_Begin
+	ld hl, STARTOF(SRAM)
+	ld bc, SIZEOF(SRAM)
 	xor a
 	call ByteFill
 	call CloseSRAM

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -105,8 +105,8 @@ _ResetWRAM:
 	xor a
 	call ByteFill
 
-	ld hl, WRAM1_Begin
-	ld bc, wGameData - WRAM1_Begin
+	ld hl, STARTOF(WRAMX)
+	ld bc, wGameData - STARTOF(WRAMX)
 	xor a
 	call ByteFill
 

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -167,8 +167,8 @@ RunTradeAnimScript:
 	jr z, .NotCGB
 	ld a, $1
 	ldh [rVBK], a
-	ld hl, vTiles0
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 	ld a, $0
@@ -176,7 +176,7 @@ RunTradeAnimScript:
 
 .NotCGB:
 	hlbgcoord 0, 0
-	ld bc, VRAM_End - vBGMap0
+	ld bc, STARTOF(VRAM) + SIZEOF(VRAM) - vBGMap0
 	ld a, " "
 	call ByteFill
 	ld hl, TradeGameBoyLZ
@@ -470,7 +470,7 @@ TradeAnim_TubeToPlayer8:
 	call DisableLCD
 	callfar ClearSpriteAnims
 	hlbgcoord 0, 0
-	ld bc, VRAM_End - vBGMap0
+	ld bc, STARTOF(VRAM) + SIZEOF(VRAM) - vBGMap0
 	ld a, " "
 	call ByteFill
 	xor a

--- a/engine/overworld/init_map.asm
+++ b/engine/overworld/init_map.asm
@@ -91,9 +91,9 @@ HDMATransfer_FillBGMap0WithBlack:
 	ldh [rHDMA1], a
 	ld a, LOW(wDecompressScratch)
 	ldh [rHDMA2], a
-	ld a, HIGH(vBGMap0 - VRAM_Begin)
+	ld a, HIGH(vBGMap0 - STARTOF(VRAM))
 	ldh [rHDMA3], a
-	ld a, LOW(vBGMap0 - VRAM_Begin)
+	ld a, LOW(vBGMap0 - STARTOF(VRAM))
 	ldh [rHDMA4], a
 	ld a, $3f
 	ldh [hDMATransfer], a

--- a/home/header.asm
+++ b/home/header.asm
@@ -68,3 +68,5 @@ Start::
 ; This makes sure it doesn't get used for anything else.
 
 	ds $0150 - @, $00
+
+ENDSECTION

--- a/home/init.asm
+++ b/home/init.asm
@@ -64,8 +64,8 @@ Init::
 	ldh [rLCDC], a
 
 ; Clear WRAM bank 0
-	ld hl, WRAM0_Begin
-	ld bc, WRAM0_End - WRAM0_Begin
+	ld hl, STARTOF(WRAM0)
+	ld bc, SIZEOF(WRAM0)
 .ByteFill:
 	ld [hl], 0
 	inc hl
@@ -82,8 +82,8 @@ Init::
 	ldh a, [hSystemBooted]
 	push af
 	xor a
-	ld hl, HRAM_Begin
-	ld bc, HRAM_End - HRAM_Begin
+	ld hl, STARTOF(HRAM)
+	ld bc, SIZEOF(HRAM)
 	call ByteFill
 	pop af
 	ldh [hSystemBooted], a
@@ -177,8 +177,8 @@ ClearVRAM::
 	xor a ; 0
 	ldh [rVBK], a
 .clear
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 	ret
@@ -193,8 +193,8 @@ ClearWRAM::
 	push af
 	ldh [rSVBK], a
 	xor a
-	ld hl, WRAM1_Begin
-	ld bc, WRAM1_End - WRAM1_Begin
+	ld hl, STARTOF(WRAMX)
+	ld bc, SIZEOF(WRAMX)
 	call ByteFill
 	pop af
 	inc a

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -293,8 +293,8 @@ ClearVBank1::
 	ld a, 1
 	ldh [rVBK], a
 
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	call ByteFill
 

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -2400,7 +2400,7 @@ MACRO macro_100fc0
 	;     Bit 7 set: Not SRAM
 	;     Lower 7 bits: Bank if SRAM
 	; address, size[, OT address]
-	db ($80 * (\1 >= SRAM_End)) | (BANK(\1) * (\1 < SRAM_End))
+	db ($80 * (\1 >= STARTOF(SRAM) + SIZEOF(SRAM))) | (BANK(\1) * (\1 < STARTOF(SRAM) + SIZEOF(SRAM)))
 	dw \1, \2
 	if _NARG == 3
 		dw \3

--- a/ram/hram.asm
+++ b/ram/hram.asm
@@ -176,3 +176,5 @@ endc
 hClockResetTrigger:: db
 
 	ds 19
+
+ENDSECTION

--- a/ram/sram.asm
+++ b/ram/sram.asm
@@ -399,3 +399,5 @@ s7_a001:: db
 	ds $7fe
 
 sMobileAdapterStatus2:: db
+
+ENDSECTION

--- a/ram/vram.asm
+++ b/ram/vram.asm
@@ -14,3 +14,5 @@ vTiles4:: ds $80 tiles
 vTiles5:: ds $80 tiles
 vBGMap2:: ds BG_MAP_WIDTH * BG_MAP_HEIGHT
 vBGMap3:: ds BG_MAP_WIDTH * BG_MAP_HEIGHT
+
+ENDSECTION

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -3650,3 +3650,5 @@ SECTION "Stack RAM", WRAMX
 
 wWindowStack:: ds $1000 - 1
 wWindowStackBottom:: ds 1
+
+ENDSECTION

--- a/rgbdscheck.asm
+++ b/rgbdscheck.asm
@@ -1,16 +1,6 @@
-MAJOR EQU 0
-MINOR EQU 6
-PATCH EQU 0
-
-WRONG_RGBDS EQUS "fail \"pokecrystal requires rgbds v0.6.0 or newer.\""
-
 IF !DEF(__RGBDS_MAJOR__) || !DEF(__RGBDS_MINOR__) || !DEF(__RGBDS_PATCH__)
-	WRONG_RGBDS
-ELSE
-IF (__RGBDS_MAJOR__ < MAJOR) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ < MINOR) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ == MINOR && __RGBDS_PATCH__ < PATCH) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ == MINOR && __RGBDS_PATCH__ == PATCH && DEF(__RGBDS_RC__))
-	WRONG_RGBDS
+	fail "pokecrystal requires rgbds v0.7.0 or newer."
 ENDC
+IF __RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ <  7
+	fail "pokecrystal requires rgbds v0.7.0 or newer."
 ENDC


### PR DESCRIPTION
These new features are used from RGBDS 0.7.0:

- Use `SIZEOF` and `STARTOF` for section types, instead of `*RAM_Begin/End` constants
- Use `ENDSECTION` at the end of `INCLUDE`d files which start their own `SECTION`s
  - These can be found via:  
    ``for f in `git grep -Elw '^SECTION'`; do git grep -ho "INCLUDE \"$f\""; done``
- `OAMDMACodeEnd` can be `.End` since `ENDL` restores scope

Also rgbdscheck.asm is rewritten to be more robust with older versions of RGBDS. (We can't define constants since `DEF` is required in 0.7.0 but not yet defined in old enough versions; likewise for backslash line continuations, `ELIF`, etc.)

Note that the object file revision is still 9, so tools/unnamed.py did not need updating.