### PR TITLE
Correct Moon Ball bug documentation

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1100,10 +1100,16 @@ This can occur if your party and current PC box are both full when you start the
 
 ### Moon Ball does not boost catch rate
 
+The Moon Ball checks the wrong memory address for the wrong item ID, so no Pokémon can receive the boost.
+
 **Fix:** Edit `MoonBallMultiplier` in [engine/items/item_effects.asm](https://github.com/pret/pokecrystal/blob/master/engine/items/item_effects.asm):
 
 ```diff
 -; BUG: Moon Ball does not boost catch rate (see docs/bugs_and_glitches.md)
+	inc hl
+-	inc hl
+-	inc hl
+
  	push bc
  	ld a, BANK("Evolutions and Attacks")
  	call GetFarByte
@@ -1113,6 +1119,7 @@ This can occur if your party and current PC box are both full when you start the
  	ret nz
 ```
 
+Note that this fix only accounts for Pokémon that evolve via Moon Stone as their first evolution method. However, that is sufficient to cover all Pokémon in the game that can evolve by Moon Stone.
 
 ### Love Ball boosts catch rate for the wrong gender
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1106,7 +1106,7 @@ The Moon Ball checks the wrong memory address for the wrong item ID, so no Poké
 
 ```diff
 -; BUG: Moon Ball does not boost catch rate (see docs/bugs_and_glitches.md)
-	inc hl
+ 	inc hl
 -	inc hl
 -	inc hl
 
@@ -1120,6 +1120,7 @@ The Moon Ball checks the wrong memory address for the wrong item ID, so no Poké
 ```
 
 Note that this fix only accounts for Pokémon that evolve via Moon Stone as their first evolution method. However, that is sufficient to cover all Pokémon in the game that can evolve by Moon Stone.
+
 
 ### Love Ball boosts catch rate for the wrong gender
 

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -913,11 +913,11 @@ MoonBallMultiplier:
 	pop bc
 	ret nz
 
+; BUG: Moon Ball does not boost catch rate (see docs/bugs_and_glitches.md)
 	inc hl
 	inc hl
 	inc hl
 
-; BUG: Moon Ball does not boost catch rate (see docs/bugs_and_glitches.md)
 	push bc
 	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte


### PR DESCRIPTION
The [Bugs and Glitches documentation](https://github.com/pret/pokecrystal/blob/master/docs/bugs_and_glitches.md#moon-ball-does-not-boost-catch-rate) currently says that the Moon Ball fails to boost the catch rate of Pokémon that evolve via Moon Stone because the Gen 1 item ID for the Moon Stone, which now points to the Burn Heal, was used. However, recent research by DanielCM has shown that this is not the only issue, and fixing only that issue will not fix the Moon Ball.

The Moon Ball is also checking the wrong memory address for the item that triggers evolution. Specifically, after confirming that the Pokémon evolves by item, it advances 3 bytes (2 bytes past the ID of the evolution item). The byte it checks is the evolution list terminator (0x00) for Pokémon with only one evolution, and the evolution method of the Pokémon's second evolution for Pokémon with multiple evolution branches. There is no evolution method with ID 0x0A, so this condition can still never be met.

The updated proposed patch still only checks the first evolution method, but that is sufficient to correctly identify all Pokémon in the game that evolve via Moon Stone.