### PR TITLE
Rename `MON_ID` to `MON_OT_ID`

### DIFF
--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -77,7 +77,7 @@ rsreset
 DEF MON_SPECIES            rb
 DEF MON_ITEM               rb
 DEF MON_MOVES              rb NUM_MOVES
-DEF MON_ID                 rw
+DEF MON_TRAINER_ID         rw
 DEF MON_EXP                rb 3
 DEF MON_STAT_EXP           rw NUM_EXP_STATS
 rsset MON_STAT_EXP

--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -77,7 +77,7 @@ rsreset
 DEF MON_SPECIES            rb
 DEF MON_ITEM               rb
 DEF MON_MOVES              rb NUM_MOVES
-DEF MON_TRAINER_ID         rw
+DEF MON_OT_ID              rw
 DEF MON_EXP                rb 3
 DEF MON_STAT_EXP           rw NUM_EXP_STATS
 rsset MON_STAT_EXP

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3864,9 +3864,9 @@ InitBattleMon:
 	ld a, MON_SPECIES
 	call GetPartyParamLocation
 	ld de, wBattleMonSpecies
-	ld bc, MON_ID
+	ld bc, MON_TRAINER_ID
 	call CopyBytes
-	ld bc, MON_DVS - MON_ID
+	ld bc, MON_DVS - MON_TRAINER_ID
 	add hl, bc
 	ld de, wBattleMonDVs
 	ld bc, MON_POKERUS - MON_DVS
@@ -3950,9 +3950,9 @@ InitEnemyMon:
 	ld hl, wOTPartyMon1Species
 	call GetPartyLocation
 	ld de, wEnemyMonSpecies
-	ld bc, MON_ID
+	ld bc, MON_TRAINER_ID
 	call CopyBytes
-	ld bc, MON_DVS - MON_ID
+	ld bc, MON_DVS - MON_TRAINER_ID
 	add hl, bc
 	ld de, wEnemyMonDVs
 	ld bc, MON_POKERUS - MON_DVS
@@ -7074,7 +7074,7 @@ GiveExperiencePoints:
 	call Divide
 ; Boost Experience for traded Pokemon
 	pop bc
-	ld hl, MON_ID
+	ld hl, MON_TRAINER_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	cp [hl]

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3864,9 +3864,9 @@ InitBattleMon:
 	ld a, MON_SPECIES
 	call GetPartyParamLocation
 	ld de, wBattleMonSpecies
-	ld bc, MON_TRAINER_ID
+	ld bc, MON_OT_ID
 	call CopyBytes
-	ld bc, MON_DVS - MON_TRAINER_ID
+	ld bc, MON_DVS - MON_OT_ID
 	add hl, bc
 	ld de, wBattleMonDVs
 	ld bc, MON_POKERUS - MON_DVS
@@ -3950,9 +3950,9 @@ InitEnemyMon:
 	ld hl, wOTPartyMon1Species
 	call GetPartyLocation
 	ld de, wEnemyMonSpecies
-	ld bc, MON_TRAINER_ID
+	ld bc, MON_OT_ID
 	call CopyBytes
-	ld bc, MON_DVS - MON_TRAINER_ID
+	ld bc, MON_DVS - MON_OT_ID
 	add hl, bc
 	ld de, wEnemyMonDVs
 	ld bc, MON_POKERUS - MON_DVS
@@ -7074,7 +7074,7 @@ GiveExperiencePoints:
 	call Divide
 ; Boost Experience for traded Pokemon
 	pop bc
-	ld hl, MON_TRAINER_ID
+	ld hl, MON_OT_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	cp [hl]

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -657,7 +657,7 @@ BattleCommand_CheckObedience:
 
 	; If the Pokémon's Trainer ID doesn't match the player's,
 	; some conditions need to be met.
-	ld a, MON_TRAINER_ID
+	ld a, MON_OT_ID
 	call BattlePartyAttr
 
 	ld a, [wPlayerID]

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -655,9 +655,9 @@ BattleCommand_CheckObedience:
 	and a
 	ret nz
 
-	; If the monster's id doesn't match the player's,
+	; If the Pokémon's Trainer ID doesn't match the player's,
 	; some conditions need to be met.
-	ld a, MON_ID
+	ld a, MON_TRAINER_ID
 	call BattlePartyAttr
 
 	ld a, [wPlayerID]

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -491,7 +491,7 @@ DayCare_GiveEgg:
 	call AddNTimes
 	ld b, h
 	ld c, l
-	ld hl, MON_TRAINER_ID + 1
+	ld hl, MON_OT_ID + 1
 	add hl, bc
 	push hl
 	ld hl, MON_MAXHP

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -491,7 +491,7 @@ DayCare_GiveEgg:
 	call AddNTimes
 	ld b, h
 	ld c, l
-	ld hl, MON_ID + 1
+	ld hl, MON_TRAINER_ID + 1
 	add hl, bc
 	push hl
 	ld hl, MON_MAXHP

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -172,7 +172,7 @@ GetHallOfFameParty:
 	ld [de], a
 	inc de
 
-	ld hl, MON_TRAINER_ID
+	ld hl, MON_OT_ID
 	add hl, bc
 	ld a, [hli]
 	ld [de], a

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -172,7 +172,7 @@ GetHallOfFameParty:
 	ld [de], a
 	inc de
 
-	ld hl, MON_ID
+	ld hl, MON_TRAINER_ID
 	add hl, bc
 	ld a, [hli]
 	ld [de], a

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -149,7 +149,7 @@ CheckForLuckyNumberWinners:
 .done
 	pop hl
 	push hl
-	ld de, MON_SPECIES - MON_ID
+	ld de, MON_SPECIES - MON_TRAINER_ID
 	add hl, de
 	ld a, [hl]
 	pop hl

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -149,7 +149,7 @@ CheckForLuckyNumberWinners:
 .done
 	pop hl
 	push hl
-	ld de, MON_SPECIES - MON_TRAINER_ID
+	ld de, MON_SPECIES - MON_OT_ID
 	add hl, de
 	ld a, [hl]
 	pop hl

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -22,7 +22,7 @@ CheckMagikarpLength:
 	ld d, h
 	ld e, l
 	pop hl
-	ld bc, MON_TRAINER_ID
+	ld bc, MON_OT_ID
 	add hl, bc
 	ld b, h
 	ld c, l

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -11,7 +11,7 @@ CheckMagikarpLength:
 	cp MAGIKARP
 	jr nz, .not_magikarp
 
-	; Now let's compute its length based on its DVs and ID.
+	; Now let's compute its length based on its DVs and Trainer ID.
 	ld a, [wCurPartyMon]
 	ld hl, wPartyMon1Species
 	ld bc, PARTYMON_STRUCT_LENGTH
@@ -22,7 +22,7 @@ CheckMagikarpLength:
 	ld d, h
 	ld e, l
 	pop hl
-	ld bc, MON_ID
+	ld bc, MON_TRAINER_ID
 	add hl, bc
 	ld b, h
 	ld c, l

--- a/engine/events/poke_seer.asm
+++ b/engine/events/poke_seer.asm
@@ -107,7 +107,7 @@ ReadCaughtData:
 	ld a, SEERACTION_TRADED
 	ld [wSeerAction], a
 
-	ld a, MON_ID
+	ld a, MON_TRAINER_ID
 	call GetPartyParamLocation
 	ld a, [wPlayerID]
 	cp [hl]

--- a/engine/events/poke_seer.asm
+++ b/engine/events/poke_seer.asm
@@ -107,7 +107,7 @@ ReadCaughtData:
 	ld a, SEERACTION_TRADED
 	ld [wSeerAction], a
 
-	ld a, MON_TRAINER_ID
+	ld a, MON_OT_ID
 	call GetPartyParamLocation
 	ld a, [wPlayerID]
 	cp [hl]

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -296,7 +296,7 @@ HatchEggs:
 	ld [hli], a
 	ld a, [de]
 	ld [hl], a
-	ld hl, MON_ID
+	ld hl, MON_TRAINER_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	ld [hli], a

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -296,7 +296,7 @@ HatchEggs:
 	ld [hli], a
 	ld a, [de]
 	ld [hl], a
-	ld hl, MON_TRAINER_ID
+	ld hl, MON_OT_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	ld [hli], a

--- a/engine/pokemon/search_owned.asm
+++ b/engine/pokemon/search_owned.asm
@@ -208,7 +208,7 @@ CheckOwnMon:
 
 	; check Trainer ID number
 
-	ld bc, MON_TRAINER_ID
+	ld bc, MON_OT_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	cp [hl]

--- a/engine/pokemon/search_owned.asm
+++ b/engine/pokemon/search_owned.asm
@@ -191,7 +191,7 @@ CheckOwnMon:
 ; wScriptVar should contain the species we're looking for
 
 ; outputs:
-; sets carry if monster matches species, ID, and OT name.
+; sets carry if monster matches species, Trainer ID, and OT name.
 
 	push bc
 	push hl
@@ -206,9 +206,9 @@ CheckOwnMon:
 	cp b
 	jr nz, .notfound
 
-	; check ID number
+	; check Trainer ID number
 
-	ld bc, MON_ID
+	ld bc, MON_TRAINER_ID
 	add hl, bc
 	ld a, [wPlayerID]
 	cp [hl]

--- a/macros/legacy.asm
+++ b/macros/legacy.asm
@@ -406,9 +406,6 @@ DEF happinesschecknpc     EQUS "HappinessCheckScript"
 charmap "%", "<BSP>"
 charmap "¯", "<WBR>"
 
-; constants/pokemon_data_constants.asm
-DEF MON_ID EQUS "MON_TRAINER_ID"
-
 ; constants/sprite_constants.asm
 DEF SPRITE_BUENA EQUS "SPRITE_BEAUTY"
 

--- a/macros/legacy.asm
+++ b/macros/legacy.asm
@@ -406,6 +406,9 @@ DEF happinesschecknpc     EQUS "HappinessCheckScript"
 charmap "%", "<BSP>"
 charmap "¯", "<WBR>"
 
+; constants/pokemon_data_constants.asm
+DEF MON_ID EQUS "MON_TRAINER_ID"
+
 ; constants/sprite_constants.asm
 DEF SPRITE_BUENA EQUS "SPRITE_BEAUTY"
 


### PR DESCRIPTION
The constant name MON_ID implies it relates to the ID number of the Pokémon itself; however, it actually refers to the Trainer ID number of the Pokémon's Original Trainer. Renaming it to MON_TRAINER_ID makes it substantially more clear what its meaning is.

The original definition of MON_ID is preserved in `macros/legacy.asm`