### PR TITLE
Remove skip prefix from AI move scores

### DIFF
--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1300,14 +1300,14 @@ AI_Smart_Mimic:
 	cp EFFECTIVE
 	pop hl
 	jr c, .discourage
-	jr z, .skip_encourage
+	jr z, .encourage
 
 	call AI_50_50
-	jr c, .skip_encourage
+	jr c, .encourage
 
 	dec [hl]
 
-.skip_encourage
+.encourage
 	ld a, [wLastPlayerCounterMove]
 	push hl
 	ld hl, UsefulMoves

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1248,12 +1248,12 @@ AI_Smart_Rage:
 
 ; If enemy's Rage is building, 50% chance to encourage this move.
 	call AI_50_50
-	jr c, .skipencourage
+	jr c, .encourage
 
 	dec [hl]
 
 ; Encourage this move based on Rage's counter.
-.skipencourage
+.encourage
 	ld a, [wEnemyRageCounter]
 	cp 2
 	ret c

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1094,11 +1094,11 @@ AI_Smart_Confuse:
 	ret c
 	call Random
 	cp 10 percent
-	jr c, .skipdiscourage
+	jr c, .discourage
 	inc [hl]
 
-.skipdiscourage
-; Discourage again if player's HP is below 25%.
+.discourage
+; Discourage if player's HP is below 25%.
 	call AICheckPlayerQuarterHP
 	ret c
 	inc [hl]


### PR DESCRIPTION
Possible naming improvement in the `engine/battle/ai/scoring.asm` file. I'm making some refactors to this file for my own game where the AI is a bit stronger and noticed these subroutines that use `skip` as a prefix. I thought the word `skip` was misleading since in all of the routines they are not skipping that action they are prefixing; in fact, they are all attempting to do the action that their name suggests they are skipping.

I know that the name is intended to show that they are skipping the discouragement or encouragement from the regular flow of the routine that calls it, but I still found the word `skip` misleading.

I considered also switching the `skip` for `maybe` but I don't think that works as it looks like `maybe` is used as a convention when some chance is involved with `AI_50_50` or one of those similar routines is used. I felt just using `discourage` or `encourage` kept the naming more consistent within the file instead of using `skip` or `maybe` for these examples.

If people disagree with my take on this, no worries! 👍  