### PR TITLE
Change Nightmare condition so that the pkm needs to be asleep

### DIFF
--- a/engine/battle/ai/redundant.asm
+++ b/engine/battle/ai/redundant.asm
@@ -113,7 +113,7 @@ AI_Redundant:
 
 .Nightmare:
 	ld a, [wBattleMonStatus]
-	and a
+	and SLP_MASK
 	jr z, .Redundant
 	ld a, [wPlayerSubStatus1]
 	bit SUBSTATUS_NIGHTMARE, a


### PR DESCRIPTION
This PR changes the logic of applying Nightmare by the AI. Instead of checking for any status (bug), it checks whether the target is asleep as intended

Fixes #1229 