### PR TITLE
Add some useful assertions

### DIFF
--- a/home/init.asm
+++ b/home/init.asm
@@ -97,6 +97,7 @@ Init::
 	call ClearSprites
 	call ClearsScratch
 
+	assert BANK(WriteOAMDMACodeToHRAM) == BANK(GameInit)
 	ld a, BANK(WriteOAMDMACodeToHRAM) ; aka BANK(GameInit)
 	rst Bankswitch
 

--- a/main.asm
+++ b/main.asm
@@ -24,6 +24,7 @@ INCLUDE "engine/gfx/color.asm"
 
 
 SECTION "bank3", ROMX
+assert BANK(ComputeAIContestantScores) == BANK(CheckBugContestContestantFlag)
 
 INCLUDE "engine/events/checktime.asm"
 INCLUDE "engine/events/specials.asm"
@@ -43,6 +44,10 @@ INCLUDE "engine/pokemon/knows_move.asm"
 
 
 SECTION "bank4", ROMX
+assert BANK(GiveItem) == BANK(TryGiveItemToPartymon)
+assert BANK(StartMenu_Quit) == BANK(StartMenuYesNo)
+assert BANK(StartMenu_Pokemon) == BANK(PokemonActionSubmenu)
+assert BANK(UseRegisteredItem) == BANK(CantUseItem)
 
 INCLUDE "engine/items/pack.asm"
 INCLUDE "engine/overworld/time.asm"
@@ -69,6 +74,9 @@ INCLUDE "engine/math/get_square_root.asm"
 
 
 SECTION "bank5", ROMX
+assert BANK(BuyMenuLoop) == BANK(CompareMoney)
+assert BANK(BuyMenuLoop) == BANK(TakeMoney)
+assert BANK(SellMenu) == BANK(GiveMoney)
 
 INCLUDE "engine/rtc/rtc.asm"
 INCLUDE "engine/overworld/overworld.asm"
@@ -162,6 +170,7 @@ INCLUDE "data/battle/effect_command_pointers.asm"
 
 
 SECTION "bank10", ROMX
+assert BANK(FillMoves) == BANK(EvosAttacksPointers)
 
 INCLUDE "engine/pokedex/pokedex.asm"
 INCLUDE "data/moves/moves.asm"
@@ -298,6 +307,9 @@ INCLUDE "mobile/mobile_22_2.asm"
 
 
 SECTION "bank23", ROMX
+assert BANK(InitPartyMenuIcon) == BANK(_InitSpriteAnimStruct)
+assert BANK(NamingScreen_InitAnimatedMonIcon) == BANK(_InitSpriteAnimStruct)
+assert BANK(MoveList_InitAnimatedMonIcon) == BANK(_InitSpriteAnimStruct)
 
 INCLUDE "engine/tilesets/timeofday_pals.asm"
 INCLUDE "engine/battle/battle_transition.asm"

--- a/ram/sram.asm
+++ b/ram/sram.asm
@@ -91,6 +91,7 @@ sOptions:: ds wOptionsEnd - wOptions
 sCheckValue1:: db ; loaded with SAVE_CHECK_VALUE_1, used to check save corruption
 
 sGameData::
+assert warn, sGameData == $a009, "sGameData has shifted."
 sPlayerData::  ds wPlayerDataEnd - wPlayerData
 sCurMapData::  ds wCurMapDataEnd - wCurMapData
 sPokemonData:: ds wPokemonDataEnd - wPokemonData
@@ -140,6 +141,7 @@ SECTION "SRAM Crystal Data", SRAM
 sGSBallFlag:: db
 
 sCrystalData:: ds wCrystalDataEnd - wCrystalData
+assert warn, sCrystalData == $be3d, "sCrystalData has shifted."
 
 sGSBallFlagBackup:: db
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2863,6 +2863,7 @@ wMapStatusEnd::
 	ds 2
 
 wCrystalData::
+assert warn, wCrystalData == $d472, "wCrystalData has shifted."
 wPlayerGender::
 ; bit 0:
 ;	0 male
@@ -2873,12 +2874,14 @@ wPlayerAge:: ds 1
 wPlayerPrefecture:: ds 1
 wPlayerPostalCode:: ds 4
 wCrystalDataEnd::
+assert warn, wCrystalDataEnd == $d479, "wCrystalDataEnd has shifted."
 
 wCrystalFlags::
 ; flags related to mobile profile
 	flag_array 16
 
 wGameData::
+assert warn, wGameData == $d47b, "wGameData has shifted."
 wPlayerData::
 wPlayerID:: dw
 
@@ -3387,6 +3390,7 @@ wMagikarpRecordHoldersName:: ds NAME_LENGTH
 
 wPokemonDataEnd::
 wGameDataEnd::
+assert warn, wGameDataEnd == $dff5, "wGameDataEnd has shifted."
 
 
 SECTION "Pic Animations", WRAMX


### PR DESCRIPTION
* Add assertions to make it more clear when things should be in the same bank, as they are called without farcall
* Especially the same-bank dependency between FillMoves and EvosAttacksPointers seems useful, since this appears to be a common issue
* Warn when wram/sram save data location/length changes, in case someone makes a romhack but wants to retain save compatibility