### PR TITLE
Replace Magic Numbers in Switch Routines

### DIFF
--- a/engine/battle/ai/switch.asm
+++ b/engine/battle/ai/switch.asm
@@ -476,7 +476,7 @@ FindEnemyMonsWithASuperEffectiveMove:
 
 	; if immune or not very effective: continue
 	ld a, [wTypeMatchup]
-	cp 10
+	cp EFFECTIVE
 	jr c, .nope
 
 	; if neutral: load 1 and continue
@@ -576,7 +576,7 @@ FindEnemyMonsThatResistPlayer:
 	ld hl, wBaseType
 	call CheckTypeMatchup
 	ld a, [wTypeMatchup]
-	cp 10 + 1
+	cp EFFECTIVE + 1
 	jr nc, .dont_choose_mon
 	ld a, [wBattleMonType2]
 


### PR DESCRIPTION
While improving the AI Switching capabilities I noticed some magic numbers so I replaced the magic numbers with the appropriate constants.