### PR TITLE
Add defintion for OAM y-Coordinate offscreen value

### DIFF
--- a/constants/gfx_constants.asm
+++ b/constants/gfx_constants.asm
@@ -55,3 +55,5 @@ DEF SPRITE_GFX_LIST_CAPACITY EQU 32 ; see wUsedSprites
 	const ANIM_MON_HOF
 	const ANIM_MON_EGG1
 	const ANIM_MON_EGG2
+
+DEF OAM_YCOORD_HIDDEN EQU 160 ; hides an OAM offscreen

--- a/engine/movie/splash.asm
+++ b/engine/movie/splash.asm
@@ -93,7 +93,7 @@ GameFreakPresentsInit:
 	call InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_YOFFSET
 	add hl, bc
-	ld [hl], 160
+	ld [hl], OAM_YCOORD_HIDDEN
 	ld hl, SPRITEANIMSTRUCT_VAR1
 	add hl, bc
 	ld [hl], 96

--- a/engine/overworld/map_objects.asm
+++ b/engine/overworld/map_objects.asm
@@ -2757,7 +2757,7 @@ _UpdateSprites::
 	ld h, HIGH(wShadowOAM)
 	ld de, SPRITEOAMSTRUCT_LENGTH
 	ld a, b
-	ld c, SCREEN_HEIGHT_PX + 2 * TILE_WIDTH
+	ld c, OAM_YCOORD_HIDDEN
 .loop
 	ld [hl], c ; y
 	add hl, de

--- a/engine/pokemon/switchpartymons.asm
+++ b/engine/pokemon/switchpartymons.asm
@@ -31,7 +31,7 @@ _SwitchPartyMons:
 	ld de, SPRITEOAMSTRUCT_LENGTH
 	ld c, 4
 .gfx_loop
-	ld [hl], SCREEN_WIDTH_PX ; y (off-screen)
+	ld [hl], OAM_YCOORD_HIDDEN
 	add hl, de
 	dec c
 	jr nz, .gfx_loop

--- a/home/clear_sprites.asm
+++ b/home/clear_sprites.asm
@@ -14,7 +14,7 @@ HideSprites::
 	ld hl, wShadowOAMSprite00YCoord
 	ld de, SPRITEOAMSTRUCT_LENGTH
 	ld b, NUM_SPRITE_OAM_STRUCTS
-	ld a, SCREEN_WIDTH_PX
+	ld a, OAM_YCOORD_HIDDEN
 .loop
 	ld [hl], a ; y
 	add hl, de


### PR DESCRIPTION
Reference: https://gbdev.io/pandocs/OAM.html#byte-0--y-position

Essentially, a y-coord of 160 is the screen's height (144) plus the height of a 8x16 sprite (2 tiles).