### PR TITLE
Document Tackle is missing part of its hit animation

### DIFF
--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -2082,6 +2082,7 @@ BattleAnim_Headbutt:
 	anim_ret
 
 BattleAnim_Tackle:
+; BUG: Tackle is missing part of its hit animation (see docs/bugs_and_glitches.md)
 	anim_1gfx BATTLE_ANIM_GFX_HIT
 	anim_call BattleAnim_TargetObj_2Row
 	anim_bgeffect BATTLE_BG_EFFECT_TACKLE, $0, BG_EFFECT_USER, $0

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -78,6 +78,7 @@ Fixes in the [multi-player battle engine](#multi-player-battle-engine) category 
   - [Using a Park Ball in non-Contest battles has a corrupt animation](#using-a-park-ball-in-non-contest-battles-has-a-corrupt-animation)
   - [Battle transitions fail to account for the enemy's level](#battle-transitions-fail-to-account-for-the-enemys-level)
   - [Some trainer NPCs have inconsistent overworld sprites](#some-trainer-npcs-have-inconsistent-overworld-sprites)
+  - [Tackle is missing part of its hit animation](#tackle-is-missing-part-of-its-hit-animation)
 - [Audio](#audio)
   - [Slot machine payout sound effects cut each other off](#slot-machine-payout-sound-effects-cut-each-other-off)
   - [Team Rocket battle music is not used for Executives or Scientists](#team-rocket-battle-music-is-not-used-for-executives-or-scientists)
@@ -2063,6 +2064,22 @@ Most of the NPCs in [maps/NationalParkBugContest.asm](https://github.com/pret/po
 (Note that [maps/Route8.asm](https://github.com/pret/pokecrystal/blob/master/maps/Route8.asm) has three `BIKER`s, `DWAYNE`, `HARRIS`, and `ZEKE`, that use `PAL_NPC_RED`, `PAL_NPC_GREEN`, and `PAL_NPC_BLUE` instead of `PAL_NPC_BROWN`; this is intentional since they're the "Kanto Pokémon Federation".)
 
 (The use of `SPRITE_ROCKER` instead of `SPRITE_COOLTRAINER_M` for `COOLTRAINERM NICK` may also be an intentional reference to the player's brother from the [Space World '97 beta](https://github.com/pret/pokegold-spaceworld).)
+
+
+### Tackle is missing part of its hit animation
+
+Copying two rows causes `BATTLE_BG_EFFECT_TACKLE` to hit the horizontal sprite limit. This fix restores the animation to copy only one row like in Pokémon Gold and Silver.
+
+**Fix:** Edit `BattleAnim_Tackle` in [data/moves/animations.asm](https://github.com/pret/pokecrystal/blob/master/data/moves/animations.asm):
+
+```diff
+ BattleAnim_Tackle:
+-; BUG: Tackle is missing part of its hit animation (see docs/bugs_and_glitches.md)
+ 	anim_1gfx BATTLE_ANIM_GFX_HIT
+-	anim_call BattleAnim_TargetObj_2Row
++	anim_call BattleAnim_TargetObj_1Row
+ 	anim_bgeffect BATTLE_BG_EFFECT_TACKLE, $0, BG_EFFECT_USER, $0
+```
 
 
 ## Audio


### PR DESCRIPTION
`BattleAnim_Tackle` in Pokémon Crystal reaches the horiztonal sprite limit due to two rows of the enemy's feet being copied from background tiles to sprites. This fix restores the animation to only copy one row like in Pokémon Gold and Silver.