### PR TITLE
Rename Curl to Rollout

### DIFF
--- a/data/battle/effect_command_pointers.asm
+++ b/data/battle/effect_command_pointers.asm
@@ -95,7 +95,7 @@ BattleCommandPointers:
 	dw BattleCommand_PerishSong
 	dw BattleCommand_StartSandstorm
 	dw BattleCommand_Endure
-	dw BattleCommand_CheckCurl
+	dw BattleCommand_CheckRollout
 	dw BattleCommand_RolloutPower
 	dw BattleCommand_Unused5D
 	dw BattleCommand_FuryCutter

--- a/data/moves/effects.asm
+++ b/data/moves/effects.asm
@@ -1536,7 +1536,7 @@ Endure:
 	endmove
 
 Rollout:
-	checkcurl
+	checkrollout
 	checkobedience
 	doturn
 	usedmovetext

--- a/docs/move_effect_commands.md
+++ b/docs/move_effect_commands.md
@@ -273,7 +273,7 @@ Defined in [macros/scripts/battle_commands.asm](https://github.com/pret/pokecrys
 ## `$5A`: `endure`
 
 
-## `$5B`: `checkcurl`
+## `$5B`: `checkrollout`
 
 
 ## `$5C`: `rolloutpower`

--- a/engine/battle/move_effects/rollout.asm
+++ b/engine/battle/move_effects/rollout.asm
@@ -1,6 +1,6 @@
 DEF MAX_ROLLOUT_COUNT EQU 5
 
-BattleCommand_CheckCurl:
+BattleCommand_CheckRollout:
 	ld de, wPlayerRolloutCount
 	ldh a, [hBattleTurn]
 	and a

--- a/macros/scripts/battle_commands.asm
+++ b/macros/scripts/battle_commands.asm
@@ -95,7 +95,7 @@ ENDM
 	command perishsong              ; 58
 	command startsandstorm          ; 59
 	command endure                  ; 5a
-	command checkcurl               ; 5b
+	command checkrollout            ; 5b
 	command rolloutpower            ; 5c
 	command effect0x5d              ; 5d
 	command furycutter              ; 5e


### PR DESCRIPTION
[Issue](https://github.com/pret/pokecrystal/issues/1156)

This PR renames `curl`  to `rollout`.