### PR TITLE
Rename `dt` and `dd` to `bigdt` and `bigdd`

### DIFF
--- a/data/battle_tower/parties.asm
+++ b/data/battle_tower/parties.asm
@@ -8,7 +8,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db THUNDERBOLT, HYPER_BEAM, SHADOW_BALL, ROAR
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -34,7 +34,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db MUD_SLAP, PSYCHIC_M, PSYCH_UP, TOXIC
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 50000
@@ -60,7 +60,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SHADOW_BALL, IRON_TAIL, PSYCH_UP, TOXIC
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -86,7 +86,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db COUNTER, MIRROR_COAT, SAFEGUARD, DESTINY_BOND
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -112,7 +112,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db REVERSAL, HYPER_BEAM, EARTHQUAKE, ATTRACT
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 30000
@@ -138,7 +138,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SURF, PSYCHIC_M, RECOVER, ANCIENTPOWER
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 30000
@@ -164,7 +164,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db BLIZZARD, EARTHQUAKE, HYPER_BEAM, TOXIC
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -190,7 +190,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db HYPER_BEAM, SUPERSONIC, EARTHQUAKE, BITE
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -216,7 +216,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db BLIZZARD, SURF, THUNDERBOLT, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -242,7 +242,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SLASH, FAINT_ATTACK, SURF, BLIZZARD
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 35000
@@ -268,7 +268,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db PSYCHIC_M, BLIZZARD, HYPER_BEAM, TRI_ATTACK
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -294,7 +294,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db PERISH_SONG, MEAN_LOOK, PAIN_SPLIT, SHADOW_BALL
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -320,7 +320,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db FAINT_ATTACK, SOLARBEAM, ROAR, SUNNY_DAY
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -346,7 +346,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db PSYBEAM, MUD_SLAP, SHADOW_BALL, AGILITY
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -372,7 +372,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db HEADBUTT, SOLARBEAM, ROLLOUT, STRENGTH
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 32000
 	bigdw 40000
@@ -398,7 +398,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db HEADBUTT, PROTECT, SNORE, SURF
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -424,7 +424,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db TOXIC, GIGA_DRAIN, THIEF, CONFUSION
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -450,7 +450,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db REVERSAL, ENDURE, COUNTER, ROCK_SMASH
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -476,7 +476,7 @@ BattleTowerMons:
 	db BERRY
 	db HIDDEN_POWER, 0, 0, 0
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -502,7 +502,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db HEADBUTT, SWAGGER, TAIL_WHIP, ICY_WIND
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -528,7 +528,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db TOXIC, PSYCH_UP, FIRE_PUNCH, HEADBUTT
 	dw 0 ; OT ID
-	dt 1000 ; Exp
+	bigdt 1000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -557,7 +557,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db PROTECT, TOXIC, MUD_SLAP, ATTRACT
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -583,7 +583,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db RECOVER, PSYCHIC_M, SURF, PSYCH_UP
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -609,7 +609,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db HYPER_BEAM, DRAGON_RAGE, THUNDERBOLT, FIRE_BLAST
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -635,7 +635,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db ROAR, IRON_TAIL, SWAGGER, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -661,7 +661,7 @@ BattleTowerMons:
 	db BERRY_JUICE
 	db PSYCHIC_M, PSYCH_UP, TOXIC, THUNDERPUNCH
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -687,7 +687,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db FLAMETHROWER, ROAR, HYPER_BEAM, IRON_TAIL
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 35000
 	bigdw 45000
@@ -713,7 +713,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db ENDURE, REVERSAL, MEGAHORN, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 30000
@@ -739,7 +739,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db HYPER_BEAM, PSYCHIC_M, TOXIC, DREAM_EATER
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -765,7 +765,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db REST, HYPER_BEAM, EARTHQUAKE, DRAGON_RAGE
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -791,7 +791,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db PSYCHIC_M, SUBMISSION, SOFTBOILED, COUNTER
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -817,7 +817,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db PSYCHIC_M, THUNDERBOLT, BLIZZARD, CONFUSE_RAY
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 30000
@@ -843,7 +843,7 @@ BattleTowerMons:
 	db LIGHT_BALL
 	db THUNDERBOLT, THUNDER_WAVE, STRENGTH, TOXIC
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -869,7 +869,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db STEEL_WING, SLASH, TOXIC, SANDSTORM
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 45000
@@ -895,7 +895,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db THUNDERPUNCH, ICE_PUNCH, FIRE_PUNCH, MEGA_PUNCH
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -921,7 +921,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db THUNDERBOLT, EARTHQUAKE, HYPER_BEAM, BLIZZARD
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -947,7 +947,7 @@ BattleTowerMons:
 	db MYSTIC_WATER
 	db SURF, BLIZZARD, ATTRACT, RAIN_DANCE
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -973,7 +973,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db EARTHQUAKE, THUNDER, ATTRACT, SURF
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -999,7 +999,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db HYPER_BEAM, BLIZZARD, FIRE_BLAST, ATTRACT
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -1025,7 +1025,7 @@ BattleTowerMons:
 	db PINK_BOW
 	db PSYCHIC_M, SWAGGER, PSYCH_UP, HEADBUTT
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1051,7 +1051,7 @@ BattleTowerMons:
 	db BERRY
 	db BLIZZARD, EARTHQUAKE, SURF, THUNDERPUNCH
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1077,7 +1077,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db AMNESIA, EARTHQUAKE, SURF, RAIN_DANCE
 	dw 0 ; OT ID
-	dt 8000 ; Exp
+	bigdt 8000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1106,7 +1106,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db THUNDERBOLT, THUNDER_WAVE, ROAR, MUD_SLAP
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1132,7 +1132,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db DOUBLE_TEAM, SURF, FISSURE, SUBMISSION
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 55000
@@ -1158,7 +1158,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db THUNDER_WAVE, PSYCHIC_M, RECOVER, SURF
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1184,7 +1184,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db BLIZZARD, LOVELY_KISS, DREAM_EATER, ATTRACT
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1210,7 +1210,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db EARTHQUAKE, SLUDGE_BOMB, SLASH, MUD_SLAP
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1236,7 +1236,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db GIGA_DRAIN, SUNNY_DAY, SOLARBEAM, DOUBLE_TEAM
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 45000
@@ -1262,7 +1262,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db TOXIC, REFLECT, SOFTBOILED, PROTECT
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 30000
@@ -1288,7 +1288,7 @@ BattleTowerMons:
 	db CHARCOAL
 	db FLAMETHROWER, CRUNCH, SHADOW_BALL, DREAM_EATER
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1314,7 +1314,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db CROSS_CHOP, ICE_PUNCH, EARTHQUAKE, FIRE_BLAST
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1340,7 +1340,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db ATTRACT, CONFUSE_RAY, TOXIC, WING_ATTACK
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1366,7 +1366,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db PSYCHIC_M, RECOVER, HYPER_BEAM, TRI_ATTACK
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 30000
@@ -1392,7 +1392,7 @@ BattleTowerMons:
 	db THICK_CLUB
 	db EARTHQUAKE, RETURN, HYPER_BEAM, BONEMERANG
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1418,7 +1418,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db LIGHT_SCREEN, THUNDERBOLT, PROTECT, THUNDER
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 45000
@@ -1444,7 +1444,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db RAIN_DANCE, WATER_GUN, ICY_WIND, STRENGTH
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -1470,7 +1470,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db RAIN_DANCE, THUNDER, SURF, FLAIL
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -1496,7 +1496,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db CONFUSION, SWIFT, TOXIC, PSYCH_UP
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1522,7 +1522,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db WRAP, TOXIC, SLUDGE_BOMB, BUBBLEBEAM
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -1548,7 +1548,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db THIEF, LICK, NIGHT_SHADE, GIGA_DRAIN
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -1574,7 +1574,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db HEADBUTT, PROTECT, ROAR, LEER
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1600,7 +1600,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db MIRROR_MOVE, PURSUIT, PECK, SWIFT
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1626,7 +1626,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db LOW_KICK, KARATE_CHOP, REVERSAL, FOCUS_ENERGY
 	dw 0 ; OT ID
-	dt 27000 ; Exp
+	bigdt 27000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -1655,7 +1655,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db RETURN, HYPER_BEAM, EARTHQUAKE, IRON_TAIL
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1681,7 +1681,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SURF, DRAGONBREATH, HYPER_BEAM, BLIZZARD
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1707,7 +1707,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db ATTRACT, BODY_SLAM, PSYCH_UP, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1733,7 +1733,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db THUNDERBOLT, ICE_BEAM, CONFUSE_RAY, SURF
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1759,7 +1759,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SANDSTORM, IRON_TAIL, EARTHQUAKE, TOXIC
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1785,7 +1785,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db PSYCHIC_M, THUNDERPUNCH, RECOVER, FIRE_PUNCH
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -1811,7 +1811,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db BLIZZARD, THUNDERBOLT, SURF, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1837,7 +1837,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db COUNTER, MIRROR_COAT, SAFEGUARD, DESTINY_BOND
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1863,7 +1863,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db EXPLOSION, EARTHQUAKE, MEGA_PUNCH, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1889,7 +1889,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SLASH, STEEL_WING, PURSUIT, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -1915,7 +1915,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db EARTHQUAKE, HYPER_BEAM, SLUDGE_BOMB, MUD_SLAP
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1941,7 +1941,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db SURF, PSYCHIC_M, EARTHQUAKE, BLIZZARD
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -1967,7 +1967,7 @@ BattleTowerMons:
 	db NO_ITEM
 	db CONVERSION2, CONVERSION, PSYBEAM, THIEF
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -1993,7 +1993,7 @@ BattleTowerMons:
 	db CHARCOAL
 	db FLAME_WHEEL, LEER, BODY_SLAM, ROAR
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2019,7 +2019,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db RAPID_SPIN, PROTECT, TOXIC, SANDSTORM
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2045,7 +2045,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db CURSE, WATER_GUN, ANCIENTPOWER, ROCK_SMASH
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2071,7 +2071,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db FIRE_SPIN, DRAGON_RAGE, FLY, SLASH
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2097,7 +2097,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db EGG_BOMB, STOMP, PSYCH_UP, CONFUSION
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2123,7 +2123,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db CONFUSION, THUNDERPUNCH, HEADBUTT, DISABLE
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -2149,7 +2149,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db SCREECH, TOXIC, SLUDGE, HARDEN
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -2175,7 +2175,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db LIGHT_SCREEN, THUNDERPUNCH, SWIFT, SNORE
 	dw 0 ; OT ID
-	dt 64000 ; Exp
+	bigdt 64000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -2204,7 +2204,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SURF, HYPER_BEAM, BLIZZARD, DRAGONBREATH
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 55000
@@ -2230,7 +2230,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db REST, CRUNCH, DREAM_EATER, FLAMETHROWER
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -2256,7 +2256,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SANDSTORM, REST, TOXIC, WRAP
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -2282,7 +2282,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db HYPER_BEAM, EARTHQUAKE, SURF, PSYCH_UP
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 55000
@@ -2308,7 +2308,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db THUNDERBOLT, SURF, CONFUSE_RAY, BLIZZARD
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 60000
@@ -2334,7 +2334,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db THUNDERBOLT, THUNDER_WAVE, SHADOW_BALL, HIDDEN_POWER
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 60000
@@ -2360,7 +2360,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db HYPER_BEAM, SLASH, AGILITY, METAL_CLAW
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2386,7 +2386,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, SURF, PSYCHIC_M, AMNESIA
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -2412,7 +2412,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db CROSS_CHOP, EARTHQUAKE, FIRE_BLAST, THUNDERPUNCH
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 45000
@@ -2438,7 +2438,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db THUNDER_WAVE, RECOVER, THUNDERBOLT, SURF
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 44000
@@ -2464,7 +2464,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db EARTHQUAKE, SLASH, HYPER_BEAM, SLUDGE_BOMB
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 40000
@@ -2490,7 +2490,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db THUNDERBOLT, EXPLOSION, MIRROR_COAT, REST
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -2516,7 +2516,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db HYPER_BEAM, EARTHQUAKE, FIRE_BLAST, IRON_TAIL
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2542,7 +2542,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db CONFUSE_RAY, ATTRACT, HYPER_BEAM, TOXIC
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 40000
@@ -2568,7 +2568,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db DRILL_PECK, THUNDERBOLT, THUNDER_WAVE, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2594,7 +2594,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SANDSTORM, FLY, STEEL_WING, TOXIC
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2620,7 +2620,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SANDSTORM, TOXIC, EXPLOSION, SWAGGER
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2646,7 +2646,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db SANDSTORM, IRON_TAIL, REST, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2672,7 +2672,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db DREAM_EATER, CRUNCH, PSYCHIC_M, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -2698,7 +2698,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db HYPER_BEAM, SURF, RAIN_DANCE, ZAP_CANNON
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -2724,7 +2724,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db BLIZZARD, HYPER_BEAM, ROAR, ICY_WIND
 	dw 0 ; OT ID
-	dt 125000 ; Exp
+	bigdt 125000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 40000
@@ -2753,7 +2753,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db DRAGONBREATH, SURF, HYPER_BEAM, BLIZZARD
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 55000
@@ -2779,7 +2779,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db CRUNCH, EARTHQUAKE, ROCK_SLIDE, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 60000
@@ -2805,7 +2805,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db FLAMETHROWER, CRUNCH, DREAM_EATER, REST
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 55000
@@ -2831,7 +2831,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db BLIZZARD, RECOVER, TOXIC, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -2857,7 +2857,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db FIRE_PUNCH, CROSS_CHOP, THUNDERPUNCH, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2883,7 +2883,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, DRILL_PECK, THUNDERBOLT, THUNDER_WAVE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -2909,7 +2909,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db COUNTER, MIRROR_COAT, DESTINY_BOND, SAFEGUARD
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -2935,7 +2935,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db HYPER_BEAM, SUPERSONIC, EARTHQUAKE, BITE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2961,7 +2961,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db HYPER_BEAM, ICY_WIND, THUNDERBOLT, SURF
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -2987,7 +2987,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db MUD_SLAP, MOONLIGHT, PSYCHIC_M, FAINT_ATTACK
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3013,7 +3013,7 @@ BattleTowerMons:
 	db CHARCOAL
 	db FLAMETHROWER, CRUNCH, EXTREMESPEED, IRON_TAIL
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -3039,7 +3039,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db STEEL_WING, FLY, TOXIC, PROTECT
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3065,7 +3065,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SOFTBOILED, TOXIC, PROTECT, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -3091,7 +3091,7 @@ BattleTowerMons:
 	db PINK_BOW
 	db ROCK_SLIDE, SURF, BODY_SLAM, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -3117,7 +3117,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db REVERSAL, MEGAHORN, EARTHQUAKE, COUNTER
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -3143,7 +3143,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db BLIZZARD, PSYCHIC_M, SHADOW_BALL, ICY_WIND
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3169,7 +3169,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SURF, EARTHQUAKE, RAPID_SPIN, BLIZZARD
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3195,7 +3195,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db EARTHQUAKE, SURF, IRON_TAIL, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3221,7 +3221,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db EARTHQUAKE, SLASH, HYPER_BEAM, SNORE
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3247,7 +3247,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SPORE, GIGA_DRAIN, HYPER_BEAM, SLUDGE_BOMB
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3273,7 +3273,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db EXPLOSION, EARTHQUAKE, FIRE_PUNCH, FRUSTRATION
 	dw 0 ; OT ID
-	dt 216000 ; Exp
+	bigdt 216000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3302,7 +3302,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db THUNDERBOLT, HYPER_BEAM, SHADOW_BALL, ROAR
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 56000
@@ -3328,7 +3328,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db BLIZZARD, SHADOW_BALL, SURF, MUD_SLAP
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3354,7 +3354,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db FAINT_ATTACK, MOONLIGHT, PSYCH_UP, TOXIC
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 54000
 	bigdw 60000
@@ -3380,7 +3380,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db COUNTER, SOFTBOILED, SHADOW_BALL, THUNDERBOLT
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 55000
@@ -3406,7 +3406,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db ROCK_SLIDE, EARTHQUAKE, BLIZZARD, SHADOW_BALL
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 55000
@@ -3432,7 +3432,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db CRUNCH, FLAMETHROWER, FAINT_ATTACK, ROAR
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 58000
 	bigdw 50000
@@ -3458,7 +3458,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db EARTHQUAKE, CRUNCH, ROCK_SLIDE, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -3484,7 +3484,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db THUNDERBOLT, DRILL_PECK, THUNDER_WAVE, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -3510,7 +3510,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db REST, EXPLOSION, PSYCHIC_M, GIGA_DRAIN
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -3536,7 +3536,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db MOONLIGHT, FAINT_ATTACK, PSYCHIC_M, SHADOW_BALL
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3562,7 +3562,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db SURF, THUNDERBOLT, HYPER_BEAM, ROAR
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 45000
@@ -3588,7 +3588,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db EARTHQUAKE, SURF, SLUDGE_BOMB, IRON_TAIL
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3614,7 +3614,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SLASH, EARTHQUAKE, HYPER_BEAM, THUNDERPUNCH
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -3640,7 +3640,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db REFLECT, FIRE_PUNCH, PSYCHIC_M, ENCORE
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -3666,7 +3666,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db CROSS_CHOP, ICE_PUNCH, THUNDERPUNCH, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -3692,7 +3692,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db AGILITY, BATON_PASS, CRUNCH, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3718,7 +3718,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db REVERSAL, ENDURE, BODY_SLAM, MEGA_KICK
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3744,7 +3744,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db REVERSAL, ENDURE, MEGAHORN, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3770,7 +3770,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db SUNNY_DAY, SOLARBEAM, SYNTHESIS, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3796,7 +3796,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SLASH, EARTHQUAKE, HYPER_BEAM, FLAMETHROWER
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3822,7 +3822,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db HYDRO_PUMP, ICE_PUNCH, HYPER_BEAM, IRON_TAIL
 	dw 0 ; OT ID
-	dt 343000 ; Exp
+	bigdt 343000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -3851,7 +3851,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db THUNDER_WAVE, THUNDERBOLT, IRON_TAIL, ROAR
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 55000
@@ -3877,7 +3877,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db REST, BELLY_DRUM, SNORE, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 55000
@@ -3903,7 +3903,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, CRUNCH, FLAMETHROWER, SUNNY_DAY
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -3929,7 +3929,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db EARTHQUAKE, BODY_SLAM, IRON_TAIL, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3955,7 +3955,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, SURF, CONFUSE_RAY, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -3981,7 +3981,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db REST, CRUNCH, EARTHQUAKE, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 55000
@@ -4007,7 +4007,7 @@ BattleTowerMons:
 	db NO_ITEM
 	db THUNDERBOLT, SHADOW_BALL, CONFUSE_RAY, THIEF
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4033,7 +4033,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db EXPLOSION, TOXIC, SOLARBEAM, SWAGGER
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -4059,7 +4059,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, SURF, BLIZZARD, DRAGONBREATH
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -4085,7 +4085,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db THUNDER_WAVE, SURF, THUNDERBOLT, OUTRAGE
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4111,7 +4111,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db PSYCHIC_M, RECOVER, HYPER_BEAM, TRI_ATTACK
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -4137,7 +4137,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db LOVELY_KISS, BLIZZARD, DREAM_EATER, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -4163,7 +4163,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db SURF, CONFUSE_RAY, BLIZZARD, WING_ATTACK
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 40000
 	bigdw 45000
@@ -4189,7 +4189,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db STEEL_WING, FLY, MUD_SLAP, TOXIC
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -4215,7 +4215,7 @@ BattleTowerMons:
 	db CHARCOAL
 	db FLAMETHROWER, SKY_ATTACK, STEEL_WING, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -4241,7 +4241,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db HYPER_BEAM, REST, EARTHQUAKE, ROAR
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -4267,7 +4267,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db THUNDERBOLT, EXPLOSION, MIRROR_COAT, TOXIC
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4293,7 +4293,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SLASH, EARTHQUAKE, THIEF, MUD_SLAP
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4319,7 +4319,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db GIGA_DRAIN, SLUDGE_BOMB, HYPER_BEAM, TOXIC
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4345,7 +4345,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db HYPER_BEAM, SUBMISSION, STRENGTH, TOXIC
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4371,7 +4371,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db ROAR, SHADOW_BALL, HYPER_BEAM, THUNDERPUNCH
 	dw 0 ; OT ID
-	dt 512000 ; Exp
+	bigdt 512000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4400,7 +4400,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db FAINT_ATTACK, MUD_SLAP, MOONLIGHT, CONFUSE_RAY
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -4426,7 +4426,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db FIRE_BLAST, HYPER_BEAM, OUTRAGE, BLIZZARD
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 65000
 	bigdw 50000
@@ -4452,7 +4452,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db RECOVER, THUNDERBOLT, SURF, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -4478,7 +4478,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db EXPLOSION, BLIZZARD, SURF, ICY_WIND
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4504,7 +4504,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db WING_ATTACK, HAZE, HYPER_BEAM, GIGA_DRAIN
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4530,7 +4530,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db TOXIC, PSYCHIC_M, RECOVER, PROTECT
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -4556,7 +4556,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db DRAGONBREATH, SURF, HYPER_BEAM, BLIZZARD
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4582,7 +4582,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db HYPER_BEAM, CRUNCH, EARTHQUAKE, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 55000
@@ -4608,7 +4608,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, SURF, THUNDERBOLT, PSYCHIC_M
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -4634,7 +4634,7 @@ BattleTowerMons:
 	db GOLD_BERRY
 	db PSYCHIC_M, SHADOW_BALL, SUNNY_DAY, MORNING_SUN
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -4660,7 +4660,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db CROSS_CHOP, VITAL_THROW, FIRE_BLAST, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 55000
@@ -4686,7 +4686,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db FIRE_BLAST, SURF, EARTHQUAKE, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -4712,7 +4712,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db SUNNY_DAY, FLAMETHROWER, EXTREMESPEED, REST
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -4738,7 +4738,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SOLARBEAM, SUNNY_DAY, SOFTBOILED, FIRE_BLAST
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 45000
@@ -4764,7 +4764,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db FLAMETHROWER, CRUNCH, SUNNY_DAY, SOLARBEAM
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -4790,7 +4790,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db SANDSTORM, STEEL_WING, TOXIC, RETURN
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4816,7 +4816,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db TOXIC, WRAP, PROTECT, ENCORE
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4842,7 +4842,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db HYPER_BEAM, FLAMETHROWER, SHADOW_BALL, ROAR
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -4868,7 +4868,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db MILK_DRINK, EARTHQUAKE, ATTRACT, BODY_SLAM
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4894,7 +4894,7 @@ BattleTowerMons:
 	db PINK_BOW
 	db THUNDERBOLT, HYPER_BEAM, ATTRACT, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4920,7 +4920,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db TOXIC, SLUDGE_BOMB, ATTRACT, GIGA_DRAIN
 	dw 0 ; OT ID
-	dt 729000 ; Exp
+	bigdt 729000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -4949,7 +4949,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db CRUNCH, FLAMETHROWER, ROAR, REST
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -4975,7 +4975,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db CROSS_CHOP, EARTHQUAKE, HYPER_BEAM, VITAL_THROW
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -5001,7 +5001,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SURF, DRAGONBREATH, REST, TOXIC
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 60000
 	bigdw 60000
@@ -5027,7 +5027,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db THUNDERBOLT, ROAR, THUNDER_WAVE, IRON_TAIL
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5053,7 +5053,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db HYPER_BEAM, EARTHQUAKE, IRON_TAIL, THUNDERBOLT
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5079,7 +5079,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db FLAMETHROWER, EXTREMESPEED, IRON_TAIL, HYPER_BEAM
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -5105,7 +5105,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db FLAMETHROWER, EARTHQUAKE, SLASH, FLY
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5131,7 +5131,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db THUNDER_WAVE, THUNDERBOLT, EXPLOSION, MIRROR_COAT
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -5157,7 +5157,7 @@ BattleTowerMons:
 	db MIRACLEBERRY
 	db SURF, EARTHQUAKE, HYPER_BEAM, ROCK_SLIDE
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -5183,7 +5183,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db EARTHQUAKE, HYPER_BEAM, SWAGGER, CRUNCH
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5209,7 +5209,7 @@ BattleTowerMons:
 	db KINGS_ROCK
 	db DRILL_PECK, STEEL_WING, HYPER_BEAM, MUD_SLAP
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 55000
 	bigdw 50000
@@ -5235,7 +5235,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db PERISH_SONG, MEAN_LOOK, PAIN_SPLIT, SHADOW_BALL
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 45000
 	bigdw 50000
@@ -5261,7 +5261,7 @@ BattleTowerMons:
 	db SCOPE_LENS
 	db SLASH, BLIZZARD, DREAM_EATER, FAINT_ATTACK
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5287,7 +5287,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db STEEL_WING, HYPER_BEAM, SLASH, TOXIC
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5313,7 +5313,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db THUNDERBOLT, BLIZZARD, FIRE_BLAST, SOFTBOILED
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 40000
@@ -5339,7 +5339,7 @@ BattleTowerMons:
 	db MINT_BERRY
 	db REST, BLIZZARD, HYPER_BEAM, EARTHQUAKE
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5365,7 +5365,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db PSYCHIC_M, TOXIC, EXPLOSION, GIGA_DRAIN
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5391,7 +5391,7 @@ BattleTowerMons:
 	db LEFTOVERS
 	db SURF, ANCIENTPOWER, BLIZZARD, TOXIC
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 50000
 	bigdw 50000
@@ -5417,7 +5417,7 @@ BattleTowerMons:
 	db BRIGHTPOWDER
 	db EXPLOSION, EARTHQUAKE, ROCK_SLIDE, FIRE_BLAST
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -5443,7 +5443,7 @@ BattleTowerMons:
 	db FOCUS_BAND
 	db COUNTER, FIRE_PUNCH, THUNDERPUNCH, ICE_PUNCH
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000
@@ -5469,7 +5469,7 @@ BattleTowerMons:
 	db QUICK_CLAW
 	db SURF, RAIN_DANCE, ZAP_CANNON, CONFUSE_RAY
 	dw 0 ; OT ID
-	dt 1000000 ; Exp
+	bigdt 1000000 ; Exp
 	; Stat exp
 	bigdw 30000
 	bigdw 30000

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -40,7 +40,7 @@ OddEggs:
 	db NO_ITEM
 	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, 0
 	dw 02048 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -66,7 +66,7 @@ OddEggs:
 	db NO_ITEM
 	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, 0
 	dw 00256 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -92,7 +92,7 @@ OddEggs:
 	db NO_ITEM
 	db POUND, CHARM, DIZZY_PUNCH, 0
 	dw 04096 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -118,7 +118,7 @@ OddEggs:
 	db NO_ITEM
 	db POUND, CHARM, DIZZY_PUNCH, 0
 	dw 00768 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -144,7 +144,7 @@ OddEggs:
 	db NO_ITEM
 	db SING, CHARM, DIZZY_PUNCH, 0
 	dw 04096 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -170,7 +170,7 @@ OddEggs:
 	db NO_ITEM
 	db SING, CHARM, DIZZY_PUNCH, 0
 	dw 00768 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -196,7 +196,7 @@ OddEggs:
 	db NO_ITEM
 	db POUND, LICK, DIZZY_PUNCH, 0
 	dw 03584 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -222,7 +222,7 @@ OddEggs:
 	db NO_ITEM
 	db POUND, LICK, DIZZY_PUNCH, 0
 	dw 00512 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -248,7 +248,7 @@ OddEggs:
 	db NO_ITEM
 	db EMBER, DIZZY_PUNCH, 0, 0
 	dw 02560 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -274,7 +274,7 @@ OddEggs:
 	db NO_ITEM
 	db EMBER, DIZZY_PUNCH, 0, 0
 	dw 00512 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -300,7 +300,7 @@ OddEggs:
 	db NO_ITEM
 	db QUICK_ATTACK, LEER, DIZZY_PUNCH, 0
 	dw 03072 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -326,7 +326,7 @@ OddEggs:
 	db NO_ITEM
 	db QUICK_ATTACK, LEER, DIZZY_PUNCH, 0
 	dw 00512 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -352,7 +352,7 @@ OddEggs:
 	db NO_ITEM
 	db TACKLE, DIZZY_PUNCH, 0, 0
 	dw 02560 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0
@@ -378,7 +378,7 @@ OddEggs:
 	db NO_ITEM
 	db TACKLE, DIZZY_PUNCH, 0, 0
 	dw 00256 ; OT ID
-	dt 125 ; Exp
+	bigdt 125 ; Exp
 	; Stat exp
 	bigdw 0
 	bigdw 0

--- a/data/items/mom_phone.asm
+++ b/data/items/mom_phone.asm
@@ -1,7 +1,6 @@
 MACRO momitem
 ; money to trigger, cost, kind, item
-	dt \1
-	dt \2
+	bigdt \1, \2
 	db \3, \4
 ENDM
 
@@ -26,4 +25,4 @@ MomItems_2:
 	momitem 100000, 22800, MOM_DOLL, DECO_BIG_SNORLAX_DOLL
 .End
 
-	dt 0 ; unused
+	bigdt 0 ; unused

--- a/engine/events/mom.asm
+++ b/engine/events/mom.asm
@@ -552,26 +552,15 @@ Mom_WithdrawDepositMenuJoypad:
 	ret
 
 .DigitQuantities:
-	dt 100000
-	dt 10000
-	dt 1000
-	dt 100
-	dt 10
-	dt 1
-
-	dt 100000
-	dt 10000
-	dt 1000
-	dt 100
-	dt 10
-	dt 1
-
-	dt 900000
-	dt 90000
-	dt 9000
-	dt 900
-	dt 90
-	dt 9
+	for x, 5, -1, -1
+		bigdt 10**x
+	endr
+	for x, 5, -1, -1
+		bigdt 10**x
+	endr
+	for x, 5, -1, -1
+		bigdt 9 * 10**x
+	endr
 
 MomLeavingText1:
 	text_far _MomLeavingText1

--- a/engine/events/mom_phone.asm
+++ b/engine/events/mom_phone.asm
@@ -228,7 +228,6 @@ MomItsInYourRoomText:
 	text_far _MomItsInYourRoomText
 	text_end
 
-
 DummyPredef3A_DummyData: ; unreferenced
 	db 0
 

--- a/engine/events/money.asm
+++ b/engine/events/money.asm
@@ -23,7 +23,7 @@ GiveMoney::
 	ret
 
 MaxMoney:
-	dt MAX_MONEY
+	bigdt MAX_MONEY
 
 TakeMoney::
 	ld a, 3

--- a/macros/data.asm
+++ b/macros/data.asm
@@ -55,16 +55,25 @@ MACRO dc ; "crumbs"
 	endr
 ENDM
 
-MACRO dt ; three-byte (big-endian)
-	db LOW((\1) >> 16), HIGH(\1), LOW(\1)
-ENDM
-
-MACRO dd ; four-byte (big-endian)
-	db HIGH((\1) >> 16), LOW((\1) >> 16), HIGH(\1), LOW(\1)
-ENDM
-
 MACRO bigdw ; big-endian word
-	db HIGH(\1), LOW(\1)
+	rept _NARG
+		db HIGH(\1), LOW(\1)
+		shift
+	endr
+ENDM
+
+MACRO bigdt ; big-endian "tribyte"
+	rept _NARG
+		db LOW((\1) >> 16), HIGH(\1), LOW(\1)
+		shift
+	endr
+ENDM
+
+MACRO bigdd ; big-endian "double word"
+	rept _NARG
+		db HIGH((\1) >> 16), LOW((\1) >> 16), HIGH(\1), LOW(\1)
+		shift
+	endr
 ENDM
 
 MACRO dba ; dbw bank, address

--- a/macros/legacy.asm
+++ b/macros/legacy.asm
@@ -13,6 +13,14 @@ ENDM
 
 ; macros/data.asm
 
+MACRO dt
+	bigdt \1
+ENDM
+
+MACRO dd
+	bigdd \1
+ENDM
+
 MACRO dbbw
 	db \1, \2
 	dw \3

--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -229,21 +229,21 @@ ENDM
 MACRO givemoney
 	db givemoney_command
 	db \1 ; account
-	dt \2 ; money
+	bigdt \2 ; money
 ENDM
 
 	const takemoney_command ; $23
 MACRO takemoney
 	db takemoney_command
 	db \1 ; account
-	dt \2 ; money
+	bigdt \2 ; money
 ENDM
 
 	const checkmoney_command ; $24
 MACRO checkmoney
 	db checkmoney_command
 	db \1 ; account
-	dt \2 ; money
+	bigdt \2 ; money
 ENDM
 
 	const givecoins_command ; $25

--- a/mobile/mobile_41.asm
+++ b/mobile/mobile_41.asm
@@ -698,21 +698,21 @@ endr
 	ret
 
 ._9
-	dd 1000000000
+	bigdd 10**9
 ._8
-	dd 100000000
+	bigdd 10**8
 ._7
-	dd 10000000
+	bigdd 10**7
 ._6
-	dd 1000000
+	bigdd 10**6
 ._5
-	dd 100000
+	bigdd 10**5
 ._4
-	dd 10000
+	bigdd 10**4
 ._3
-	dd 1000
+	bigdd 10**3
 ._2
-	dd 100
+	bigdd 10**2
 
 .Function1062b2:
 	ld c, $0


### PR DESCRIPTION
This makes their big-endianness obvious and matches `bigdw`