### PR TITLE
Add Documentation for HideHeadbuttTree

### DIFF
--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -79,8 +79,8 @@ HeadbuttTreeGFX:
 INCBIN "gfx/overworld/headbutt_tree.2bpp"
 
 HideHeadbuttTree:
-	; Replaces headbutted tree with grass tile at hardcoded value $05
-	; Assumes all tilesets have grass at tile $05
+	; Replaces all four headbutted tree tiles with tile $05
+	; Assumes any tileset with headbutt trees has grass at tile $05
 	xor a
 	ldh [hBGMapMode], a
 	ld a, [wPlayerDirection]
@@ -94,7 +94,7 @@ HideHeadbuttTree:
 	ld h, [hl]
 	ld l, a
 
-	ld a, $05 ; Assumed grass tile
+	ld a, $05 ; grass tile
 	ld [hli], a
 	ld [hld], a
 	ld bc, SCREEN_WIDTH

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -79,6 +79,8 @@ HeadbuttTreeGFX:
 INCBIN "gfx/overworld/headbutt_tree.2bpp"
 
 HideHeadbuttTree:
+	; Replaces headbutted tree with grass tile at hardcoded value $05
+	; Assumes all tilesets have grass at tile $05
 	xor a
 	ldh [hBGMapMode], a
 	ld a, [wPlayerDirection]
@@ -92,7 +94,7 @@ HideHeadbuttTree:
 	ld h, [hl]
 	ld l, a
 
-	ld a, $05 ; grass block
+	ld a, $05 ; Assumed grass tile
 	ld [hli], a
 	ld [hld], a
 	ld bc, SCREEN_WIDTH


### PR DESCRIPTION
This is a documentation PR for `HideHeadbuttTree`. This documentation makes it clear that the subroutine uses a hardcoded value for a grass tile to replace the headbutted tree with.

[Linked issue](https://github.com/pret/pokecrystal/issues/1127).