### PR TITLE
Document time of day bug in RandomUnseenWildMon

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -2810,3 +2810,22 @@ This bug allows all the options to be updated at once if the left or right butto
 -	call PlaySFX
 +	call WaitPlaySFX
 ```
+
+### `RandomUnseenWildMon` only works correctly in the morning
+
+In the function `RandomUnseenWildMon`, the code first picks a random pokemon that can be found on the route out of the three most rarest encounters for the current time of day. It then compares that pokemon to the four most common encounters and bails if they match. The problem is that the code will compare to the four most common encounters for the morning, regardless of the time of day.
+
+**Fix:** Edit `RandomUnseenWildMon` in [engine/overworld/wildmons.asm](https://github.com/pret/pokecrystal/blob/master/engine/overworld/wildmons.asm):
+
+```diff
+ .GetGrassmon:
++	ld a, [wTimeOfDay]
++	ld bc, NUM_GRASSMON * 2
++	call AddNTimes
+ 	push hl
+ 	ld bc, 5 + 4 * 2 ; Location of the level of the 5th wild Pokemon in that map
+ 	add hl, bc
+-	ld a, [wTimeOfDay]
+-	ld bc, NUM_GRASSMON * 2
+-	call AddNTimes
+```

--- a/engine/overworld/wildmons.asm
+++ b/engine/overworld/wildmons.asm
@@ -781,6 +781,7 @@ RandomUnseenWildMon:
 	jr nc, .done
 
 .GetGrassmon:
+; BUG: RandomUnseenWildMon always picks a morning Pokémon species (see docs/bugs_and_glitches.md)
 	push hl
 	ld bc, 5 + 4 * 2 ; Location of the level of the 5th wild Pokemon in that map
 	add hl, bc
@@ -802,7 +803,6 @@ RandomUnseenWildMon:
 	pop hl
 	ld de, 5 + 0 * 2
 	add hl, de
-; BUG: HL points to the morning encounters, regardless of the time of day (see docs/bugs_and_glitches.md)
 	inc hl ; Species index of the most common Pokemon on that route
 	ld b, 4
 .loop2

--- a/engine/overworld/wildmons.asm
+++ b/engine/overworld/wildmons.asm
@@ -802,6 +802,7 @@ RandomUnseenWildMon:
 	pop hl
 	ld de, 5 + 0 * 2
 	add hl, de
+; BUG: HL points to the morning encounters, regardless of the time of day (see docs/bugs_and_glitches.md)
 	inc hl ; Species index of the most common Pokemon on that route
 	ld b, 4
 .loop2


### PR DESCRIPTION
When porting the function `RandomUnseenWildMon` to Rust ([for Rustic Crystal](https://github.com/LinusU/rustic-crystal)) I noticed a logic error where it will always compare the potentially rare pokemon to the the first 4 _morning_ encounters to see it is indeed rare.

I haven't seen the issue while playing since it's quite rare, and would be hard to notice unless you know what to look for.

Looking thru the grass data, it looks like it could happen for e.g. `ROUTE_30` in the night. If it first picked slot 6 `HOOTHOOT` it would tell the player of the rare Hoothoot, even though slot 2 & 4 also contains `HOOTHOOT` in the night...