### PR TITLE
Restore CheckTypeMatchup bug description

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1390,6 +1390,8 @@ AI_Cautious:
 
 ### AI makes a false assumption about `CheckTypeMatchup`
 
+There is an incorrect assumption about this function made in the AI related code: when the AI calls CheckTypeMatchup (not BattleCheckTypeMatchup), it assumes that placing the offensive type in a will make this function do the right thing. Since a is overwritten, this assumption is incorrect. A simple fix would be to load the move type for the current move into a in BattleCheckTypeMatchup, before falling through, which is consistent with how the rest of the code assumes this code works like.
+
 **Fix:** Edit `BattleCheckTypeMatchup` in [engine/battle/effect_commands.asm](https://github.com/pret/pokecrystal/blob/master/engine/battle/effect_commands.asm):
 
 ```diff


### PR DESCRIPTION
The description of this bug was lost during a mass clean-up of the bugs document (https://github.com/pret/pokecrystal/pull/912). This PR restores the description to what it was before.