### PR TITLE
Rename `unleashenergy` to `startbide`

### DIFF
--- a/data/battle/effect_command_pointers.asm
+++ b/data/battle/effect_command_pointers.asm
@@ -38,7 +38,7 @@ BattleCommandPointers:
 	dw BattleCommand_Conversion
 	dw BattleCommand_ResetStats
 	dw BattleCommand_StoreEnergy
-	dw BattleCommand_UnleashEnergy
+	dw BattleCommand_StartBide
 	dw BattleCommand_ForceSwitch
 	dw BattleCommand_EndLoop
 	dw BattleCommand_FlinchTarget

--- a/data/moves/effects.asm
+++ b/data/moves/effects.asm
@@ -797,7 +797,7 @@ Bide:
 	checkobedience
 	doturn
 	usedmovetext
-	unleashenergy
+	startbide
 	resettypematchup
 	checkhit
 	moveanim

--- a/docs/move_effect_commands.md
+++ b/docs/move_effect_commands.md
@@ -102,7 +102,7 @@ Defined in [macros/scripts/battle_commands.asm](https://github.com/pret/pokecrys
 ## `$21`: `storeenergy`
 
 
-## `$22`: `unleashenergy`
+## `$22`: `startbide`
 
 
 ## `$23`: `forceswitch`

--- a/engine/battle/move_effects/bide.asm
+++ b/engine/battle/move_effects/bide.asm
@@ -59,7 +59,7 @@ BattleCommand_StoreEnergy:
 	ld a, BIDE
 	ld [hl], a
 
-	ld b, unleashenergy_command
+	ld b, startbide_command
 	jp SkipToBattleCommand
 
 .still_storing
@@ -67,7 +67,7 @@ BattleCommand_StoreEnergy:
 	call StdBattleTextbox
 	jp EndMoveEffect
 
-BattleCommand_UnleashEnergy:
+BattleCommand_StartBide:
 	ld de, wPlayerDamageTaken
 	ld bc, wPlayerRolloutCount
 	ldh a, [hBattleTurn]

--- a/macros/scripts/battle_commands.asm
+++ b/macros/scripts/battle_commands.asm
@@ -38,7 +38,7 @@ ENDM
 	command conversion              ; 1f
 	command resetstats              ; 20
 	command storeenergy             ; 21
-	command unleashenergy           ; 22
+	command startbide               ; 22
 	command forceswitch             ; 23
 	command endloop                 ; 24
 	command flinchtarget            ; 25


### PR DESCRIPTION
## Summary

- Renames the `unleashenergy` battle command (and `BattleCommand_UnleashEnergy`) to `startbide` (`BattleCommand_StartBide`), since it initializes Bide rather than unleashing energy.
- The actual energy unleashing is handled by `storeenergy` (`BattleCommand_StoreEnergy`) when Bide's turn counter reaches zero.
- Pure label/macro rename across 5 files; produces byte-identical ROMs (`make compare` passes).

Fixes #1174