### PR TITLE
add comment to note _CGB_Diploma also loads PartyMenuOBPals

### DIFF
--- a/engine/gfx/cgb_layouts.asm
+++ b/engine/gfx/cgb_layouts.asm
@@ -509,7 +509,7 @@ _CGB_BetaPoker:
 _CGB_Diploma:
 	ld hl, DiplomaPalettes
 	ld de, wBGPals1
-	ld bc, 16 palettes
+	ld bc, 16 palettes ; also loads PartyMenuOBPals into wOBPals1
 	ld a, BANK(wBGPals1)
 	call FarCopyWRAM
 


### PR DESCRIPTION
gamefreak did a fallthrough :D

other instances of `ld bc, [>8] palettes` are obvious in what object palettes they're loading, this is the one that isn't