### PR TITLE
Specify a max item length for `list_start`

### DIFF
--- a/data/battle/stat_names.asm
+++ b/data/battle/stat_names.asm
@@ -1,6 +1,6 @@
 StatNames:
 ; entries correspond to stat ids
-	list_start
+	list_start STRING_BUFFER_LENGTH - 1
 	li "ATTACK"
 	li "DEFENSE"
 	li "SPEED"

--- a/data/decorations/names.asm
+++ b/data/decorations/names.asm
@@ -1,6 +1,6 @@
 DecorationNames:
 ; entries correspond to constants/deco_constants.asm
-	list_start
+	list_start TEXTBOX_INNERW - 1
 	li "CANCEL"
 	li "PUT IT AWAY"
 	li "MAGNAPLANT"

--- a/data/events/unown_walls.asm
+++ b/data/events/unown_walls.asm
@@ -6,7 +6,7 @@ DEF UNOWNWORD_{d:UNOWNWORDS_HO_OH}  EQUS "HO-OH"
 
 UnownWalls:
 ; entries correspond to UNOWNWORDS_* constants
-	list_start
+	list_start 9
 	for x, NUM_UNOWN_WALLS
 		li #UNOWNWORD_{d:x}
 	endr

--- a/data/items/names.asm
+++ b/data/items/names.asm
@@ -1,5 +1,5 @@
 ItemNames::
-	list_start
+	list_start ITEM_NAME_LENGTH - 1
 	li "MASTER BALL"
 	li "ULTRA BALL"
 	li "BRIGHTPOWDER"

--- a/data/mon_menu.asm
+++ b/data/mon_menu.asm
@@ -11,7 +11,7 @@ DEF NUM_MONMENUVALUES EQU const_value - 1
 
 MonMenuOptionStrings:
 ; entries correspond to MONMENUVALUE_* constants
-	list_start
+	list_start MOVE_NAME_LENGTH - 2
 	li "STATS"
 	li "SWITCH"
 	li "ITEM"

--- a/data/moves/names.asm
+++ b/data/moves/names.asm
@@ -1,5 +1,5 @@
 MoveNames::
-	list_start
+	list_start MOVE_NAME_LENGTH - 1
 	li "POUND"
 	li "KARATE CHOP"
 	li "DOUBLESLAP"

--- a/data/trainers/class_names.asm
+++ b/data/trainers/class_names.asm
@@ -1,6 +1,6 @@
 TrainerClassNames::
 ; entries correspond to trainer classes (see constants/trainer_constants.asm)
-	list_start
+	list_start TRAINER_CLASS_NAME_LENGTH - 1
 	li "LEADER"
 	li "LEADER"
 	li "LEADER"

--- a/macros/asserts.asm
+++ b/macros/asserts.asm
@@ -4,8 +4,8 @@ MACRO? _redef_current_label
 	if DEF(\1)
 		PURGE \1
 	endc
-	if _NARG == 3 + (\3)
-		DEF \1 EQUS "\<_NARG>"
+	if _NARG > 2
+		DEF \1 EQUS "\3"
 	elif STRLEN(#__SCOPE__)
 		if {{__SCOPE__}} - @ == 0
 			DEF \1 EQUS #{__SCOPE__}
@@ -19,7 +19,8 @@ ENDM
 
 MACRO? table_width
 	DEF CURRENT_TABLE_WIDTH = \1
-	_redef_current_label CURRENT_TABLE_START, "._table_width\@", 2, \#
+	shift
+	_redef_current_label CURRENT_TABLE_START, "._table_width\@", \#
 ENDM
 
 MACRO? assert_table_length
@@ -32,11 +33,20 @@ ENDM
 
 MACRO? list_start
 	DEF list_index = 0
-	_redef_current_label CURRENT_LIST_START, "._list_start\@", 1, \#
+	DEF list_item_length = 0
+	if _NARG > 0
+		DEF list_item_length = \1
+		shift
+	endc
+	_redef_current_label CURRENT_LIST_START, "._list_start\@", \#
 ENDM
 
 MACRO? li
 	assert STRFIND(\1, "@") == -1, "String terminator \"@\" in list entry: \1"
+	if list_item_length
+		assert CHARLEN(\1) <= list_item_length, \
+			"List entry longer than {d:list_item_length} characters: \1"
+	endc
 	db \1, "@"
 	DEF list_index += 1
 ENDM


### PR DESCRIPTION
This addresses https://github.com/pret/pokered/issues/544.

Most of our text-buffer-length constants include the terminating `"@"`, so most of the `list_start`s subtract 1. We could instead have `list_start` take a length that includes the terminator, but since `li` doesn't include it, I think it's more clear for `li "123456"` to fail given `list_start 5`. But if anyone disagrees I'd like to hear it!

```
data/battle/stat_names.asm:3:          list_start STRING_BUFFER_LENGTH - 1
data/decorations/names.asm:3:          list_start TEXTBOX_INNERW - 1
data/events/unown_walls.asm:9:          list_start 9
data/items/names.asm:2:          list_start ITEM_NAME_LENGTH - 1
data/mon_menu.asm:14:         list_start MOVE_NAME_LENGTH - 2
data/moves/names.asm:2:          list_start MOVE_NAME_LENGTH - 1
data/trainers/class_names.asm:3:          list_start TRAINER_CLASS_NAME_LENGTH - 1
```